### PR TITLE
feat(notifications): default body template → Server酱 JSON (title/desp)

### DIFF
--- a/packages/core/src/notifications/config.ts
+++ b/packages/core/src/notifications/config.ts
@@ -48,9 +48,13 @@ export interface NotificationsConfig {
   channels: NotificationChannel[];
 }
 
-/** A neutral plaintext starting point; the WebUI ships per-vendor presets
- *  (钉钉/Discord/…) as frontend constants the operator can drop in. */
-export const DEFAULT_BODY_TEMPLATE = '{nickname}({uin}) {event} @ {time}';
+/** Default body template — Server酱-style JSON ({title}/{desp}). The WebUI
+ *  ships additional per-vendor presets (钉钉/Discord/…) as frontend constants
+ *  the operator can drop in. */
+export const DEFAULT_BODY_TEMPLATE = `{
+  "title": "账号状态通知：{event}",
+  "desp": "您的账号状态发生了改变。\\n\\n**昵称**：{nickname}\\n**QQ号**：{uin}\\n**当前状态**：{event}\\n**时间**：{time}"
+}`;
 
 export function defaultNotificationsConfig(): NotificationsConfig {
   return {

--- a/packages/webui/src/components/settings/notifications-panel.tsx
+++ b/packages/webui/src/components/settings/notifications-panel.tsx
@@ -16,7 +16,10 @@ import { cn } from '@/lib/utils';
 import type { NotificationChannel, NotificationsConfig } from '@/types';
 import { NotificationChannelDialog } from './notification-channel-dialog';
 
-const DEFAULT_TEMPLATE = '{nickname}({uin}) {event} @ {time}';
+const DEFAULT_TEMPLATE = `{
+  "title": "账号状态通知：{event}",
+  "desp": "您的账号状态发生了改变。\\n\\n**昵称**：{nickname}\\n**QQ号**：{uin}\\n**当前状态**：{event}\\n**时间**：{time}"
+}`;
 
 /** A fresh channel with a non-colliding default id. */
 function blankChannel(existing: NotificationChannel[]): NotificationChannel {


### PR DESCRIPTION
## Summary
- 将新建通知渠道的默认 Body 模板从纯文本 {nickname}({uin}) {event} @ {time} 改为 Server酱 风格的 JSON（	itle/desp），与现有 Content-Type: application/json 的 POST 直接对口
- 同步修改前端 DEFAULT_TEMPLATE（
otifications-panel.tsx）与后端 DEFAULT_BODY_TEMPLATE（config.ts，normalize 兜底），保持两端一致
- 变量占位符 {nickname}/{uin}/{event}/{time} 不变，enderTemplate 正则只匹配 {单词}，JSON 结构大括号不受影响

## Testing
- 
otifications-config.test.ts + 
otifications-manager.test.ts：35 个通知相关测试全部通过
- webui typecheck 通过