### PR TITLE
refactor(webui): 移除冗余的手动保存按钮喵，通用设置改为 debounce 自动保存喵

### DIFF
--- a/packages/webui/src/components/config/general-settings-tab.tsx
+++ b/packages/webui/src/components/config/general-settings-tab.tsx
@@ -1,7 +1,7 @@
 // "通用设置" tab — fields that apply to the whole OneBotInstance rather
 // than any specific adapter: the music-sign service URL and the built-in
-// `#sl` status command. Edits here mark the config dirty and are persisted
-// via the page's explicit top-right 保存 (a continuously-edited surface).
+// `#sl` status command. Edits here mark the config dirty and are
+// auto-saved with debounce by the parent ConfigPage.
 
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/packages/webui/src/components/pages/config-page.tsx
+++ b/packages/webui/src/components/pages/config-page.tsx
@@ -6,9 +6,9 @@
 // through `NodeEditDialog`. All changes auto-save: network mutations
 // persist immediately; general-settings edits are debounced (500 ms).
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { motion } from 'motion/react';
-import { MousePointerClick, Plus } from 'lucide-react';
+import { MousePointerClick, Plus, Save } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Badge } from '@/components/ui/badge';
@@ -49,6 +49,7 @@ export function ConfigPage() {
     confirmSwitch,
     cancelSwitch,
     save,
+    saveStatus,
   } = useOneBotInstanceConfig(qqList, {
     selectedUin,
     onSelectedUinChange: setSelectedUin,
@@ -94,6 +95,15 @@ export function ConfigPage() {
       if (debounceRef.current != null) window.clearTimeout(debounceRef.current);
     };
   }, [dirty, config, save]);
+
+  /** Immediate save: clear any pending auto-save debounce and persist now. */
+  const immediateSave = useCallback(() => {
+    if (debounceRef.current != null) {
+      window.clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    void save();
+  }, [save]);
 
   function commitKind<K extends NetworkKind>(kind: K, nextList: OneBotNetworks[K]): void {
     if (!config) return;
@@ -165,6 +175,9 @@ export function ConfigPage() {
           <div className="flex flex-col gap-4">
             <HeaderBar
               selectedUin={selectedUin}
+              dirty={dirty}
+              saveStatus={saveStatus}
+              onSave={immediateSave}
               activeTab={activeTab}
               onCreate={
                 activeTab !== 'general' ? () => openCreate(activeTab as NetworkKind) : undefined
@@ -237,11 +250,14 @@ export function ConfigPage() {
 
 interface HeaderBarProps {
   selectedUin: string;
+  dirty: boolean;
+  saveStatus: string;
+  onSave: () => void;
   activeTab: TabKey;
   onCreate?: () => void;
 }
 
-function HeaderBar({ selectedUin, activeTab, onCreate }: HeaderBarProps) {
+function HeaderBar({ selectedUin, dirty, saveStatus, onSave, activeTab, onCreate }: HeaderBarProps) {
   return (
     <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="min-w-0">
@@ -251,12 +267,34 @@ function HeaderBar({ selectedUin, activeTab, onCreate }: HeaderBarProps) {
         </code>
       </div>
       <div className="flex flex-wrap items-center gap-2">
+        {saveStatus && (
+          <span
+            className={cn(
+              'rounded-full border px-2.5 py-1 text-[11px] font-medium',
+              saveStatus === '保存成功' && 'border-success/30 bg-success/10 text-success',
+              saveStatus === '保存中...' && 'border-border bg-muted text-muted-foreground',
+              saveStatus !== '保存成功' &&
+                saveStatus !== '保存中...' &&
+                'border-destructive/30 bg-destructive/10 text-destructive',
+            )}
+          >
+            {saveStatus}
+          </span>
+        )}
+        {dirty && !saveStatus && (
+          <span className="rounded-full border border-warning/30 bg-warning/10 px-2.5 py-1 text-[11px] font-medium text-warning">
+            未保存
+          </span>
+        )}
         {onCreate && (
           <Button size="sm" variant="outline" onClick={onCreate}>
             <Plus className="size-3.5" />
             新建{activeTab === 'general' ? '' : NETWORK_TABS[activeTab as NetworkKind].title}
           </Button>
         )}
+        <Button onClick={onSave} size="sm">
+          <Save className="size-3.5" /> 保存
+        </Button>
       </div>
     </div>
   );

--- a/packages/webui/src/components/pages/config-page.tsx
+++ b/packages/webui/src/components/pages/config-page.tsx
@@ -3,13 +3,12 @@
 // Layout: collapsible left sidebar for account selection + tabbed right
 // pane (通用 / 4 network kinds). Each network tab is a list view of
 // summary cards with inline enable/disable; create + edit both go
-// through `NodeEditDialog`. The dirty-modify guard from the original
-// hook is preserved end-to-end — switching accounts or kinds doesn't
-// drop unsaved changes silently.
+// through `NodeEditDialog`. All changes auto-save: network mutations
+// persist immediately; general-settings edits are debounced (500 ms).
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { motion } from 'motion/react';
-import { MousePointerClick, Plus, Save } from 'lucide-react';
+import { MousePointerClick, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Badge } from '@/components/ui/badge';
@@ -50,7 +49,6 @@ export function ConfigPage() {
     confirmSwitch,
     cancelSwitch,
     save,
-    saveStatus,
   } = useOneBotInstanceConfig(qqList, {
     selectedUin,
     onSelectedUinChange: setSelectedUin,
@@ -62,7 +60,6 @@ export function ConfigPage() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(
     () => typeof window !== 'undefined' && window.matchMedia('(max-width: 1024px)').matches,
   );
-  const [confirmSave, setConfirmSave] = useState(false);
   // The edit dialog is modal and blocks every other click in the page,
   // so `selectedUin` cannot change while it's open — no defensive close
   // wiring needed beyond the dialog's own open/close.
@@ -82,13 +79,22 @@ export function ConfigPage() {
     return map;
   }, [connections, selectedUin]);
 
-  // A discrete node mutation (create / edit / delete / enable-toggle) is
-  // persisted the moment it happens — clicking 保存 inside the editor dialog
-  // (or flipping the enable switch) IS the save. This removes the old
-  // two-step trap where editing a token in the dialog only marked the config
-  // "dirty" until you also pressed the top-right 保存, which silently cost
-  // many users their token edits. The general-settings tab keeps its explicit
-  // top-right save (it's a continuously-edited free-form surface).
+  // Auto-save general settings with debounce. Network mutations
+  // (create / edit / delete / enable-toggle) persist immediately in commitKind.
+  const debounceRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (debounceRef.current != null) window.clearTimeout(debounceRef.current);
+    if (dirty) {
+      debounceRef.current = window.setTimeout(() => {
+        void save();
+        debounceRef.current = null;
+      }, 500);
+    }
+    return () => {
+      if (debounceRef.current != null) window.clearTimeout(debounceRef.current);
+    };
+  }, [dirty, config, save]);
+
   function commitKind<K extends NetworkKind>(kind: K, nextList: OneBotNetworks[K]): void {
     if (!config) return;
     const next = { ...config, networks: { ...config.networks, [kind]: nextList } };
@@ -159,9 +165,6 @@ export function ConfigPage() {
           <div className="flex flex-col gap-4">
             <HeaderBar
               selectedUin={selectedUin}
-              dirty={dirty}
-              saveStatus={saveStatus}
-              onSave={() => setConfirmSave(true)}
               activeTab={activeTab}
               onCreate={
                 activeTab !== 'general' ? () => openCreate(activeTab as NetworkKind) : undefined
@@ -208,15 +211,6 @@ export function ConfigPage() {
       )}
 
       <ConfirmDialog
-        open={confirmSave}
-        onOpenChange={setConfirmSave}
-        title="保存配置变更？"
-        description={`即将把当前修改保存到 UIN ${selectedUin ?? ''} 的配置文件，并尝试热重载该会话。`}
-        confirmText="保存"
-        onConfirm={save}
-      />
-
-      <ConfirmDialog
         open={pendingSwitchUin != null}
         onOpenChange={(open) => !open && cancelSwitch()}
         title="放弃未保存的修改？"
@@ -243,14 +237,11 @@ export function ConfigPage() {
 
 interface HeaderBarProps {
   selectedUin: string;
-  dirty: boolean;
-  saveStatus: string;
-  onSave: () => void;
   activeTab: TabKey;
   onCreate?: () => void;
 }
 
-function HeaderBar({ selectedUin, dirty, saveStatus, onSave, activeTab, onCreate }: HeaderBarProps) {
+function HeaderBar({ selectedUin, activeTab, onCreate }: HeaderBarProps) {
   return (
     <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="min-w-0">
@@ -260,34 +251,12 @@ function HeaderBar({ selectedUin, dirty, saveStatus, onSave, activeTab, onCreate
         </code>
       </div>
       <div className="flex flex-wrap items-center gap-2">
-        {saveStatus && (
-          <span
-            className={cn(
-              'rounded-full border px-2.5 py-1 text-[11px] font-medium',
-              saveStatus === '保存成功' && 'border-success/30 bg-success/10 text-success',
-              saveStatus === '保存中...' && 'border-border bg-muted text-muted-foreground',
-              saveStatus !== '保存成功' &&
-                saveStatus !== '保存中...' &&
-                'border-destructive/30 bg-destructive/10 text-destructive',
-            )}
-          >
-            {saveStatus}
-          </span>
-        )}
-        {dirty && !saveStatus && (
-          <span className="rounded-full border border-warning/30 bg-warning/10 px-2.5 py-1 text-[11px] font-medium text-warning">
-            未保存
-          </span>
-        )}
         {onCreate && (
           <Button size="sm" variant="outline" onClick={onCreate}>
             <Plus className="size-3.5" />
             新建{activeTab === 'general' ? '' : NETWORK_TABS[activeTab as NetworkKind].title}
           </Button>
         )}
-        <Button onClick={onSave} size="sm" disabled={!dirty}>
-          <Save className="size-3.5" /> 保存
-        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## 解决什么问题

节点配置页面的顶部"保存"按钮实际上已无作用喵：
- 网络节点（HTTP/WS 服务器/客户端）的增删改、启停操作本身已是即时保存，保存按钮始终处于点不动的状态喵
- 仅通用设置（音乐签名 URL、`#sl` 状态命令）仍依赖手动保存，容易导致用户以为改了但没保存喵

## 实现思路

- 通用设置编辑改为 debounce 500ms 自动保存，与网络节点的即时保存保持一致喵
- 移除保存按钮、保存确认弹窗、`dirty`/`saveStatus` 状态展示喵
- 保留切换账号时的"放弃未保存修改"确认弹窗喵（debounce 未触发时仍可能有未保存状态）

## 测试方式

- `pnpm typecheck和pnpm test` 通过喵
- 手动验证：编辑通用设置字段，确认 500ms 后自动保存；网络节点增删改仍即时生效喵