### PR TITLE
fix(send): keep c2c video compatQMsgSceneType at 2

### DIFF
--- a/packages/core/src/bridge/highway/video-upload.ts
+++ b/packages/core/src/bridge/highway/video-upload.ts
@@ -487,11 +487,17 @@ export async function uploadVideoMsgInfo(
           subFileType: 100,
         },
       ],
-      // Scene tag the NTV2 upload registers under. image-upload and
-      // ptt-upload both differentiate (group=2, c2c=1); video was
-      // hardcoded to the group value, which contributed to the c2c
-      // send-back rejection (PbSendMsg result=79).
-      compatQmsgSceneType: isGroup ? 2 : 1,
+      // Hardcoded 2 even on c2c (matches NapCat). Image/PTT use
+      // `isGroup ? 2 : 1` because their legacy compat elements differ
+      // per scene (notOnlineImage vs customFace; ptt c2c vs group),
+      // but the legacy `videoFile` element has no scene split — its
+      // fromChatType/toChatType live inside the element itself — so
+      // the server generates a single group-shaped compat payload
+      // regardless. Setting 1 here makes the server emit a c2c-scene
+      // shaped compat blob that old QQ clients fail to resolve,
+      // showing the message as "视频已过期" on those receivers while
+      // new clients (which only read the commonElem) display fine.
+      compatQmsgSceneType: 2,
       extBizInfo: {
         pic: { bizType: 0, textSummary: 'Nya~' },
         video: { bytesPbReserve: new Uint8Array([0x80, 0x01, 0x00]) },


### PR DESCRIPTION
## Summary

- Revert the c2c half of #29f28d6's `compatQmsgSceneType` change. Set it back to a flat `2` for both c2c and group video (matching NapCat). The `commonElem.businessType = isGroup ? 21 : 11` half of that commit stays — that's what fixed `PbSendMsg result=79` and is verified by `tests/element-builder.test.ts`.

- Root cause: image/ptt have *different* legacy compat elements per scene (`notOnlineImage` vs `customFace`; ptt c2c vs group), so their `compatQMsgSceneType` tracks the upload's sceneType. The legacy `videoFile` element (Elem field 19) does not — its `fromChatType` / `toChatType` live inside the element itself — so the QQ NT server emits a single group-shaped compat payload regardless of scene. NapCat hardcodes `compatQMsgSceneType: 2` in both `UploadGroupVideo.ts` and `UploadPrivateVideo.ts` for exactly this reason.

- Symptom: with `compatQmsgSceneType: 1` on c2c, the server emitted a c2c-scene shaped compat blob older QQ clients couldn't resolve — they rendered the message as "视频已过期". Newer clients read the `commonElem(48, 11)` directly and worked fine, which is why only "some devices" saw the breakage.

## Test plan

- [x] `vitest run tests/highway/video-upload.test.ts tests/element-builder.test.ts` — all 15 tests pass.
- [ ] Send a c2c video to an account that has an older mobile QQ logged in alongside a newer NT client; confirm both render the video (was: NT fine, older mobile showed "视频已过期").
- [ ] Send a group video; confirm no regression in the group scene (compatQmsgSceneType was already 2 there).