### PR TITLE
Feat: Request decrypt database key

### DIFF
--- a/packages/core/src/bridge/apis/misc.ts
+++ b/packages/core/src/bridge/apis/misc.ts
@@ -9,6 +9,7 @@ import type { BridgeContext } from '../bridge-context';
 import { ClickInlineKeyboardButton } from '@snowluma/protocol/oidb-services/misc/click-inline-keyboard-button';
 import { SendGroupSign } from '@snowluma/protocol/oidb-services/misc/send-group-sign';
 import { TranslateEnToZh } from '@snowluma/protocol/oidb-services/misc/translate-en-to-zh';
+import { RequestDbKey } from '@snowluma/protocol/oidb-services/misc/request-decrypt-key';
 
 export class MiscApi {
   constructor(private readonly ctx: BridgeContext) { }
@@ -74,5 +75,16 @@ export class MiscApi {
 
   sendGroupSign(groupId: number): Promise<void> {
     return SendGroupSign.invoke(this.ctx, { groupId });
+  }
+
+  async getDecryptKey(dbSalt: string): Promise<string> {
+    const result = await RequestDbKey.invoke(this.ctx, { db_salt: dbSalt });
+    if (!result.success) {
+      throw new Error(result.errorMsg || `Failed to get decrypt key (code: ${result.errorCode})`);
+    }
+    if (!result.dbKey) {
+      throw new Error('Decrypt key is empty');
+    }
+    return result.dbKey;
   }
 }

--- a/packages/onebot/src/actions/extended.ts
+++ b/packages/onebot/src/actions/extended.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises';
 import type { ApiActionContext, ApiHandler } from '../api-handler';
 import { asBoolean, asMessage, asNumber, asString } from '../api-handler';
 import type { ForwardPreviewMeta } from '../modules/message-actions';
@@ -1171,6 +1172,35 @@ export function register(h: ApiHandler, ctx: ApiActionContext): void {
     try {
       await ctx.bridge.apis.extras.fetchAiVoice(groupId, character, text, chatType);
       return okResponse({ message_id: 0 });
+    } catch (err) {
+      return failedResponse(RETCODE.ACTION_FAILED, err instanceof Error ? err.message : String(err));
+    }
+  });
+
+  h.registerAction('request_decrypt_key', async (params) => {
+    const dbPath = asString(params.db_path);
+    if (!dbPath) {
+      return failedResponse(RETCODE.BAD_REQUEST, 'db_path is required');
+    }
+
+    try {
+      const buffer = Buffer.alloc(128);
+      const fileHandle = await readFile(dbPath);
+
+      if (fileHandle.length < 0xaf) {
+        return failedResponse(RETCODE.ACTION_FAILED, 'Database file too short');
+      }
+
+      fileHandle.copy(buffer, 0, 0x2f, 0xaf);
+      const dbSalt = buffer.toString('utf8');
+
+      if (!/^[0-9a-fA-F]{128}$/.test(dbSalt)) {
+        return failedResponse(RETCODE.ACTION_FAILED, 'Invalid db_salt: not a valid 128-character hex string');
+      }
+
+      const dbKey = await ctx.bridge.apis.misc.getDecryptKey(dbSalt.toLowerCase());
+
+      return okResponse({ db_key: dbKey });
     } catch (err) {
       return failedResponse(RETCODE.ACTION_FAILED, err instanceof Error ? err.message : String(err));
     }

--- a/packages/proto-defs/src/oidb-actions/base.ts
+++ b/packages/proto-defs/src/oidb-actions/base.ts
@@ -658,3 +658,21 @@ export interface GroupAvatarExtra {
   field5?:   pb<5, uint_32>;
   field6?:   pb<6, uint_32>;
 }
+
+export interface Oidb0xcdeReqBodyInfo {
+  db_salt?: pb<1, string>;
+}
+
+export interface Oidb0xcdeReq {
+  info?: pb<2, Oidb0xcdeReqBodyInfo>;
+  sessionData?: pb<10, bytes>;
+}
+
+export interface Oidb0xcdeRespBodyInfo {
+  dbKey?: pb<1, string>;
+}
+
+export interface Oidb0xcdeResp {
+  info?: pb<2, Oidb0xcdeRespBodyInfo>;
+}
+

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -107,6 +107,10 @@
       "types": "./src/oidb-services/misc/send-group-sign.ts",
       "default": "./src/oidb-services/misc/send-group-sign.ts"
     },
+    "./oidb-services/misc/request-decrypt-key": {
+      "types": "./src/oidb-services/misc/request-decrypt-key.ts",
+      "default": "./src/oidb-services/misc/request-decrypt-key.ts"
+    },
     "./oidb-services/web/force-fetch-client-key": {
       "types": "./src/oidb-services/web/force-fetch-client-key.ts",
       "default": "./src/oidb-services/web/force-fetch-client-key.ts"

--- a/packages/protocol/src/oidb-service.ts
+++ b/packages/protocol/src/oidb-service.ts
@@ -117,8 +117,18 @@ export async function invokeOidb<TCtx extends OidbSender, TReq, TResp, TParams, 
     : `OidbSvcTrpcTcp.0x${spec.command.toString(16)}_${subCommand}`;
 
   const result = await ctx.sendRawPacket(wireName, reqBytes, timeoutMs);
-  if (!result.success) throw new Error(result.errorMessage || 'packet send failed');
   if (!result.gotResponse) throw new Error(result.errorMessage || 'no response');
+
+  if (!result.success) {
+    if (result.errorCode && result.errorCode !== 0) {
+      throw new OidbError(
+        result.errorCode,
+        result.errorMessage || '',
+        spec.command,
+        subCommand
+      );
+    }
+  }
 
   const respBytes = result.responseData ?? new Uint8Array(0);
   if (respBytes.length > 0) {

--- a/packages/protocol/src/oidb-services/misc/request-decrypt-key.ts
+++ b/packages/protocol/src/oidb-services/misc/request-decrypt-key.ts
@@ -1,0 +1,70 @@
+import { protobuf_decode, protobuf_encode } from '@snowluma/proton';
+import type { OidbBase } from '@snowluma/proto-defs/oidb';
+import type { Oidb0xcdeReq, Oidb0xcdeResp } from '@snowluma/proto-defs/oidb-actions/base';
+import { invokeOidb, type OidbSender } from '../../oidb-service';
+
+export namespace RequestDbKey {
+  export const command = 0xcde;
+  export const subCommand = 2;
+
+  export interface Params {
+    db_salt: string;
+    sessionData?: Uint8Array;
+  }
+
+  export interface Result {
+    success: boolean;
+    dbKey?: string;
+    errorCode?: number;
+    errorMsg?: string;
+  }
+
+  export type Deps = OidbSender;
+
+  export const serialize = (_ctx: Deps, p: Params): Oidb0xcdeReq => {
+    const req: Oidb0xcdeReq = {
+      info: {
+        db_salt: p.db_salt,
+      }
+    };
+    if (p.sessionData) {
+      req.sessionData = p.sessionData;
+    }
+    return req;
+  };
+
+  export const deserialize = (_ctx: Deps, body: Oidb0xcdeResp): string => {
+    const dbKey = body.info?.dbKey;
+
+    if (!dbKey) {
+      throw new Error('Oidb 0xcde_2 payload empty (Missing dbKey)');
+    }
+    return dbKey;
+  };
+
+  export const encode = (env: OidbBase<Oidb0xcdeReq>): Uint8Array =>
+    protobuf_encode<OidbBase<Oidb0xcdeReq>>(env);
+
+  export const decode = (bytes: Uint8Array): OidbBase<Oidb0xcdeResp> =>
+    protobuf_decode<OidbBase<Oidb0xcdeResp>>(bytes);
+
+  export const invoke = async (deps: Deps, params: Params): Promise<Result> => {
+    try {
+      const key = await invokeOidb(deps, RequestDbKey, params);
+      return {
+        success: true,
+        dbKey: key,
+      };
+    } catch (error: any) {
+      const code = error?.code ?? -1;
+
+      return {
+        success: false,
+        errorCode: code,
+        errorMsg: code === 1006
+          ? "数据库不匹配！检查数据库是否属于当前帐号"
+          : (error?.serverMsg || error?.message || "网络或包结构解析失败"),
+      };
+    }
+  };
+}


### PR DESCRIPTION
### 主动获取数据库密钥

#### 原理说明
- QQ魔改sqlcipher数据库有1024字节的头，里面放了一个长128的hex数据，QQ本体叫它key_meta 它是数据库的标识，可以兑换数据库密钥
- 0xcde_1请求获取encrypt_key，只在数据库初始化的时候触发，返回db_meta和db_key，db_salt写入数据库的1024字节头
- 0xcde_2 请求获取decrypt_key，在登录时触发，返回db_key，两个核心参数是db_meta和鉴权的一个令牌
---
但是实际上，鉴权的令牌是不需要的（（ 登录初期带上它可能是因为鉴权流程还没完成
- 备份手机获取临时数据库密钥时，只有db_salt
- 不带令牌可以正常获取自己数据库的db_key（用临时数据库请求的proto包），但是尝试其它账号数据库的db_salt会报错1006

**总之本PR实现了主动触发获取数据库密钥**

#### 修改
1. 新增一个OIDB action  (0xcde)
2. 修改了oidb service 遇到错误码时的抛出的error，返回错误码便于1006的拦截
3. 新增获取密钥的onebot api  （便于测试）