### PR TITLE
feat: 添加注入前探测 QQ 登录状态功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 
 /config/
 /data/
+logs/
 
 # macOS metadata
 .DS_Store

--- a/packages/core/src/hook/hook-manager.ts
+++ b/packages/core/src/hook/hook-manager.ts
@@ -12,9 +12,11 @@ import { HookSession, type HookSessionDeps } from './hook-session';
 import { PipeWatcher } from './pipe-watcher';
 import { QqHookClient } from './qq-hook-client';
 import type { HookProcessInfo } from './types';
+import { probeQqLoginInfo, type QqPortLoginInfo } from './qq-port-probe';
 
 export type { HookProcessInfo, HookProcessStatus } from './types';
 export type { HookProcessBaseInfo } from './injector';
+export type { QqPortLoginInfo } from './qq-port-probe';
 
 export type HookManagerDeps = {
   bridgeManager: BridgeManager;
@@ -145,6 +147,11 @@ export class HookManager {
     await this.startPromise;
     const session = this.ensureSession(pid);
     return session.refresh();
+  }
+
+  async probeProcessLoginInfo(pid: number): Promise<QqPortLoginInfo | null> {
+    this.assertValidPid(pid);
+    return probeQqLoginInfo(pid);
   }
 
   dispose(): void {

--- a/packages/core/src/hook/qq-port-probe.ts
+++ b/packages/core/src/hook/qq-port-probe.ts
@@ -1,0 +1,168 @@
+import net from 'net';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+const PORT_RANGE_START = 9210;
+const PORT_RANGE_END = 9219;
+const PROBE_TIMEOUT_MS = 1000;
+const CONNECTION_TIMEOUT_MS = 500;
+
+export interface QqPortLoginInfo {
+  port: number;
+  uin: string;
+  uid?: string;
+  nickName?: string;
+  loggedIn: boolean;
+}
+
+interface JwtPayload {
+  errCode: number;
+  errMsg: string;
+  port: number;
+  uin?: string;
+  uid?: string;
+  nickName?: string;
+  data?: {
+    uin?: string;
+    url?: string;
+  };
+  iat: number;
+}
+
+function decodeJwt(token: string): JwtPayload | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    const payload = Buffer.from(parts[1], 'base64').toString('utf8');
+    return JSON.parse(payload);
+  } catch {
+    return null;
+  }
+}
+
+async function probePort(port: number): Promise<QqPortLoginInfo | null> {
+  return new Promise((resolve) => {
+    const client = new net.Socket();
+    const link = 'tencent://';
+    const payload = `POST /tencent HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\nConnection: close\r\nContent-Length: ${link.length}\r\n\r\n${link}`;
+
+    let responseData = '';
+    let timer: NodeJS.Timeout;
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      client.removeAllListeners();
+      client.destroy();
+    };
+
+    timer = setTimeout(() => {
+      cleanup();
+      resolve(null);
+    }, PROBE_TIMEOUT_MS);
+
+    client.setTimeout(CONNECTION_TIMEOUT_MS);
+
+    client.connect(port, '127.0.0.1', () => {
+      client.write(payload);
+    });
+
+    client.on('data', (data) => {
+      responseData += data.toString();
+    });
+
+    client.on('close', () => {
+      cleanup();
+      const jwtMatch = responseData.match(/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/);
+      if (!jwtMatch) {
+        resolve(null);
+        return;
+      }
+
+      const decoded = decodeJwt(jwtMatch[0]);
+      if (!decoded || decoded.errCode !== 0) {
+        resolve(null);
+        return;
+      }
+
+      const uin = decoded.uin || decoded.data?.uin || '';
+      resolve({
+        port,
+        uin,
+        uid: decoded.uid,
+        nickName: decoded.nickName,
+        loggedIn: uin.length > 0,
+      });
+    });
+
+    client.on('error', () => {
+      cleanup();
+      resolve(null);
+    });
+
+    client.on('timeout', () => {
+      cleanup();
+      resolve(null);
+    });
+  });
+}
+
+async function getProcessPorts(pid: number): Promise<number[]> {
+  try {
+    if (process.platform === 'win32') {
+      const { stdout } = await execAsync(`netstat -ano | findstr ${pid}`);
+      const ports = new Set<number>();
+      const lines = stdout.split('\n');
+      for (const line of lines) {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length < 5) continue;
+        const owningPid = parts[parts.length - 1];
+        if (owningPid !== String(pid)) continue;
+        const localAddr = parts[1];
+        const portMatch = localAddr.match(/:(\d+)$/);
+        if (!portMatch) continue;
+        const port = Number(portMatch[1]);
+        if (port >= PORT_RANGE_START && port <= PORT_RANGE_END) {
+          ports.add(port);
+        }
+      }
+      return Array.from(ports);
+    } else {
+      const { stdout } = await execAsync(`ss -tlnp | grep pid=${pid}`);
+      const ports = new Set<number>();
+      const lines = stdout.split('\n');
+      for (const line of lines) {
+        const match = line.match(/:(\d+)\s/);
+        if (match) {
+          const port = Number(match[1]);
+          if (port >= PORT_RANGE_START && port <= PORT_RANGE_END) {
+            ports.add(port);
+          }
+        }
+      }
+      return Array.from(ports);
+    }
+  } catch {
+    return [];
+  }
+}
+
+export async function probeQqLoginInfo(pid: number): Promise<QqPortLoginInfo | null> {
+  const ports = await getProcessPorts(pid);
+
+  if (ports.length === 0) {
+    for (let port = PORT_RANGE_START; port <= PORT_RANGE_END; port++) {
+      const info = await probePort(port);
+      if (info) return info;
+    }
+    return null;
+  }
+
+  for (const port of ports) {
+    const info = await probePort(port);
+    if (info) return info;
+  }
+
+  return null;
+}

--- a/packages/core/src/webui/server.ts
+++ b/packages/core/src/webui/server.ts
@@ -450,6 +450,21 @@ export async function initWebUI(
   app.post('/api/processes/:pid/unload',  processAction('unload',  (pid) => hookManager!.unloadProcess(pid)));
   app.post('/api/processes/:pid/refresh', processAction('refresh', (pid) => hookManager!.refreshProcess(pid)));
 
+  app.get('/api/processes/:pid/probe-login', async (c) => {
+    if (!hookManager) return c.json({ info: null, message: 'hook manager is not available' }, 503);
+    const pid = Number(c.req.param('pid'));
+    if (!Number.isInteger(pid) || pid <= 0 || pid > MAX_PID) {
+      return c.json({ info: null, message: 'invalid pid' }, 400);
+    }
+    try {
+      const info = await hookManager.probeProcessLoginInfo(pid);
+      return c.json({ info });
+    } catch (err) {
+      log.warn('probe-login pid=%d failed: %s', pid, err instanceof Error ? err.message : String(err));
+      return c.json({ info: null, message: '探测失败' }, 500);
+    }
+  });
+
   app.get('/api/config/:uin', (c) => {
     const uin = c.req.param('uin');
     if (!UIN_REGEX.test(uin)) return c.json({ message: 'invalid uin' }, 400);

--- a/packages/webui/src/components/pages/overview-page.tsx
+++ b/packages/webui/src/components/pages/overview-page.tsx
@@ -5,6 +5,7 @@ import {
   AlertCircle,
   CheckCircle2,
   Cpu,
+  Eye,
   Loader2,
   MemoryStick,
   MonitorCog,
@@ -21,6 +22,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ConfirmDialog } from '@/components/confirm-dialog';
+import { ProcessProbeDialog } from '@/components/process-probe-dialog';
 import { cn, formatBytes, formatUptime } from '@/lib/utils';
 import type { HookProcessInfo } from '@/types';
 import { useAppState } from '@/contexts/AppStateContext';
@@ -91,6 +93,7 @@ export function OverviewPage() {
     | { kind: 'load' | 'unload'; pid: number; name: string }
     | null
   >(null);
+  const [probeDialog, setProbeDialog] = useState<{ pid: number; name: string } | null>(null);
 
   // Lightweight tick to refresh "uptime" pretty-print every 30s
   const [, force] = useState(0);
@@ -325,6 +328,14 @@ export function OverviewPage() {
                       )}
                     </div>
                     <div className="flex shrink-0 items-center gap-1.5">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={busy}
+                        onClick={() => setProbeDialog({ pid: proc.pid, name: proc.name || `PID ${proc.pid}` })}
+                      >
+                        <Eye className="size-3.5" /> 探测登录
+                      </Button>
                       {showRefresh && (
                         <Button
                           size="icon"
@@ -430,6 +441,15 @@ export function OverviewPage() {
           else await load(confirm.pid);
         }}
       />
+
+      {probeDialog && (
+        <ProcessProbeDialog
+          pid={probeDialog.pid}
+          processName={probeDialog.name}
+          open={!!probeDialog}
+          onOpenChange={(open) => !open && setProbeDialog(null)}
+        />
+      )}
     </div>
   );
 }

--- a/packages/webui/src/components/process-probe-dialog.tsx
+++ b/packages/webui/src/components/process-probe-dialog.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { Eye, Loader2, User, UserX } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { useApi } from '@/lib/api';
+
+interface QqPortLoginInfo {
+  port: number;
+  uin: string;
+  uid?: string;
+  nickName?: string;
+  loggedIn: boolean;
+}
+
+interface ProcessProbeDialogProps {
+  pid: number;
+  processName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function qqAvatarUrl(uin: string) {
+  return `/avatar/${encodeURIComponent(uin)}`;
+}
+
+export function ProcessProbeDialog({ pid, processName, open, onOpenChange }: ProcessProbeDialogProps) {
+  const api = useApi();
+  const [loading, setLoading] = useState(false);
+  const [info, setInfo] = useState<QqPortLoginInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const probe = async () => {
+    setLoading(true);
+    setError(null);
+    setInfo(null);
+    try {
+      const result = await api.processes.probeLoginInfo(pid);
+      setInfo(result as QqPortLoginInfo | null);
+      if (!result) {
+        setError('未检测到登录信息（端口 9210-9219 无响应）');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '探测失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      probe();
+    } else {
+      setInfo(null);
+      setError(null);
+    }
+  }, [open]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>查看登录状态</DialogTitle>
+          <DialogDescription>
+            {processName} (PID {pid})
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {loading && (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="size-6 animate-spin text-muted-foreground" />
+            </div>
+          )}
+
+          {!loading && error && (
+            <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed py-8 text-muted-foreground">
+              <UserX className="size-8" strokeWidth={1.5} />
+              <p className="text-sm">{error}</p>
+            </div>
+          )}
+
+          {!loading && info && (
+            <div className="space-y-4">
+              {info.loggedIn ? (
+                <div className="flex items-center gap-4 rounded-lg border bg-card/50 p-4">
+                  <Avatar className="size-14">
+                    <AvatarImage src={qqAvatarUrl(info.uin)} alt={info.uin} />
+                    <AvatarFallback>
+                      <User className="size-6" />
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold">{info.nickName || info.uin}</span>
+                      <Badge variant="success">已登录</Badge>
+                    </div>
+                    <div className="mt-1 text-sm text-muted-foreground">UIN: {info.uin}</div>
+                    {info.uid && (
+                      <div className="mt-0.5 truncate font-mono text-xs text-muted-foreground">
+                        UID: {info.uid}
+                      </div>
+                    )}
+                    <div className="mt-1 text-xs text-muted-foreground">端口: {info.port}</div>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed py-8 text-muted-foreground">
+                  <UserX className="size-8" strokeWidth={1.5} />
+                  <div className="text-center">
+                    <p className="text-sm font-medium">等待登录</p>
+                    <p className="mt-1 text-xs">端口 {info.port} 已响应，但未检测到登录账号</p>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+              关闭
+            </Button>
+            {!loading && (
+              <Button size="sm" onClick={probe}>
+                <Eye className="size-3.5" /> 重新探测
+              </Button>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/webui/src/lib/api/client.ts
+++ b/packages/webui/src/lib/api/client.ts
@@ -53,6 +53,7 @@ class HttpApiClient implements ApiClient {
       load: (pid) => this.postJson<ProcessActionResult>(`/api/processes/${pid}/load`),
       unload: (pid) => this.postJson<ProcessActionResult>(`/api/processes/${pid}/unload`),
       refresh: (pid) => this.postJson<ProcessActionResult>(`/api/processes/${pid}/refresh`),
+      probeLoginInfo: (pid) => this.getJson<{ info: unknown }>(`/api/processes/${pid}/probe-login`).then((d) => d.info ?? null),
     };
 
     this.config = {

--- a/packages/webui/src/lib/api/types.ts
+++ b/packages/webui/src/lib/api/types.ts
@@ -57,6 +57,7 @@ export interface ApiClient {
     load(pid: number): Promise<ProcessActionResult>;
     unload(pid: number): Promise<ProcessActionResult>;
     refresh(pid: number): Promise<ProcessActionResult>;
+    probeLoginInfo(pid: number): Promise<unknown>;
   };
 
   // ---- OneBotInstance per-UIN config ----


### PR DESCRIPTION
## 在DLL注入前获取QQ实例信息（登陆情况，账号信息）

#### 实现原理
- QQ 在启动后会在本地开启一个 HTTP 服务（端口范围 9210-9219）**用于处理`tencent://`深链接**
- 逆向`Timwp.exe`可以得到预期的网络包格式
- 请求会返回实例账号的JWT，payload包含uin和uid的信息
#### 实现形式
- 已知一个QQ实例的主PID，**获取该进程的开放端口**
- 如果存在端口范围在9210-9219之间，则发送探测数据包（tencent:// 空深链接请求）
- 返回值即我们需要的数据（uin和uid），如果uin为空，则代表实例未登录
<img width="1856" height="1160" alt="image" src="https://github.com/user-attachments/assets/4cb0801c-2c3c-469c-9752-8bc6820cf729" />
<img width="1390" height="932" alt="image" src="https://github.com/user-attachments/assets/4cad6750-0a92-4f0b-88ca-81912f5cb19f" />

#### 改动
- 新增端口探测模块 (qq-port-probe.ts)
- 前端添加"探测登录"按钮和状态显示对话框
---
**值得一提的是**
- win32和linux的QQ启动的端口范围都在9210-9219之间，所以可以无缝适配
- 返回数据只有uin和uid，不包含昵称等信息