### PR TITLE
Fix SSR bundle and node:sqlite resolution in Vite config

### DIFF
--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -23,9 +23,10 @@ const toPosix = (p: string) => p.replace(/\\/g, '/');
 // `@snowluma/websocket` is bundled — it's an
 // in-tree TS workspace wrapper that routes its native `.node`
 // addon through `dist/native/`. Only Node builtins stay external.
-const external: string[] = [];
-
-const nodeModules = [...builtinModules, ...builtinModules.map((m) => `node:${m}`)].flat();
+const isNodeBuiltin = (id: string) =>
+  id.startsWith('node:') ||
+  builtinModules.includes(id) ||
+  builtinModules.includes(id.replace(/^node:/, ''));
 
 const runtimeSrc = toPosix(runtimeDir);
 const nativeSrc = toPosix(nativeDir);
@@ -115,8 +116,9 @@ const BaseConfig = (source_map: boolean = false) => defineConfig({
     }
   },
   build: {
+    ssr: true,
     sourcemap: source_map,
-    target: 'esnext',
+    target: 'node22',
     minify: false,
     lib: {
       entry: {
@@ -126,7 +128,7 @@ const BaseConfig = (source_map: boolean = false) => defineConfig({
       fileName: (_, entryName) => `${entryName}.mjs`
     },
     rollupOptions: {
-      external: [...nodeModules, ...external],
+      external: isNodeBuiltin,
       output: {
         // better-sqlite3's JS wrapper is pure CJS — its `require('fs')` /
         // `require('path')` / `require('bindings')` calls get inlined into
@@ -142,6 +144,9 @@ const BaseConfig = (source_map: boolean = false) => defineConfig({
         // the shim then transparently delegates every inlined CJS require
         // to the real CJS loader. Node 18+ ships `createRequire` in the
         // `node:module` builtin, so this is supported on every target.
+        entryFileNames: '[name].mjs',
+        chunkFileNames: '[name].mjs',
+
         banner: [
           "import { createRequire as __snowlumaCreateRequire } from 'node:module';",
           "const require = __snowlumaCreateRequire(import.meta.url);",
@@ -152,6 +157,9 @@ const BaseConfig = (source_map: boolean = false) => defineConfig({
     outDir: distDir,
     // Required since outDir is outside the vite project root.
     emptyOutDir: true
+  },
+  ssr: {
+    noExternal: true,
   },
   define: {
     __BUILD_WEBUI__: process.env.BUILD_WEBUI === 'true',


### PR DESCRIPTION
### 修复背景
Commit f2b7ef0 在将数据库迁移至 node:sqlite 时，未能同步调整 packages/core 的 Vite 构建配置。这导致 Vite 默认将该包作为前端客户端环境进行打包，把 node:sqlite 错误地转换为了浏览器兼容空壳，最终在hook时引发 DatabaseSync is not a constructor 崩溃。

### 修改内容
1. 调整构建环境：在 packages/core/vite.config.ts 中开启 build.ssr: true，并将编译目标变更为 target: 'node22'，以匹配 Node 原生独占模块的编译规范。
2. 动态模块拦截：将原有的 external 静态数组重构为动态函数 isNodeBuiltin。该函数可以精准捕获所有带 node: 前缀的实验性内置模块（如 node:sqlite），同时解决了第三方依赖（如 @hono/node-server）因默认外置而产生的 MODULE_NOT_FOUND 错误。

### 测试结果
本地执行 `pnpm run build:all` 顺利通过，执行 `pnpm start` 后 hook正常工作。