### PR TITLE
New implement for QQ status detection

### DIFF
--- a/packages/bridge/src/qq-port-probe.ts
+++ b/packages/bridge/src/qq-port-probe.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
 import net from 'net';
+import https from 'https';
 import { promisify } from 'util';
 
 const execAsync = promisify(exec);
@@ -41,6 +42,7 @@ function decodeJwt(token: string): JwtPayload | null {
     return null;
   }
 }
+
 
 async function probePort(port: number): Promise<QqPortLoginInfo | null> {
   return new Promise((resolve) => {
@@ -108,6 +110,85 @@ async function probePort(port: number): Promise<QqPortLoginInfo | null> {
   });
 }
 
+
+async function fetchPtlogin(port: number): Promise<any[]> {
+  return new Promise((resolve) => {
+    const url = `https://127.0.0.1:${port}/pt_get_uins?callback=ptui_getuins_CB&pt_local_tk=0`;
+
+    const req = https.get(
+      url,
+      {
+        headers: {
+          Host: 'localhost.ptlogin2.qq.com',
+          Referer: 'https://xui.ptlogin2.qq.com/',
+          Cookie: 'pt_local_token=0',
+        },
+        rejectUnauthorized: false, // 忽略本地自签证书报错
+        timeout: CONNECTION_TIMEOUT_MS,
+      },
+      (res) => {
+        let text = '';
+        res.on('data', (chunk) => { text += chunk.toString(); });
+        res.on('end', () => {
+          try {
+            // 100% 复刻 Python 切片逻辑：获取两个方括号中间的字符串，再包装成数组
+            const inner = text.split('[')[1].split(']')[0];
+            const data = JSON.parse('[' + inner + ']');
+            resolve(data);
+          } catch {
+            resolve([]);
+          }
+        });
+      }
+    );
+
+    req.on('error', () => resolve([]));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve([]);
+    });
+  });
+}
+
+async function tryPtloginMethod(port: number): Promise<QqPortLoginInfo | 'fallback'> {
+  // 抽象的 QQNT
+  const res1 = await fetchPtlogin(port);
+  const res2 = await fetchPtlogin(port);
+
+  const target = res1.length < res2.length ? res1 : res2;
+
+  if (target.length === 1) {
+    const account = target[0];
+    return {
+      port,
+      uin: String(account.uin || account.account || ''),
+      nickName: account.nickname || '',
+      loggedIn: true,
+    };
+  }
+
+  if ((res1.length === 2 && res2.length === 0) || (res1.length === 0 && res2.length === 2)) {
+    return 'fallback';
+  }
+
+  return 'fallback';
+}
+
+
+async function getQqProcessCount(): Promise<number> {
+  try {
+    if (process.platform === 'win32') {
+      const { stdout } = await execAsync('tasklist /fi "imagename eq QQ.exe" /nh');
+      return stdout.toLowerCase().split('\n').filter(line => line.includes('qq.exe')).length;
+    } else {
+      const { stdout } = await execAsync('pgrep -c qq');
+      return parseInt(stdout.trim(), 10) || 0;
+    }
+  } catch {
+    return 6;
+  }
+}
+
 async function getProcessPorts(pid: number): Promise<number[]> {
   try {
     if (process.platform === 'win32') {
@@ -119,13 +200,11 @@ async function getProcessPorts(pid: number): Promise<number[]> {
         if (parts.length < 5) continue;
         const owningPid = parts[parts.length - 1];
         if (owningPid !== String(pid)) continue;
+
         const localAddr = parts[1];
         const portMatch = localAddr.match(/:(\d+)$/);
         if (!portMatch) continue;
-        const port = Number(portMatch[1]);
-        if (port >= PORT_RANGE_START && port <= PORT_RANGE_END) {
-          ports.add(port);
-        }
+        ports.add(Number(portMatch[1]));
       }
       return Array.from(ports);
     } else {
@@ -135,10 +214,7 @@ async function getProcessPorts(pid: number): Promise<number[]> {
       for (const line of lines) {
         const match = line.match(/:(\d+)\s/);
         if (match) {
-          const port = Number(match[1]);
-          if (port >= PORT_RANGE_START && port <= PORT_RANGE_END) {
-            ports.add(port);
-          }
+          ports.add(Number(match[1]));
         }
       }
       return Array.from(ports);
@@ -148,18 +224,41 @@ async function getProcessPorts(pid: number): Promise<number[]> {
   }
 }
 
+
 export async function probeQqLoginInfo(pid: number): Promise<QqPortLoginInfo | null> {
   const ports = await getProcessPorts(pid);
 
   if (ports.length === 0) {
-    for (let port = PORT_RANGE_START; port <= PORT_RANGE_END; port++) {
-      const info = await probePort(port);
-      if (info) return info;
+    const totalPids = await getQqProcessCount();
+    if (totalPids < 6) {
+      return { port: 0, uin: '', loggedIn: false };
     }
     return null;
   }
 
-  for (const port of ports) {
+  const PT_PORTS = [4301, 4303, 4305, 4307, 4309];
+  const matchedPtPorts = ports.filter(p => PT_PORTS.includes(p));
+
+  if (matchedPtPorts.length > 0) {
+    for (const port of matchedPtPorts) {
+      const ptResult = await tryPtloginMethod(port);
+      if (ptResult !== 'fallback') {
+        return ptResult;
+      }
+    }
+  } else {
+    const totalPids = await getQqProcessCount();
+    if (totalPids < 6) {  // 13579  5个端口全部用光
+      return {
+        port: ports[0] || 0,
+        uin: '',
+        loggedIn: false,
+      };
+    }
+  }
+
+  const deepLinkPorts = ports.filter(p => p >= PORT_RANGE_START && p <= PORT_RANGE_END);
+  for (const port of deepLinkPorts) {
     const info = await probePort(port);
     if (info) return info;
   }


### PR DESCRIPTION
refactor(probe): 优化 QQ 进程登录状态探测逻辑 (引入 Ptlogin2 无感探测)
---

## 📝 描述

重构了 `qq-port-probe.ts` 中的进程登录状态探测机制。 PR #56 中的不够优雅的实现

**现有痛点：**
原有的探测方案会无差别地对 `9210-9219` 端口发送 `tencent://` 空深链接 payload。虽然这种方案通用性强，但在部分场景下会导致 QQ 抛出深链接解析错误的弹窗报错，对用户打扰较大，不够优雅。同时，旧逻辑存在全局扫段的问题，未与指定的 PID 严格绑定。

**本次变更：**
1. **精确绑定 PID**：不再全局扫段，改为通过 `netstat` / `ss` 严格提取目标 PID 实际监听的端口，所有探测均作用于该进程的真实端口。
2. **引入 Ptlogin2 探测**：优先使用本地 Ptlogin2 接口获取 UIN，实现 100% 无弹窗、无感知的状态探测。
3. **完善的 Fallback 机制**：在 Ptlogin2 探测失败或进程环境过于复杂时，安全降级到原有的深链接探测逻辑。

---

## 🔍 原理与实现细节

### 1. Ptlogin2 探测机制 (Primary)
QQ 进程会在本地开放特定的端口（如 `4301, 4303, 4305, 4307, 4309`）用于网页端快捷登录。我们通过伪造请求头（`Host`, `Referer`, `Cookie`）向 `https://127.0.0.1:<port>/pt_get_uins` 发起 HTTPS GET 请求，直接截取返回的 JSONP 数据流。

### 2. “双发包”对齐策略
Ptlogin 接口存在一个非常怪异的轮换返回机制：它会交替返回“前两个登录的账号”和“当前账号”。为了准确锁定当前进程的登录账号，我们采用了**连续请求两次，取长度较小的结果**的策略：
* **情况一 (2+1)**：一次返回2个历史账号，一次返回1个，取 1，即为当前登录账号。
* **情况二 (1+1)**：两次均返回1个，取 1，即为当前登录账号。
* **情况三 (2+0)**：账号已登录，但并非前两个登录的账号，导致接口返回空。此时直接中断 Ptlogin 探测，回退到后续容灾逻辑。

### 3. 降级与容灾逻辑 (Fallback)
为了保证极端情况下的探测稳定性，保留了原有的 JWT 探测作为兜底：
* **无 Ptlogin 端口**：若当前系统内的 QQ 进程总数 $< 6$，则推断该 PID 处于“等待登录”状态；若进程数 $\ge 6$，环境可能被污染，交由深链接逻辑继续探测。
* **异常拦截**：任何未预期的数组长度或请求超时，均自动降级到探测该进程名下的 `9210-9219` 端口，复用旧版 deep-link 方案。

## ✅ 测试情况
- [x] Windows 环境下 PID 端口提取测试通过
- [x] Linux 环境下 PID 端口提取测试通过
- [x] 多账号登录情况下的 Ptlogin2 结果解析测试通过
- [x] 降级触发测试（模拟端口无响应）通过