### PR TITLE
feat: add temp session (grpTmp) routing for non-friend private messages

### DIFF
--- a/packages/core/src/bridge/apis/message.ts
+++ b/packages/core/src/bridge/apis/message.ts
@@ -87,8 +87,18 @@ export class MessageApi {
    * Resolves the recipient's UID only when the message carries media
    * — text-only messages skip the lookup. Routes through `c2c.uin`
    * (and optionally `c2c.uid` for the media case).
+   *
+   * For non-friend targets the method automatically falls back to the
+   * temp-session (临时会话) channel using the `grpTmp` routing head
+   * (proto field 3). The caller may supply a `sourceGroupId` to pin
+   * the source group; otherwise the first common group found in the
+   * identity cache is used.
    */
-  async sendPrivate(userUin: number, elements: MessageElement[]): Promise<SendMessageReceipt> {
+  async sendPrivate(
+    userUin: number,
+    elements: MessageElement[],
+    sourceGroupId?: number,
+  ): Promise<SendMessageReceipt> {
     if (elements.length === 0) throw new Error('message is empty');
 
     let userUid = '';
@@ -101,17 +111,45 @@ export class MessageApi {
     const random = this.ctx.nextMessageRandom();
     const clientSeq = this.ctx.nextClientSequence();
 
-    const request = protobuf_encode<SendMessageRequest>({
-      routingHead: {
-        c2c: {
+    const isFriend = !!this.ctx.identity.findFriend(userUin);
+
+    // Build routing head — friend C2C vs temp session (grpTmp).
+    const routingHead: SendMessageRequest['routingHead'] = {};
+
+    if (isFriend) {
+      routingHead.c2c = {
+        uin: userUin,
+        ...(userUid ? { uid: userUid } : {}),
+      };
+    } else {
+      // Find source group for temp session.
+      let groupId = sourceGroupId && sourceGroupId > 0 ? sourceGroupId : undefined;
+      if (!groupId) {
+        for (const group of this.ctx.identity.groups) {
+          if (group.members.has(userUin)) {
+            groupId = group.groupId;
+            break;
+          }
+        }
+      }
+      if (groupId) {
+        routingHead.grpTmp = { groupUin: groupId, toUin: userUin };
+      } else {
+        // No group found — fall back to friend C2C (will fail with
+        // result=16 for non-friends, but better than misrouting).
+        routingHead.c2c = {
           uin: userUin,
           ...(userUid ? { uid: userUid } : {}),
-        },
-      },
+        };
+      }
+    }
+
+    const request = protobuf_encode<SendMessageRequest>({
+      routingHead,
       contentHead: {
         type: 1,
         subType: 0,
-        c2cCmd: 11,
+        c2cCmd: isFriend ? 11 : 0,
       },
       messageBody: {
         richText: {

--- a/packages/onebot/src/actions/message.ts
+++ b/packages/onebot/src/actions/message.ts
@@ -13,7 +13,29 @@ export function register(h: ApiHandler, ctx: ApiActionContext): void {
       return failedResponse(RETCODE.BAD_REQUEST, 'message is required');
     }
 
-    if (messageType === 'group' || params.group_id !== undefined) {
+    // ★ Explicit message_type takes precedence; group_id alone only
+    // drives routing when message_type is absent (backward compat).
+    if (messageType === 'group') {
+      const groupId = asNumber(params.group_id);
+      if (!Number.isInteger(groupId) || groupId <= 0) {
+        return failedResponse(RETCODE.BAD_REQUEST, 'group_id is required');
+      }
+      const result = await ctx.sendGroupMessage(groupId, message, autoEscape);
+      return okResponse({ message_id: result.messageId });
+    }
+
+    if (messageType === 'private') {
+      const userId = asNumber(params.user_id);
+      if (!Number.isInteger(userId) || userId <= 0) {
+        return failedResponse(RETCODE.BAD_REQUEST, 'user_id is required');
+      }
+      const groupId = asNumber(params.group_id);
+      const result = await ctx.sendPrivateMessage(userId, message, autoEscape, groupId);
+      return okResponse({ message_id: result.messageId });
+    }
+
+    // No message_type: infer from group_id (legacy OneBot behaviour).
+    if (params.group_id !== undefined) {
       const groupId = asNumber(params.group_id);
       if (!Number.isInteger(groupId) || groupId <= 0) {
         return failedResponse(RETCODE.BAD_REQUEST, 'group_id is required');

--- a/packages/onebot/src/api-handler.ts
+++ b/packages/onebot/src/api-handler.ts
@@ -38,7 +38,7 @@ export interface ApiActionContext {
   isOnline: () => boolean;
   getMessage: (messageId: number) => JsonObject | null;
   getMessageMeta: (messageId: number) => MessageMeta | null;
-  sendPrivateMessage: (userId: number, message: JsonValue, autoEscape: boolean) => Promise<MessageSendResult>;
+  sendPrivateMessage: (userId: number, message: JsonValue, autoEscape: boolean, groupId?: number) => Promise<MessageSendResult>;
   sendGroupMessage: (groupId: number, message: JsonValue, autoEscape: boolean) => Promise<MessageSendResult>;
   deleteMessage: (messageId: number, meta: MessageMeta) => Promise<void>;
   canSendImage: () => boolean;

--- a/packages/onebot/src/event-converter/to-message.ts
+++ b/packages/onebot/src/event-converter/to-message.ts
@@ -86,7 +86,7 @@ export async function convertTempMessage(ctx: ConverterContext, event: TempMessa
     event.elements, false, event.senderUin,
     ctx.imageUrlResolver, ctx.mediaUrlResolver, ctx.messageIdResolver, ctx.mediaSegmentSink,
   );
-  return {
+  const result: JsonObject = {
     time: event.time,
     self_id: ctx.selfId,
     post_type: postType,
@@ -105,4 +105,8 @@ export async function convertTempMessage(ctx: ConverterContext, event: TempMessa
       age: 0,
     },
   };
+  if (event.groupId > 0) {
+    result.group_id = event.groupId;
+  }
+  return result;
 }

--- a/packages/onebot/src/instance-context.ts
+++ b/packages/onebot/src/instance-context.ts
@@ -64,7 +64,7 @@ export function buildApiContext(ref: OneBotInstanceContext): ApiActionContext {
     getMessageMeta: (messageId) => messageStore.findMeta(messageId),
     canSendImage: () => true,
     canSendRecord: () => true,
-    sendPrivateMessage: (userId, message, autoEscape) => sendPrivateMessage(ref, userId, message, autoEscape),
+    sendPrivateMessage: (userId, message, autoEscape, groupId) => sendPrivateMessage(ref, userId, message, autoEscape, groupId),
     sendGroupMessage: (groupId, message, autoEscape) => sendGroupMessage(ref, groupId, message, autoEscape),
     deleteMessage: (_messageId, meta) => deleteMessage(bridge, meta),
     getFriendList: () => getFriendList(bridge),

--- a/packages/onebot/src/modules/message-actions.ts
+++ b/packages/onebot/src/modules/message-actions.ts
@@ -185,6 +185,7 @@ export async function sendPrivateMessage(
   userId: number,
   message: JsonValue,
   autoEscape: boolean,
+  groupId?: number,  // ★ source group for temp session fallback
 ): Promise<MessageSendResult> {
   const elements = await parseMessage(message, autoEscape, {
     resolveReplySequence: (replyMessageId) => {
@@ -249,7 +250,7 @@ export async function sendPrivateMessage(
 
   let lastReceipt: Awaited<ReturnType<typeof ref.bridge.apis.message.sendPrivate>> | undefined;
   if (nonFileElements.length > 0) {
-    lastReceipt = await ref.bridge.apis.message.sendPrivate(userId, nonFileElements);
+    lastReceipt = await ref.bridge.apis.message.sendPrivate(userId, nonFileElements, groupId);
     logSentMessage(false, userId, nonFileElements);
   }
   if (fileElements.length > 0) {

--- a/packages/proto-defs/src/action.ts
+++ b/packages/proto-defs/src/action.ts
@@ -11,6 +11,12 @@ export interface RoutingGroup {
   groupCode?: pb<1, uint_64>;
 }
 
+// Temp-session (临时会话) routing — used when the target is not a friend.
+export interface RoutingGrpTmp {
+  groupUin?: pb<1, uint_64>;
+  toUin?:    pb<2, uint_64>;
+}
+
 // 服务器限制 C2C 文件消息必须使用 Trans0x211 路由头（RoutingHead 字段 15）
 // 若误用常规 RoutingC2C 会被服务器拒绝。
 // 仅在包含 FileEntity 时触发，且 CcCmd 固定为 4。
@@ -24,6 +30,7 @@ export interface RoutingTrans0x211 {
 export interface RoutingHead {
   c2c?:        pb<1, RoutingC2C>;
   grp?:        pb<2, RoutingGroup>;
+  grpTmp?:     pb<3, RoutingGrpTmp>;
   trans0x211?: pb<15, RoutingTrans0x211>;
 }
 


### PR DESCRIPTION
## Summary

Adds support for sending private messages to non-friend QQ users via the temp session (临时会话 / grpTmp) channel.

### Changes

- **proto-defs**: Added `RoutingGrpTmp` type and `grpTmp` field to `RoutingHead`
- **core/bridge**: `MessageApi.sendPrivate` now detects friend status via `identity.findFriend()` — friends use the standard `c2c` routing head, non-friends automatically fall back to `grpTmp` with source group auto-discovery (or caller-specified `sourceGroupId`)
- **onebot actions**: `send_msg` with `message_type: private` extracts `group_id` param and passes it down as the temp session source group
- **onebot modules**: `sendPrivateMessage` threads `groupId` through to the bridge layer
- **onebot events**: `convertTempMessage` now includes `group_id` in the OneBot event payload so clients know which group a temp message originated from

### Verification

All LSP diagnostics pass clean across all changed files.
