### PR TITLE
feat(ci): 默认将 release 镜像同步发布到 GHCR

### DIFF
--- a/.github/workflows/dispatch-docker-release.yml
+++ b/.github/workflows/dispatch-docker-release.yml
@@ -22,6 +22,10 @@ on:
         description: 'Override platforms (defaults to vars.DOCKER_PLATFORMS or linux/amd64,linux/arm64)'
         required: false
         default: ''
+      ghcr_image_override:
+        description: 'Override GHCR image name (defaults to vars.GHCR_IMAGE, leave empty to skip GHCR)'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -42,6 +46,8 @@ jobs:
           SNOWLUMA_TAG: ${{ inputs.snowluma_tag }}
           IMAGE_OVERRIDE: ${{ inputs.docker_image_override }}
           PLATFORMS_OVERRIDE: ${{ inputs.platforms_override }}
+          GHCR_IMAGE: ${{ vars.GHCR_IMAGE }}
+          GHCR_OVERRIDE: ${{ inputs.ghcr_image_override }}
         with:
           github-token: ${{ secrets.SNOWLUMA_TOKEN }}
           script: |
@@ -59,6 +65,7 @@ jobs:
             const platforms = process.env.PLATFORMS_OVERRIDE || process.env.DOCKER_PLATFORMS || 'linux/amd64,linux/arm64';
             const workflowId = process.env.DOCKER_WORKFLOW || 'docker-image.yml';
             const ref = process.env.DOCKER_REF || 'main';
+            const ghcrImage = process.env.GHCR_OVERRIDE || process.env.GHCR_IMAGE || '';
 
             await github.rest.actions.createWorkflowDispatch({
               owner,
@@ -72,7 +79,8 @@ jobs:
                 platforms,
                 snowluma_tag: tag,
                 snowluma_repository: sourceRepo,
+                ghcr_image: ghcrImage,
               },
             });
 
-            core.info(`Re-dispatched ${workflowId}@${ref} on ${target} for SnowLuma release ${sourceRepo}@${tag} (image=${image}, platforms=${platforms}).`);
+            core.info(`Re-dispatched ${workflowId}@${ref} on ${target} for SnowLuma release ${sourceRepo}@${tag} (image=${image}, ghcr_image=${ghcrImage}, platforms=${platforms}).`);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,7 @@ jobs:
           DOCKER_PLATFORMS: ${{ vars.DOCKER_PLATFORMS }}
           DOCKER_WORKFLOW: ${{ vars.DOCKER_WORKFLOW }}
           DOCKER_REF: ${{ vars.DOCKER_REF }}
+          GHCR_IMAGE: ${{ vars.GHCR_IMAGE }}
         with:
           github-token: ${{ secrets.SNOWLUMA_TOKEN }}
           script: |
@@ -195,6 +196,7 @@ jobs:
             const platforms = process.env.DOCKER_PLATFORMS || 'linux/amd64,linux/arm64';
             const workflowId = process.env.DOCKER_WORKFLOW || 'docker-image.yml';
             const ref = process.env.DOCKER_REF || 'main';
+            const ghcrImage = process.env.GHCR_IMAGE || '';
 
             await github.rest.actions.createWorkflowDispatch({
               owner,
@@ -208,7 +210,8 @@ jobs:
                 platforms,
                 snowluma_tag: tag,
                 snowluma_repository: sourceRepo,
+                ghcr_image: ghcrImage,
               },
             });
 
-            core.info(`Dispatched ${workflowId}@${ref} on ${target} for SnowLuma release ${sourceRepo}@${tag} (image=${image}, platforms=${platforms}).`);
+            core.info(`Dispatched ${workflowId}@${ref} on ${target} for SnowLuma release ${sourceRepo}@${tag} (image=${image}, ghcr_image=${ghcrImage}, platforms=${platforms}).`);


### PR DESCRIPTION
发布 release 后，自动将 Docker 镜像推送到 Docker Hub 和 GHCR：
- Docker Hub：`motricseven7/snowluma`
- GHCR：`ghcr.io/snowluma/snowluma`

自动发布与手动重建都会传入 `ghcr_image`。镜像名优先使用 SnowLuma environment 的 `GHCR_IMAGE`；未配置或为空时默认使用 `ghcr.io/snowluma/snowluma`。手动重建还可通过 `ghcr_image_override` 覆盖，留空时沿用环境变量或默认值。

下游支持已合并：https://github.com/SnowLuma/SnowLuma.Docker.Framework/pull/4 。原有 Docker Hub 镜像名、平台、release tag 与源仓库参数保持一致。

使用：
```bash
docker pull ghcr.io/snowluma/snowluma:latest
SNOWLUMA_IMAGE=ghcr.io/snowluma/snowluma:latest docker compose up -d
```
首次发布 GHCR package 后需设置为 Public，才能匿名拉取；已有 package 需授予 Docker.Framework 仓库 Actions 写入权限。

验证：
- actionlint 1.7.12 校验两个工作流通过。
- 8 组本地模拟调用检查通过，覆盖未配置、空值、自定义变量、手动覆盖及覆盖优先级。
- 与已合并 Docker.Framework 工作流的输入定义一致，并确认原有 dispatch 字段保持一致。
- 未触发实际 release 或镜像发布；完整项目 CI 结果见本 PR 检查。

完整 CI：test、typecheck、build、lint 全部通过。运行记录：https://github.com/SnowLuma/SnowLuma/actions/runs/34808502212
