### PR TITLE
fix(onebot): cache self-id-based message meta for private recall

### DIFF
--- a/packages/core/src/onebot/modules/message-actions.ts
+++ b/packages/core/src/onebot/modules/message-actions.ts
@@ -141,7 +141,7 @@ export async function sendPrivateMessage(
 
   logSentMessage(false, userId, elements);
 
-  ref.cacheMessageMeta(messageId, {
+  cachePrivateMessageMeta(ref, messageId, userId, {
     isGroup: false,
     targetId: userId,
     sequence: receipt.sequence,
@@ -152,6 +152,21 @@ export async function sendPrivateMessage(
   });
 
   return { messageId };
+}
+
+function cachePrivateMessageMeta(
+  ref: OneBotInstanceContext,
+  messageId: number,
+  userId: number,
+  meta: MessageMeta,
+): void {
+  ref.cacheMessageMeta(messageId, meta);
+  if (userId !== ref.selfId) {
+    const selfMessageId = hashMessageIdInt32(meta.sequence, ref.selfId, PRIVATE_MESSAGE_EVENT);
+    if (selfMessageId !== messageId) {
+      ref.cacheMessageMeta(selfMessageId, meta);
+    }
+  }
 }
 
 export async function sendGroupMessage(
@@ -253,7 +268,7 @@ export async function sendPrivateForwardMessage(
   const receipt = await ref.bridge.sendPrivateMessage(userId, [previewElement]);
   const messageId = hashMessageIdInt32(receipt.sequence, userId, PRIVATE_MESSAGE_EVENT);
 
-  ref.cacheMessageMeta(messageId, {
+  cachePrivateMessageMeta(ref, messageId, userId, {
     isGroup: false,
     targetId: userId,
     sequence: receipt.sequence,
@@ -323,10 +338,7 @@ export async function forwardSingleMessage(
   } else {
     receipt = await ref.bridge.sendPrivateMessage(target.userId!, elements);
     messageIdOut = hashMessageIdInt32(receipt.sequence, target.userId!, PRIVATE_MESSAGE_EVENT);
-    ref.cacheMessageMeta(messageIdOut, {
-      isGroup: false,
-      targetId: target.userId!,
-      sequence: receipt.sequence,
+    cachePrivateMessageMeta(ref, messageIdOut, target.userId!, {
       eventName: PRIVATE_MESSAGE_EVENT,
       clientSequence: receipt.clientSequence,
       random: receipt.random,


### PR DESCRIPTION
## Summary

Add an alternate cached message_id entry for private messages sent by self, so recall logic can resolve the message meta when the framework reports message_sent under the bot's own UIN.

### Changes
- Add cachePrivateMessageMeta() helper.
- Cache meta under both peer-based and self-based message IDs for private sends.
- Apply the same fix in sendPrivateMessage, sendPrivateForwardMessage, and the private branch of forwardSingleMessage.

### Why
The message recall path needs the actual message meta for self-sent private messages. Previously the bot only stored the peer-based hash, but message_sent events are reported using the bot's own UIN, causing recall to miss the correct cached meta.

### Testing
Manual send/recall path for private song list and voice recall was used as the expected scenario.