### PR TITLE
fix(protocol): one TCP connection per highway chunk

### DIFF
--- a/packages/core/tests/highway/highway-client.test.ts
+++ b/packages/core/tests/highway/highway-client.test.ts
@@ -1,0 +1,161 @@
+// highway-client.uploadHighwayHttp 的连接生命周期测试。
+//
+// 回归覆盖：当上传数据 > HIGHWAY_BLOCK_SIZE (1 MiB) 时，旧实现会复用
+// 同一个 TCP socket 在 keep-alive 模式下连续 POST，但 QQ highway 的
+// 边缘节点经常在第一次响应后立刻 FIN 关闭，导致第二次 POST 报
+// `connection closed before response`。用户上报的 1.19 MB 图片
+// （onebot retcode=1200）就是这个分支。
+//
+// 修复方案：每个 chunk 独立建一个新的 TCP 连接。本测试通过 mock
+// `net.createConnection` 计数建连次数，断言每个 chunk 一连接的不变量。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'events';
+
+// highway-client 解析响应只关心 errorCode === 0 —— 一个完全空的
+// RespDataHighwayHead protobuf 体（0 字节）会被解为 ，errorCode
+// 是 undefined，走 falsy 通过分支。
+//
+// HTTP body 是 highway frame：
+//   0x28 | head_len(BE32) | body_len(BE32) | head | body | 0x29
+function buildEmptyHighwayResponseFrame(): Buffer {
+  const frame = Buffer.alloc(10);
+  frame[0] = 0x28;
+  frame.writeUInt32BE(0, 1); // head_len
+  frame.writeUInt32BE(0, 5); // body_len
+  frame[9] = 0x29;
+  return frame;
+}
+
+function buildHttpResponse(frameBody: Buffer): Buffer {
+  const headers = [
+    'HTTP/1.1 200 OK',
+    `Content-Length: ${frameBody.length}`,
+    'Connection: close',
+    '',
+    '',
+  ].join('\r\n');
+  return Buffer.concat([Buffer.from(headers, 'ascii'), frameBody]);
+}
+
+// FakeSocket 模拟 net.Socket 的最小子集。highway-client 用到：
+//   - 'data' / 'error' / 'close' 事件
+//   - .write(data, cb)  cb 会被 socketWrite 等待
+//   - .destroy()
+//   - .setTimeout / .once / .removeListener  （继承自 EventEmitter）
+class FakeSocket extends EventEmitter {
+  destroyed = false;
+  // 每个 POST = 2 次 write（HTTP header + body）。第二次 write 落地后
+  // 异步回放响应并立刻 close —— 复现 QQ highway 真实行为：响应一发完
+  // 就 FIN，旧实现的下一次 POST 必然撞上已关闭的 socket。
+  private writeCount = 0;
+  private response: Buffer;
+
+  constructor(response: Buffer) {
+    super();
+    this.response = response;
+  }
+
+  setTimeout(_ms: number) { /* no-op */ }
+
+  write(_data: unknown, cb?: (err?: Error) => void): boolean {
+    this.writeCount += 1;
+    if (this.writeCount === 2) {
+      setImmediate(() => {
+        this.emit('data', this.response);
+        this.emit('close');
+      });
+    }
+    if (cb) cb();
+    return true;
+  }
+
+  destroy() {
+    this.destroyed = true;
+  }
+}
+
+// vitest 把 vi.mock 工厂 hoist 到文件顶部，所以工厂里不能引用普通的
+// 顶层 const —— 那会触发 "Cannot access X before initialization"。
+// 用 vi.hoisted 让这两个值跟着 mock 一起被 hoist。
+const { createdSockets, createConnectionMock } = vi.hoisted(() => ({
+  createdSockets: [] as FakeSocket[],
+  createConnectionMock: vi.fn(),
+}));
+
+vi.mock('net', () => ({
+  default: { createConnection: createConnectionMock },
+  createConnection: createConnectionMock,
+}));
+
+import { uploadHighwayHttp, type HighwaySession } from '@snowluma/protocol/highway';
+import type { BridgeContext } from '@snowluma/protocol/bridge-context';
+
+const HIGHWAY_BLOCK_SIZE = 1024 * 1024;
+
+function makeBridge(): BridgeContext {
+  return {
+    identity: { uin: '10001' } as unknown,
+  } as unknown as BridgeContext;
+}
+
+function makeSession(): HighwaySession {
+  return {
+    sigSession: new Uint8Array([0xAA]),
+    sessionKey: new Uint8Array([0xBB]),
+    host: '127.0.0.1',
+    port: 80,
+  };
+}
+
+describe('uploadHighwayHttp connection lifecycle', () => {
+  beforeEach(() => {
+    createdSockets.length = 0;
+    createConnectionMock.mockReset();
+    createConnectionMock.mockImplementation((_opts: unknown, listener?: () => void) => {
+      const sock = new FakeSocket(buildHttpResponse(buildEmptyHighwayResponseFrame()));
+      createdSockets.push(sock);
+      // net.createConnection 在握手成功后调用 listener。同步触发即可，
+      // tcpConnect 的 Promise 会立刻 resolve。
+      if (listener) setImmediate(listener);
+      return sock as unknown as ReturnType<typeof createConnectionMock>;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses a single TCP connection for a sub-block payload', async () => {
+    // 0.5 MiB → 1 chunk。覆盖 PTT / 小图的常见场景。
+    const bytes = new Uint8Array(512 * 1024);
+    await uploadHighwayHttp(
+      makeBridge(), makeSession(), 1003, bytes, new Uint8Array(16), new Uint8Array(0),
+    );
+    expect(createConnectionMock).toHaveBeenCalledTimes(1);
+    expect(createdSockets[0]!.destroyed).toBe(true);
+  });
+
+  it('uses a fresh TCP connection per chunk for multi-block payloads', async () => {
+    // 1.5 MiB → ceil(1.5) = 2 chunks。这正是用户上报的 1.19 MB 图片
+    // 触发的代码路径：旧实现复用 socket 时第二次 POST 撞上 keep-alive
+    // 关闭，新实现必须为每个 chunk 各开一个 socket。
+    const bytes = new Uint8Array(Math.floor(1.5 * HIGHWAY_BLOCK_SIZE));
+    await uploadHighwayHttp(
+      makeBridge(), makeSession(), 1003, bytes, new Uint8Array(16), new Uint8Array(0),
+    );
+    expect(createConnectionMock).toHaveBeenCalledTimes(2);
+    expect(createdSockets).toHaveLength(2);
+    for (const sock of createdSockets) {
+      expect(sock.destroyed).toBe(true);
+    }
+  });
+
+  it('opens N connections for N chunks (3 chunks here)', async () => {
+    const bytes = new Uint8Array(Math.floor(2.5 * HIGHWAY_BLOCK_SIZE));
+    await uploadHighwayHttp(
+      makeBridge(), makeSession(), 1004, bytes, new Uint8Array(16), new Uint8Array(0),
+    );
+    expect(createConnectionMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/protocol/src/highway/highway-client.ts
+++ b/packages/protocol/src/highway/highway-client.ts
@@ -202,7 +202,14 @@ function readHttpResponseBody(socket: net.Socket): Promise<Uint8Array> {
     const onClose = () => finish(() => {
       const buf = Buffer.concat(chunks);
       if (headerEnd >= 0) resolve(new Uint8Array(buf.subarray(headerEnd)));
-      else reject(new Error('connection closed before response'));
+      // QQ 的 highway 边缘节点对单连接多 POST 的 keep-alive 支持不稳定：
+      // 第一次 POST 拿到响应后服务器经常立刻 FIN 关闭，下一次写入的请求体
+      // 走到一个已被对端 close 的 socket 上，触发这里。诊断信息把已收到的
+      // 字节数和是否解析到 header 一起带出来，便于区分 “连接刚握手就被关”
+      // 和 “响应读到一半被截断” 两种情况。
+      else reject(new Error(
+        `connection closed before response (received=${buf.length}B, headerSeen=${headerEnd >= 0})`
+      ));
     });
 
     socket.on('data', onData);
@@ -225,42 +232,60 @@ export async function uploadHighwayHttp(
   bytes: Uint8Array, fileMd5: Uint8Array, extend: Uint8Array,
 ): Promise<void> {
   const pathStr = `/cgi-bin/httpconn?htcmd=0x6FF0087&uin=${bridge.identity.uin}`;
-  const socket = await tcpConnect(session.host, session.port);
 
-  try {
-    let offset = 0;
-    while (offset < bytes.length) {
-      const chunkSize = Math.min(HIGHWAY_BLOCK_SIZE, bytes.length - offset);
-      const chunk = bytes.subarray(offset, offset + chunkSize);
-      const chunkMd5 = computeMd5(chunk);
-      const head = makeHighwayHead(
-        bridge.identity.uin, commandId, bytes.length, offset, chunkSize,
-        chunkMd5, fileMd5, session.sigSession, extend,
-      );
-      const frame = packHighwayFrame(head, chunk);
-      const responseBody = await httpPostFrame(socket, session.host, pathStr, frame);
-      const { head: respHead } = unpackHighwayFrame(responseBody);
-      const resp = protobuf_decode<RespDataHighwayHead>(respHead);
-      if (resp?.errorCode && resp.errorCode !== 0) {
-        // Surface every diagnostic the highway response carries so
-        // user reports of `error_code=921` and friends include the
-        // server-side context (segHead.retCode, chunk size, file md5)
-        // — without these we can't tell apart a malformed-payload
-        // reject, a session-ticket mismatch, or a per-account rate-
-        // limit.
-        const segRetCode = resp.msgSegHead?.retCode ?? 0;
-        const fileMd5Hex = Buffer.from(fileMd5).toString('hex');
-        throw new Error(
-          `highway upload error_code=${resp.errorCode}` +
-          ` (cmdId=${commandId} chunk=${chunkSize}/${bytes.length}` +
-          ` offset=${offset} segRetCode=${segRetCode}` +
-          ` fileMd5=${fileMd5Hex.slice(0, 16)}…)`,
-        );
-      }
-      offset += chunkSize;
-      console.log(`[Highway] uploaded ${offset}/${bytes.length} bytes`);
+  // 每个 chunk 一个独立的 TCP 连接。
+  //
+  // 旧实现整个文件复用同一个 socket，依赖 `Connection: keep-alive` 跑多次
+  // POST。但 QQ highway 边缘节点（以及链路上的代理/NAT）经常在第一次响应
+  // 之后立刻 FIN 关闭连接，导致第二个 chunk 写入一个已被对端关闭的 socket，
+  // `readHttpResponseBody` 立刻收到 `close` 事件并抛 `connection closed
+  // before response`。
+  //
+  // 现象上的体现：≤1 MB 的图片/PTT 因为只发一个 chunk，不会触发；超过 1 MB
+  // 的图片或视频（HIGHWAY_BLOCK_SIZE = 1 MiB）必然失败。
+  //
+  // 改成每 chunk 一连接代价可忽略：
+  //   - 单个 1 MB chunk 的传输时间远大于 TCP 建连开销；
+  //   - QQ 服务端反正也不希望客户端长时间占用连接；
+  //   - 与 NapCat / Lagrange 在大文件上传时的连接生命周期一致。
+  let offset = 0;
+  while (offset < bytes.length) {
+    const chunkSize = Math.min(HIGHWAY_BLOCK_SIZE, bytes.length - offset);
+    const chunk = bytes.subarray(offset, offset + chunkSize);
+    const chunkMd5 = computeMd5(chunk);
+    const head = makeHighwayHead(
+      bridge.identity.uin, commandId, bytes.length, offset, chunkSize,
+      chunkMd5, fileMd5, session.sigSession, extend,
+    );
+    const frame = packHighwayFrame(head, chunk);
+
+    const socket = await tcpConnect(session.host, session.port);
+    let responseBody: Uint8Array;
+    try {
+      responseBody = await httpPostFrame(socket, session.host, pathStr, frame);
+    } finally {
+      socket.destroy();
     }
-  } finally {
-    socket.destroy();
+
+    const { head: respHead } = unpackHighwayFrame(responseBody);
+    const resp = protobuf_decode<RespDataHighwayHead>(respHead);
+    if (resp?.errorCode && resp.errorCode !== 0) {
+      // Surface every diagnostic the highway response carries so
+      // user reports of `error_code=921` and friends include the
+      // server-side context (segHead.retCode, chunk size, file md5)
+      // — without these we can't tell apart a malformed-payload
+      // reject, a session-ticket mismatch, or a per-account rate-
+      // limit.
+      const segRetCode = resp.msgSegHead?.retCode ?? 0;
+      const fileMd5Hex = Buffer.from(fileMd5).toString('hex');
+      throw new Error(
+        `highway upload error_code=${resp.errorCode}` +
+        ` (cmdId=${commandId} chunk=${chunkSize}/${bytes.length}` +
+        ` offset=${offset} segRetCode=${segRetCode}` +
+        ` fileMd5=${fileMd5Hex.slice(0, 16)}…)`,
+      );
+    }
+    offset += chunkSize;
+    console.log(`[Highway] uploaded ${offset}/${bytes.length} bytes`);
   }
 }


### PR DESCRIPTION
## 这个 PR 干了什么

修一个 highway 大文件上传的 bug：超过 1 MiB 的图片/视频通过 OneBot 发出去时 100% 失败，OneBot 侧表现是 `retcode=1200` / `wording: connection closed before response`。

## 复现

任何超过 `HIGHWAY_BLOCK_SIZE` (1 MiB) 的图片/视频 → 必然失败。
≤1 MiB 的图片、PTT、文本完全正常。

```
[OneBot.HTTP] action send_msg failed: connection closed before response
```

## 根因

[`uploadHighwayHttp`](packages/protocol/src/highway/highway-client.ts:1) 之前的实现是开**一个** TCP socket，靠 HTTP keep-alive 把每个 1 MiB chunk 依次 POST 出去。

但 QQ highway 的边缘节点（以及链路上的代理/NAT）经常在第一次响应之后**立刻 FIN 关闭连接**，第二个 chunk 的 POST 写到一个已被对端 close 的 socket 上，[`readHttpResponseBody`](packages/protocol/src/highway/highway-client.ts:165) 立刻收到 `close` 事件并抛出 `connection closed before response`。

为什么以前看着像网络问题：≤1 MiB 的载荷只发一次 POST，永远不会触发；但凡跨过 `HIGHWAY_BLOCK_SIZE = 1 MiB`，第二个 chunk 路径必然失败。改 Clash MTU、关 TUN、加直连规则都没用 —— 因为问题不在网络层。

## 改动

- [`uploadHighwayHttp`](packages/protocol/src/highway/highway-client.ts:230)：每个 chunk 都新开一个 TCP 连接，`finally` 里 `destroy()`。建连开销相对 1 MiB chunk 的传输时间可以忽略，行为也和 NapCat / Lagrange 在大文件上传时的连接生命周期一致。
- [`readHttpResponseBody`](packages/protocol/src/highway/highway-client.ts:202)：报错信息带上 `received=NB, headerSeen=true|false`，方便后续区分"连接刚握手就被关"和"响应读到一半被截断"两种情况。

## 测试

新增 [`packages/core/tests/highway/highway-client.test.ts`](packages/core/tests/highway/highway-client.test.ts) 三个用例：

| size | chunks | 用例覆盖 |
| --- | --- | --- |
| 0.5 MiB | 1 | 单 chunk 不应该回归到多连接 |
| **1.5 MiB** | **2** | **本次 bug 直接复现** |
| 2.5 MiB | 3 | 三连模式下每个 socket 都被 destroy |

断言：`net.createConnection` 调用次数严格等于 `ceil(size / HIGHWAY_BLOCK_SIZE)`，并且每个用过的 socket 在下一次建连之前都被 destroy。

```
pnpm --filter @snowluma/core test highway
```

已有的 highway 全套（multi-image / pipeline / image-upload / ptt-upload / video-upload）继续通过。

## 线上验证

之前每次发 1 MB 以上的图片必出 retcode=1200 的账号，打这个补丁、重新打镜像、重启容器之后正常发出。

## 关联

不知道有没有对应的 issue，常见的相关用户报告关键词：`retcode 1200` / `connection closed before response` / `图片发不出` / `视频发不出` / `图大于 1MB 失败`。
