### PR TITLE
feat(notifications): default body template to Server酱 JSON (title/desp)

### DIFF
--- a/packages/core/src/notifications/config.ts
+++ b/packages/core/src/notifications/config.ts
@@ -48,9 +48,13 @@ export interface NotificationsConfig {
   channels: NotificationChannel[];
 }
 
-/** A neutral plaintext starting point; the WebUI ships per-vendor presets
- *  (钉钉/Discord/…) as frontend constants the operator can drop in. */
-export const DEFAULT_BODY_TEMPLATE = '{nickname}({uin}) {event} @ {time}';
+/** Default body template — Server酱-style JSON ({title}/{desp}). The WebUI
+ *  ships additional per-vendor presets (钉钉/Discord/…) as frontend constants
+ *  the operator can drop in. */
+export const DEFAULT_BODY_TEMPLATE = `{
+  "title": "账号状态通知：{event}",
+  "desp": "您的账号状态发生了改变。\\n\\n**昵称**：{nickname}\\n**QQ号**：{uin}\\n**当前状态**：{event}\\n**时间**：{time}"
+}`;
 
 export function defaultNotificationsConfig(): NotificationsConfig {
   return {
@@ -67,12 +71,25 @@ export function defaultNotificationsConfig(): NotificationsConfig {
  * A key present in `vars` is replaced by its value; an unknown `{key}` is left
  * untouched (原样) so a typo'd placeholder is visible rather than silently
  * blanked. Pure + total (a non-string template yields '').
+ *
+ * **JSON safety**: When the template is valid JSON (parseable by JSON.parse),
+ * values are escaped to prevent breaking the JSON structure — backslashes
+ * become `\\` and double-quotes become `\"`.
  */
 export function renderTemplate(template: string, vars: Record<string, string>): string {
   if (typeof template !== 'string') return '';
-  return template.replace(/\{(\w+)\}/g, (match, key: string) =>
-    Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] : match,
-  );
+  let isJson = false;
+  try {
+    JSON.parse(template);
+    isJson = true;
+  } catch {
+    // not JSON — plain text mode
+  }
+  return template.replace(/\{(\w+)\}/g, (match, key: string) => {
+    if (!Object.prototype.hasOwnProperty.call(vars, key)) return match;
+    const val = vars[key];
+    return isJson ? val.replace(/\\/g, '\\\\').replace(/"/g, '\\"') : val;
+  });
 }
 
 // ─── Normalization helpers (replicated from ui-config conventions) ──────────

--- a/packages/core/tests/notifications-config.test.ts
+++ b/packages/core/tests/notifications-config.test.ts
@@ -47,6 +47,15 @@ describe('renderTemplate — mechanical {key} substitution', () => {
     // to a recursive/loop replace would break this while passing every other test.
     expect(renderTemplate('{a}', { a: '{b}', b: 'NESTED' })).toBe('{b}');
   });
+
+  it('escapes backslashes and quotes when template is JSON-like', () => {
+    const tmpl = '{"text": "{val}"}';
+    expect(renderTemplate(tmpl, { val: 'a"b\\c' })).toBe('{"text": "a\\"b\\\\c"}');
+  });
+
+  it('does NOT escape when template is plain text', () => {
+    expect(renderTemplate('{val}', { val: 'a"b\\c' })).toBe('a"b\\c');
+  });
 });
 
 describe('normalizeNotificationsConfig — total normalize', () => {

--- a/packages/webui/src/components/settings/notifications-panel.tsx
+++ b/packages/webui/src/components/settings/notifications-panel.tsx
@@ -16,7 +16,10 @@ import { cn } from '@/lib/utils';
 import type { NotificationChannel, NotificationsConfig } from '@/types';
 import { NotificationChannelDialog } from './notification-channel-dialog';
 
-const DEFAULT_TEMPLATE = '{nickname}({uin}) {event} @ {time}';
+const DEFAULT_TEMPLATE = `{
+  "title": "账号状态通知：{event}",
+  "desp": "您的账号状态发生了改变。\\n\\n**昵称**：{nickname}\\n**QQ号**：{uin}\\n**当前状态**：{event}\\n**时间**：{time}"
+}`;
 
 /** A fresh channel with a non-colliding default id. */
 function blankChannel(existing: NotificationChannel[]): NotificationChannel {


### PR DESCRIPTION
## Summary
- 将新建通知渠道的默认 Body 模板从纯文本 `{nickname}({uin}) {event} @ {time}` 改为 Server酱 风格的 JSON（`title/desp`），与现有 `Content-Type: application/json` 的 POST 直接对口
- 同步修改前端 `DEFAULT_TEMPLATE`（`notifications-panel.tsx`）与后端 `DEFAULT_BODY_TEMPLATE`（`config.ts`，normalize 兜底），保持两端一致
- 变量占位符 `{nickname}/{uin}/{event}/{time}` 不变，`renderTemplate` 正则只匹配 `{单词}`，JSON 结构大括号不受影响
- **新增 JSON 转义逻辑**：当模板是合法 JSON 时，自动对变量值中的 `\` 和 `"` 进行转义，防止昵称含特殊字符导致非法 JSON

## Changes
1. `packages/core/src/notifications/config.ts`:
   - 修改 `DEFAULT_BODY_TEMPLATE` 为 Server酱 JSON 格式
   - 修改 `renderTemplate` 函数，当模板是合法 JSON 时自动转义变量值

2. `packages/webui/src/components/settings/notifications-panel.tsx`:
   - 修改 `DEFAULT_TEMPLATE` 与后端保持一致

3. `packages/core/tests/notifications-config.test.ts`:
   - 新增 JSON 转义测试用例

## Testing
- `notifications-config.test.ts` + `notifications-manager.test.ts` + `notifications-debounce.test.ts`：47 个通知相关测试全部通过
- webui typecheck 通过