### PR TITLE
feat(protocol): modify/move custom face via OIDB 0x902e + 0x902f

### DIFF
--- a/packages/core/src/bridge/apis/profile.ts
+++ b/packages/core/src/bridge/apis/profile.ts
@@ -7,6 +7,9 @@ import type {
 } from '@snowluma/proto-defs/oidb-actions/base';
 import { AddCustomFace } from '@snowluma/protocol/oidb-services/custom-face/add-custom-face';
 import { DeleteCustomFace } from '@snowluma/protocol/oidb-services/custom-face/delete-custom-face';
+import { ModifyCustomFace } from '@snowluma/protocol/oidb-services/custom-face/modify-custom-face';
+import { MoveCustomFace } from '@snowluma/protocol/oidb-services/custom-face/move-custom-face';
+import { OrderCustomFace } from '@snowluma/protocol/oidb-services/custom-face/order-custom-face';
 import { fetchHighwaySession, uploadHighwayHttp } from '@snowluma/protocol/highway';
 import { computeHashes, loadBinarySource } from '@snowluma/protocol/highway/utils';
 import { GetLike, type LikeInfo } from '@snowluma/protocol/oidb-services/profile/get-like';
@@ -163,4 +166,59 @@ export class ProfileApi {
     const { bytes } = await loadBinarySource(imageSource, 'custom-face');
     return AddCustomFace.invoke(this.ctx, { uin: this.ctx.identity.uin, imageBytes: bytes });
   }
+
+  /**
+   * 修改收藏表情（custom face）备注。emoji_id 来自 fetchCustomFace 返回的
+   * URL 路径段；md5 从 emoji_id 中段解析，无需调用方单独提供。desc 为空串
+   * 则清空备注。
+   */
+  modifyCustomFace(emojiId: string, desc: string): Promise<void> {
+    return ModifyCustomFace.invoke(this.ctx, {
+      emojiId,
+      md5: md5FromEmojiId(emojiId),
+      desc,
+    });
+  }
+
+  /**
+   * 收藏表情（custom face）移到最前。QQ 客户端只有"移动到最前"，协议层
+   * （0x902f 的 f3=1）也只支持最前，不支持移到其他位置。两步流程：先 0x902f
+   * 移动指令，再 0x902e opType=2 上传新顺序（fetch 当前列表把目标挪到第一）。
+   * 两步都发才生效。
+   */
+  async moveCustomFaceToFront(emojiId: string): Promise<void> {
+    // 1. fetch 当前完整列表（fetch 顺序即可，不需要 DB 显示顺序）
+    const urls = await this.fetchCustomFace(1000);
+    const ids = urls.map((url) => {
+      const m = /\/qq_expression\/[^/]+\/([^/]+)\//.exec(url);
+      return m ? m[1] : '';
+    }).filter(Boolean);
+    const idx = ids.indexOf(emojiId);
+    if (idx < 0) throw new Error(`emoji_id not in list: ${emojiId}`);
+    // 新顺序：目标挪到第一，其余按原顺序
+    const reordered = ids.slice();
+    reordered.splice(idx, 1);
+    reordered.unshift(emojiId);
+    // 2. 0x902f 移动指令（f3=1 = 移到最前）
+    await OrderCustomFace.invoke(this.ctx, { emojiId, position: 1 });
+    // 3. 0x902e opType=2 上传新顺序
+    await MoveCustomFace.invoke(this.ctx, {
+      emojis: reordered.map((id) => ({ emojiId: id, md5: md5FromEmojiId(id) })),
+    });
+  }
+}
+
+/**
+ * 从 emoji_id `<uin>_0_0_0_<MD5>_0_0` 提取中段 32 位大写 hex MD5。
+ * 格式固定（fetch/delete/move 共用），取第 5 段。解析失败抛错——比静默
+ * 传空串让服务端拒绝更早定位问题。
+ */
+function md5FromEmojiId(emojiId: string): string {
+  const parts = emojiId.split('_');
+  // 期望形如 `<uin>_0_0_0_<md5>_0_0`，共 7 段，md5 在 index 4。
+  const md5 = parts[4];
+  if (!md5 || md5.length !== 32 || !/^[0-9a-fA-F]{32}$/.test(md5)) {
+    throw new Error(`invalid emoji_id (cannot extract md5): ${emojiId}`);
+  }
+  return md5.toUpperCase();
 }

--- a/packages/mcp/src/generated/catalog.ts
+++ b/packages/mcp/src/generated/catalog.ts
@@ -96,13 +96,28 @@ export const ACTIONS: CatalogAction[] = [
   {
     "name": "_get_model_show",
     "aliases": [],
-    "summary": "获取机型展示（占位）",
+    "summary": "获取机型展示（兼容 mock）",
     "readOnly": true,
-    "params": [],
+    "params": [
+      {
+        "name": "model",
+        "type": "string",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "default": ""
+      }
+    ],
     "invariants": [],
     "inputSchema": {
       "type": "object",
-      "properties": {},
+      "properties": {
+        "model": {
+          "type": "string",
+          "default": ""
+        }
+      },
       "additionalProperties": true
     },
     "category": "扩展"
@@ -1657,6 +1672,37 @@ export const ACTIONS: CatalogAction[] = [
     "category": "扩展"
   },
   {
+    "name": "get_doubt_friends_add_request",
+    "aliases": [],
+    "summary": "获取可疑好友申请",
+    "readOnly": true,
+    "params": [
+      {
+        "name": "count",
+        "type": "int",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "default": 50
+      }
+    ],
+    "invariants": [],
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 50
+        }
+      },
+      "additionalProperties": true
+    },
+    "category": "扩展"
+  },
+  {
     "name": "get_emoji_likes",
     "aliases": [],
     "summary": "获取表情回应用户",
@@ -2633,6 +2679,40 @@ export const ACTIONS: CatalogAction[] = [
     "category": "扩展"
   },
   {
+    "name": "get_group_signed_list",
+    "aliases": [],
+    "summary": "获取群今日打卡列表",
+    "readOnly": true,
+    "params": [
+      {
+        "name": "group_id",
+        "type": "uint",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "desc": "群号"
+      }
+    ],
+    "invariants": [],
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "group_id": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "群号"
+        }
+      },
+      "required": [
+        "group_id"
+      ],
+      "additionalProperties": true
+    },
+    "category": "扩展"
+  },
+  {
     "name": "get_group_system_msg",
     "aliases": [],
     "summary": "获取群系统消息",
@@ -2754,7 +2834,7 @@ export const ACTIONS: CatalogAction[] = [
   {
     "name": "get_online_clients",
     "aliases": [],
-    "summary": "获取在线客户端（占位）",
+    "summary": "获取在线客户端（占位，OneBot v11 形状）",
     "readOnly": true,
     "params": [],
     "invariants": [],
@@ -2877,6 +2957,70 @@ export const ACTIONS: CatalogAction[] = [
           "minimum": 0,
           "default": 0
         },
+        "count": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 10
+        }
+      },
+      "additionalProperties": true
+    },
+    "category": "扩展"
+  },
+  {
+    "name": "get_qun_album_list",
+    "aliases": [],
+    "readOnly": true,
+    "params": [
+      {
+        "name": "group_id",
+        "type": "uint",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "desc": "群号"
+      }
+    ],
+    "invariants": [],
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "group_id": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "群号"
+        }
+      },
+      "required": [
+        "group_id"
+      ],
+      "additionalProperties": true
+    },
+    "category": "群相册"
+  },
+  {
+    "name": "get_recent_contact",
+    "aliases": [],
+    "summary": "获取最近会话（占位）",
+    "readOnly": true,
+    "params": [
+      {
+        "name": "count",
+        "type": "int",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "default": 10
+      }
+    ],
+    "invariants": [],
+    "inputSchema": {
+      "type": "object",
+      "properties": {
         "count": {
           "type": "integer",
           "minimum": 0,
@@ -3231,6 +3375,83 @@ export const ACTIONS: CatalogAction[] = [
     "category": "扩展"
   },
   {
+    "name": "modify_custom_face",
+    "aliases": [],
+    "summary": "修改收藏表情备注",
+    "readOnly": false,
+    "params": [
+      {
+        "name": "emoji_id",
+        "type": "string",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      {
+        "name": "desc",
+        "type": "string",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "default": ""
+      }
+    ],
+    "invariants": [],
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "emoji_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "desc": {
+          "type": "string",
+          "default": ""
+        }
+      },
+      "required": [
+        "emoji_id"
+      ],
+      "additionalProperties": true
+    },
+    "category": "扩展"
+  },
+  {
+    "name": "move_custom_face_to_front",
+    "aliases": [],
+    "summary": "收藏表情移到最前",
+    "readOnly": false,
+    "params": [
+      {
+        "name": "emoji_id",
+        "type": "string",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    ],
+    "invariants": [],
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "emoji_id": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "emoji_id"
+      ],
+      "additionalProperties": true
+    },
+    "category": "扩展"
+  },
+  {
     "name": "move_group_file",
     "aliases": [],
     "summary": "移动群文件",
@@ -3568,6 +3789,61 @@ export const ACTIONS: CatalogAction[] = [
     "category": "扩展"
   },
   {
+    "name": "send_ark_share",
+    "aliases": [],
+    "summary": "分享用户/群 Ark 卡片（NapCat 标准名）",
+    "readOnly": true,
+    "params": [
+      {
+        "name": "user_id",
+        "type": "uint",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "group_id",
+        "type": "uint",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "phone_number",
+        "type": "string",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "default": ""
+      }
+    ],
+    "invariants": [],
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "user_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "group_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "phone_number": {
+          "type": "string",
+          "default": ""
+        }
+      },
+      "additionalProperties": true
+    },
+    "category": "扩展"
+  },
+  {
     "name": "send_forward_msg",
     "aliases": [],
     "summary": "发送合并转发（按 message_type/群号自动路由）",
@@ -3678,6 +3954,38 @@ export const ACTIONS: CatalogAction[] = [
         "group_id",
         "character",
         "text"
+      ],
+      "additionalProperties": true
+    },
+    "category": "扩展"
+  },
+  {
+    "name": "send_group_ark_share",
+    "aliases": [],
+    "summary": "分享群 Ark 卡片（NapCat 标准名）",
+    "readOnly": true,
+    "params": [
+      {
+        "name": "group_id",
+        "type": "uint",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    ],
+    "invariants": [],
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "group_id": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "required": [
+        "group_id"
       ],
       "additionalProperties": true
     },
@@ -4201,6 +4509,51 @@ export const ACTIONS: CatalogAction[] = [
       },
       "required": [
         "face_id"
+      ],
+      "additionalProperties": true
+    },
+    "category": "扩展"
+  },
+  {
+    "name": "set_doubt_friends_add_request",
+    "aliases": [],
+    "summary": "处理可疑好友申请",
+    "readOnly": false,
+    "params": [
+      {
+        "name": "flag",
+        "type": "string",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      {
+        "name": "approve",
+        "type": "bool",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "default": true
+      }
+    ],
+    "invariants": [],
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "flag": {
+          "type": "string",
+          "minLength": 1
+        },
+        "approve": {
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "required": [
+        "flag"
       ],
       "additionalProperties": true
     },
@@ -5125,6 +5478,66 @@ export const ACTIONS: CatalogAction[] = [
     "category": "扩展"
   },
   {
+    "name": "set_group_robot_add_option",
+    "aliases": [],
+    "summary": "设置群机器人加群选项",
+    "readOnly": false,
+    "params": [
+      {
+        "name": "group_id",
+        "type": "uint",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "desc": "群号"
+      },
+      {
+        "name": "robot_member_switch",
+        "type": "int",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      {
+        "name": "robot_member_examine",
+        "type": "int",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    ],
+    "invariants": [],
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "group_id": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "群号"
+        },
+        "robot_member_switch": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "robot_member_examine": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "group_id"
+      ],
+      "additionalProperties": true
+    },
+    "category": "扩展"
+  },
+  {
     "name": "set_group_search",
     "aliases": [],
     "summary": "允许群被搜索",
@@ -5645,6 +6058,93 @@ export const ACTIONS: CatalogAction[] = [
     "category": "扩展"
   },
   {
+    "name": "share_group_ex",
+    "aliases": [],
+    "summary": "分享群 Ark 卡片",
+    "readOnly": true,
+    "params": [
+      {
+        "name": "group_id",
+        "type": "uint",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    ],
+    "invariants": [],
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "group_id": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "required": [
+        "group_id"
+      ],
+      "additionalProperties": true
+    },
+    "category": "扩展"
+  },
+  {
+    "name": "share_peer",
+    "aliases": [],
+    "summary": "分享用户/群 Ark 卡片",
+    "readOnly": true,
+    "params": [
+      {
+        "name": "user_id",
+        "type": "uint",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "group_id",
+        "type": "uint",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "phone_number",
+        "type": "string",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "default": ""
+      }
+    ],
+    "invariants": [],
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "user_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "group_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "phone_number": {
+          "type": "string",
+          "default": ""
+        }
+      },
+      "additionalProperties": true
+    },
+    "category": "扩展"
+  },
+  {
     "name": "trans_group_file",
     "aliases": [],
     "summary": "转存群文件（未实现）",
@@ -6066,10 +6566,10 @@ export const CATEGORIES: CatalogCategory[] = [
   },
   {
     "category": "扩展",
-    "count": 87
+    "count": 98
   },
   {
     "category": "群相册",
-    "count": 7
+    "count": 8
   }
 ];

--- a/packages/onebot/src/actions/extended.ts
+++ b/packages/onebot/src/actions/extended.ts
@@ -243,6 +243,43 @@ export const actions = [
     },
   }),
 
+  // 修改收藏表情备注（OIDB 0x902e_1 opType=3）
+  defineAction({
+    name: 'modify_custom_face',
+    summary: '修改收藏表情备注',
+    params: {
+      emoji_id: f.string({ allowEmpty: false }),
+      desc: f.string().default(''),
+    },
+    run: async (p, ctx) => {
+      try {
+        await ctx.bridge.apis.profile.modifyCustomFace(p.emoji_id, p.desc);
+        return okResponse();
+      } catch (e) {
+        return failedResponse(RETCODE.ACTION_FAILED, String(e));
+      }
+    },
+  }),
+
+  // 收藏表情排序（OIDB 0x902f + 0x902e opType=2 两步）。把 emoji_id 移到
+  // position 位置（1=最前）。move_to_front 是 position=1 的语法糖。
+  // 收藏表情移到最前（OIDB 0x902f + 0x902e opType=2 两步）。QQ 客户端只有
+  // "移动到最前"操作，协议层也只支持最前——0x902f 的 f3=1 是固定标志，不是
+  // 位置变量，移到其他位置服务端不生效。所以这个 action 只做"移到最前"。
+  defineAction({
+    name: 'move_custom_face_to_front',
+    summary: '收藏表情移到最前',
+    params: { emoji_id: f.string({ allowEmpty: false }) },
+    run: async (p, ctx) => {
+      try {
+        await ctx.bridge.apis.profile.moveCustomFaceToFront(p.emoji_id);
+        return okResponse();
+      } catch (e) {
+        return failedResponse(RETCODE.ACTION_FAILED, String(e));
+      }
+    },
+  }),
+
   // 消息历史
   groupAction({
     name: 'get_group_msg_history',

--- a/packages/proto-defs/src/oidb-actions/base.ts
+++ b/packages/proto-defs/src/oidb-actions/base.ts
@@ -564,6 +564,83 @@ export interface FaceroamOpBody {
   emojiId?: pb<1, string>;
 }
 
+// OIDB 0x902e_1 opType=3 — 修改收藏表情（custom face）备注。
+// modify 和 move 走两个不同 cmd：modify=0x902e（opType=3），move=0x902f。
+// 之前以为 move 也走 0x902e opType=2，实测不生效——0x902e opType=2 是 move 后
+// 服务端触发的列表同步包，不是 move 本身。真正 move 是 0x902f（见下）。
+//
+// modify 业务体（OIDB 信封 f4 内）:
+//   { f1:1, f2:osVersion, f3:3, f5:{ f1:{emojiId,md5}, f2:desc }, f12:1 }
+// f5.entry.emoji 是 {emojiId, md5}，desc 是新备注。f12=1 是修改标志。
+// 字段编号严格对齐 QQ 9.9.26-44343 抓包。
+export interface CustomFaceOpEmojiEntry {
+  emojiId?: pb<1, string>;
+  md5?:     pb<2, string>;
+}
+export interface CustomFaceModifyEntry {
+  emoji?: pb<1, CustomFaceOpEmojiEntry>;
+  desc?:  pb<2, string>;
+}
+export interface CustomFaceModifyBody {
+  field1?:    pb<1, uint_32>;
+  osVersion?: pb<2, string>;
+  opType?:    pb<3, uint_32>;
+  entry?:     pb<5, CustomFaceModifyEntry>;
+  field12?:   pb<12, uint_32>;
+}
+// 0x902e modify 响应：f1=retcode, f2=errmsg, f3=opType, f4 repeated 受影响条目
+// {f1:{emojiId,md5}, f3:desc}（含改后 desc）。
+export interface CustomFaceModifyRespEntry {
+  emoji?: pb<1, CustomFaceOpEmojiEntry>;
+  desc?:  pb<3, string>;
+}
+export interface CustomFaceModifyResp {
+  retCode?: pb<1, uint_32>;
+  errMsg?:  pb<2, string>;
+  opType?:  pb<3, uint_32>;
+  entries?: pb_repeated<4, CustomFaceModifyRespEntry>;
+}
+
+// OIDB 0x902f_1 — 收藏表情（custom face）移动指令（move 第1步）。
+// "移动到最前"的第一步：发 0x902f 指明目标 emoji + 目标位置，服务端据此
+// 调整顺序。f3=1 = 移到最前。envelope 带 f12=1（uinForm）。
+// 业务体（OIDB 信封 f4 内）:
+//   { f1:{f1:1024, f2:osVersion, f3:buildVersion}, f2:emojiId, f3:位置 }
+// f1 是客户端环境（1024 是 client type 标志），f2 要移动的 emoji_id，
+// f3 目标位置（1=最前）。
+export interface CustomFaceOrderEnv {
+  field1?:       pb<1, uint_32>;
+  osVersion?:    pb<2, string>;
+  buildVersion?: pb<3, string>;
+}
+export interface CustomFaceOrderBody {
+  env?:      pb<1, CustomFaceOrderEnv>;
+  emojiId?:  pb<2, string>;
+  /** 目标位置（从 1 开始，1=最前）。 */
+  position?: pb<3, uint_32>;
+}
+// 0x902f 响应复用 CustomFaceModifyResp（f1=retcode, f2=errmsg）。
+
+// OIDB 0x902e_1 opType=2 — 收藏表情排序上传（move 第2步）。
+// "移动到最前"的第二步：把新顺序的完整 emoji 列表上传，第一个就是移到最前的。
+// 必须先发 0x902f（移动指令），再发本包（新顺序）——单发本包不生效。
+// modify（opType=3）和 move（opType=2）共用 cmd 0x902e，区分在业务体 f3。
+// envelope 带 f12=1（reserved=1，uinForm）。业务体（OIDB 信封 f4 内）:
+//   { f1:1, f2:osVersion, f3:2, f4:[repeated {emojiId, md5}] }
+// f4 是完整排序后的列表，用 fetch 顺序把目标挪到第一即可（不需要 DB 显示顺序）。
+export interface CustomFaceMoveEntry {
+  emojiId?: pb<1, string>;
+  md5?:     pb<2, string>;
+}
+export interface CustomFaceMoveBody {
+  field1?:    pb<1, uint_32>;
+  osVersion?: pb<2, string>;
+  opType?:    pb<3, uint_32>;
+  emojis?:    pb_repeated<4, CustomFaceMoveEntry>;
+}
+// 0x902e move 响应复用 CustomFaceModifyResp（f1=retcode, f2=errmsg）。move 成功
+// 返回 "操作成功"，f3 是 opType 回显，只看 retCode。
+
 // ImgStore.BDHExpressionRoam — 收藏表情上传申请（add 第1步）
 // 请求 body 结构来自 9.9.26-44343 frida 抓包。
 export interface BDHExpressionRoamInner {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -60,6 +60,18 @@
       "types": "./src/oidb-services/custom-face/add-custom-face.ts",
       "default": "./src/oidb-services/custom-face/add-custom-face.ts"
     },
+    "./oidb-services/custom-face/modify-custom-face": {
+      "types": "./src/oidb-services/custom-face/modify-custom-face.ts",
+      "default": "./src/oidb-services/custom-face/modify-custom-face.ts"
+    },
+    "./oidb-services/custom-face/move-custom-face": {
+      "types": "./src/oidb-services/custom-face/move-custom-face.ts",
+      "default": "./src/oidb-services/custom-face/move-custom-face.ts"
+    },
+    "./oidb-services/custom-face/order-custom-face": {
+      "types": "./src/oidb-services/custom-face/order-custom-face.ts",
+      "default": "./src/oidb-services/custom-face/order-custom-face.ts"
+    },
     "./oidb-services/interaction/send-poke": {
       "types": "./src/oidb-services/interaction/send-poke.ts",
       "default": "./src/oidb-services/interaction/send-poke.ts"

--- a/packages/protocol/src/oidb-services/custom-face/modify-custom-face.ts
+++ b/packages/protocol/src/oidb-services/custom-face/modify-custom-face.ts
@@ -1,0 +1,64 @@
+// OIDB 0x902e_1 opType=3 — 修改收藏表情（custom face）备注。
+//
+// modify 和 move 共用 cmd 0x902e，靠业务体 f3 的 opType 区分（modify=3）。
+// 走 OIDB 通道（OidbSvcTrpcTcp.0x902e_1），不是 Faceroam.OpReq——fetch/delete
+// 走 Faceroam，modify/move 走 OIDB，是抓包确认的两条不同通道。
+//
+// 业务体（OIDB 信封 f4 内）:
+//   { f1:1, f2:osVersion, f3:3, f5:{ f1:{emojiId,md5}, f2:desc }, f12:1 }
+// f5.entry.emoji 是 {emojiId, md5}，desc 是新备注。f12=1 是修改标志。
+// emojiId 格式 `<uin>_0_0_0_<MD5>_0_0`，md5 是 32 位大写 hex，均来自 fetch。
+//
+// 响应 f4 repeated 返回受影响条目 {f1:{emojiId,md5}, f3:desc}（含改后 desc），
+// 成功只看 retCode=0。字段编号严格对齐 9.9.26-44343 frida 抓包。
+
+import { protobuf_decode, protobuf_encode } from '@snowluma/proton';
+import type {
+  CustomFaceModifyBody,
+  CustomFaceModifyResp,
+} from '@snowluma/proto-defs/oidb-actions/base';
+import type { OidbBase } from '@snowluma/proto-defs/oidb';
+import { invokeOidb, type OidbSender } from '../../oidb-service';
+import { CLIENT_VERSION } from './shared';
+
+export namespace ModifyCustomFace {
+  export const command = 0x902e;
+  export const subCommand = 1;
+
+  export interface Params {
+    /** 形如 `<UIN>_0_0_0_<MD5>_0_0`，来自 fetch 响应。 */
+    emojiId: string;
+    /** 32 位大写 hex MD5，emoji_id 中段。 */
+    md5: string;
+    /** 新备注（可为空字符串清空备注）。 */
+    desc: string;
+  }
+
+  export type Deps = OidbSender;
+
+  export const serialize = (_ctx: Deps, p: Params): CustomFaceModifyBody => ({
+    field1: 1,
+    osVersion: CLIENT_VERSION,
+    opType: 3,
+    entry: {
+      emoji: { emojiId: p.emojiId, md5: p.md5 },
+      desc: p.desc,
+    },
+    field12: 1,
+  });
+
+  export const deserialize = (_ctx: Deps, body: CustomFaceModifyResp): void => {
+    if (body.retCode && body.retCode !== 0) {
+      throw new Error(`modify custom face error: ${body.errMsg || body.retCode}`);
+    }
+  };
+
+  export const encode = (env: OidbBase<CustomFaceModifyBody>): Uint8Array =>
+    protobuf_encode<OidbBase<CustomFaceModifyBody>>(env);
+
+  export const decode = (bytes: Uint8Array): OidbBase<CustomFaceModifyResp> =>
+    protobuf_decode<OidbBase<CustomFaceModifyResp>>(bytes);
+
+  export const invoke = (deps: Deps, params: Params): Promise<void> =>
+    invokeOidb(deps, ModifyCustomFace, params);
+}

--- a/packages/protocol/src/oidb-services/custom-face/move-custom-face.ts
+++ b/packages/protocol/src/oidb-services/custom-face/move-custom-face.ts
@@ -1,0 +1,63 @@
+// OIDB 0x902e_1 opType=2 — 收藏表情（custom face）排序上传（move 第2步）。
+//
+// "移动到最前"两步流程的第2步：把新顺序的完整 emoji 列表上传，第一个就是
+// 移到最前的。第1步是 OrderCustomFace（0x902f 移动指令）。必须先发 0x902f
+// 再发本包——单发本包不生效（服务端无移动指令上下文）。
+//
+// modify（opType=3）和 move（opType=2）共用 cmd 0x902e，区分在业务体 f3。
+// envelope 带 f12=1（reserved=1，uinForm）。业务体（OIDB 信封 f4 内）:
+//   { f1:1, f2:osVersion, f3:2, f4:[repeated {emojiId, md5}] }
+// f4 是完整排序后的列表，用 fetch 顺序把目标挪到第一即可（不需要 DB 显示顺序）。
+// 字段编号严格对齐 QQ 9.9.26-44343 抓包。
+
+import { protobuf_decode, protobuf_encode } from '@snowluma/proton';
+import type {
+  CustomFaceModifyResp,
+  CustomFaceMoveBody,
+} from '@snowluma/proto-defs/oidb-actions/base';
+import type { OidbBase } from '@snowluma/proto-defs/oidb';
+import { invokeOidb, type OidbSender } from '../../oidb-service';
+import { CLIENT_VERSION } from './shared';
+
+export namespace MoveCustomFace {
+  export const command = 0x902e;
+  export const subCommand = 1;
+  /** envelope reserved=1（UIN-form），抓包见信封 f12=1。不发则服务端不改顺序。 */
+  export const uinForm = true;
+
+  export interface EmojiItem {
+    /** 形如 `<UIN>_0_0_0_<MD5>_0_0`，来自 fetch 响应。 */
+    emojiId: string;
+    /** 32 位大写 hex MD5，emoji_id 中段。 */
+    md5: string;
+  }
+
+  export interface Params {
+    /** 完整且有序的 emoji 列表，整表上传。 */
+    emojis: EmojiItem[];
+  }
+
+  export type Deps = OidbSender;
+
+  export const serialize = (_ctx: Deps, p: Params): CustomFaceMoveBody => ({
+    field1: 1,
+    osVersion: CLIENT_VERSION,
+    opType: 2,
+    emojis: p.emojis.map((e) => ({ emojiId: e.emojiId, md5: e.md5 })),
+  });
+
+  export const deserialize = (_ctx: Deps, body: CustomFaceModifyResp): void => {
+    if (body.retCode && body.retCode !== 0) {
+      throw new Error(`move custom face error: ${body.errMsg || body.retCode}`);
+    }
+  };
+
+  export const encode = (env: OidbBase<CustomFaceMoveBody>): Uint8Array =>
+    protobuf_encode<OidbBase<CustomFaceMoveBody>>(env);
+
+  export const decode = (bytes: Uint8Array): OidbBase<CustomFaceModifyResp> =>
+    protobuf_decode<OidbBase<CustomFaceModifyResp>>(bytes);
+
+  export const invoke = (deps: Deps, params: Params): Promise<void> =>
+    invokeOidb(deps, MoveCustomFace, params);
+}

--- a/packages/protocol/src/oidb-services/custom-face/order-custom-face.ts
+++ b/packages/protocol/src/oidb-services/custom-face/order-custom-face.ts
@@ -1,0 +1,59 @@
+// OIDB 0x902f_1 — 收藏表情（custom face）移动指令（move 第1步）。
+//
+// "移动到最前"两步流程的第1步：发 0x902f 指明目标 emoji + 目标位置。
+// 第2步是 MoveCustomFace（0x902e opType=2 上传新顺序列表）。单发本包不生效，
+// 必须配合第2步。envelope 带 f12=1（uinForm）。
+//
+// 业务体（OIDB 信封 f4 内）:
+//   { f1:{f1:1024, f2:osVersion, f3:buildVersion}, f2:emojiId, f3:position }
+// f1 是客户端环境（1024 是 client type 标志），f2 要移动的 emoji_id，
+// f3 目标位置（1=最前）。字段编号对齐 9.9.26-44343 frida 抓包。
+
+import { protobuf_decode, protobuf_encode } from '@snowluma/proton';
+import type {
+  CustomFaceModifyResp,
+  CustomFaceOrderBody,
+} from '@snowluma/proto-defs/oidb-actions/base';
+import type { OidbBase } from '@snowluma/proto-defs/oidb';
+import { invokeOidb, type OidbSender } from '../../oidb-service';
+import { CLIENT_VERSION } from './shared';
+
+// build 版本简写：抓包见 f1.f3 = "9.9.26"（去掉 build 号后缀）。
+const BUILD_VERSION_SHORT = '9.9.26';
+
+export namespace OrderCustomFace {
+  export const command = 0x902f;
+  export const subCommand = 1;
+  /** envelope reserved=1（UIN-form），抓包见信封 f12=1。 */
+  export const uinForm = true;
+
+  export interface Params {
+    /** 形如 `<UIN>_0_0_0_<MD5>_0_0`，来自 fetch 响应。 */
+    emojiId: string;
+    /** 目标位置（从 1 开始，1=最前）。 */
+    position: number;
+  }
+
+  export type Deps = OidbSender;
+
+  export const serialize = (_ctx: Deps, p: Params): CustomFaceOrderBody => ({
+    env: { field1: 1024, osVersion: CLIENT_VERSION, buildVersion: BUILD_VERSION_SHORT },
+    emojiId: p.emojiId,
+    position: p.position,
+  });
+
+  export const deserialize = (_ctx: Deps, body: CustomFaceModifyResp): void => {
+    if (body.retCode && body.retCode !== 0) {
+      throw new Error(`order custom face error: ${body.errMsg || body.retCode}`);
+    }
+  };
+
+  export const encode = (env: OidbBase<CustomFaceOrderBody>): Uint8Array =>
+    protobuf_encode<OidbBase<CustomFaceOrderBody>>(env);
+
+  export const decode = (bytes: Uint8Array): OidbBase<CustomFaceModifyResp> =>
+    protobuf_decode<OidbBase<CustomFaceModifyResp>>(bytes);
+
+  export const invoke = (deps: Deps, params: Params): Promise<void> =>
+    invokeOidb(deps, OrderCustomFace, params);
+}

--- a/packages/protocol/src/oidb-services/custom-face/shared.ts
+++ b/packages/protocol/src/oidb-services/custom-face/shared.ts
@@ -11,9 +11,10 @@ import type { FaceroamOpReqInner } from '@snowluma/proto-defs/oidb-actions/base'
 export const FACEROAM_SERVICE = 'Faceroam.OpReq';
 
 // 客户端版本标识。直接硬编码抓包看到的值——QQ 不同小版本之间这部分
-// 理论上会变，但 Faceroam 服务端对版本号并不敏感，先按当前目标版本写死，
+// 理论上会变，但服务端对版本号并不敏感，先按当前目标版本写死，
 // 真出问题再从 identity 里取。
-const CLIENT_VERSION = '10.0.26200';
+/** osVersion 字符串，Faceroam inner 与 0x902e 业务体 f2 共用。 */
+export const CLIENT_VERSION = '10.0.26200';
 const CLIENT_BUILD = '9.9.26-44343';
 
 /**

--- a/packages/protocol/tests/oidb-services/custom-face/modify-custom-face.test.ts
+++ b/packages/protocol/tests/oidb-services/custom-face/modify-custom-face.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { protobuf_decode } from '@snowluma/proton';
+import type { OidbBase } from '@snowluma/proto-defs/oidb';
+import type { CustomFaceModifyBody } from '@snowluma/proto-defs/oidb-actions/base';
+import type { SendPacketResult } from '@snowluma/common/packet-sender';
+
+import { ModifyCustomFace } from '../../../src/oidb-services/custom-face/modify-custom-face';
+
+const SAMPLE_EMOJI_ID = '2550419068_0_0_0_ABCDEF0123456789ABCDEF0123456789_0_0';
+const SAMPLE_MD5 = 'ABCDEF0123456789ABCDEF0123456789';
+
+// Independent byte-oracle: hand-decoded from the proto layout (NOT re-derived
+// from the encoder), so a field-number change goes red. Cross-checked against
+// the 9.9.26-44343 frida capture (cmd 0x902e_1, opType 3):
+//   08 aea002   f1 command = 0x902e
+//   10 01       f2 subCommand = 1
+//   22 73       f4 body (115B):
+//     08 01                f1 = 1
+//     12 0a "10.0.26200"   f2 osVersion
+//     18 03                f3 opType = 3
+//     2a 5f                f5 entry (95B):
+//       0a 59              f1 emoji (89B):
+//         0a 35 <emoji_id> f1
+//         12 20 <md5>      f2
+//       12 02 "hi"         f2 desc
+//     60 01                f12 = 1
+const MODIFY_WIRE_HEX =
+  '08aea002100122730801120a31302e302e323632303018032a5f0a590a35323535303431393036385f305f305f305f41424344454630313233343536373839414243444546303132333435363738395f305f3012204142434445463031323334353637383941424344454630313233343536373839120268696001';
+
+function makeSender() {
+  const r: SendPacketResult = {
+    success: true, gotResponse: true, errorCode: 0, errorMessage: '',
+    responseData: Buffer.alloc(0),
+  };
+  return { sendRawPacket: vi.fn(async () => r) };
+}
+
+describe('ModifyCustomFace namespace', () => {
+  it('declares command 0x902e sub 1', () => {
+    expect(ModifyCustomFace.command).toBe(0x902e);
+    expect(ModifyCustomFace.subCommand).toBe(1);
+  });
+
+  it('serializes opType=3 with emoji {emojiId,md5} + desc in f5.entry, f12=1', () => {
+    const out = ModifyCustomFace.serialize({} as any, { emojiId: SAMPLE_EMOJI_ID, md5: SAMPLE_MD5, desc: 'hi' });
+    expect(out.opType).toBe(3);
+    expect(out.entry?.emoji).toMatchObject({ emojiId: SAMPLE_EMOJI_ID, md5: SAMPLE_MD5 });
+    expect(out.entry?.desc).toBe('hi');
+    expect(out.field12).toBe(1);
+  });
+
+  it('routes to OidbSvcTrpcTcp.0x902e_1 and encodes the exact wire bytes', async () => {
+    const sender = makeSender();
+    await ModifyCustomFace.invoke(sender, { emojiId: SAMPLE_EMOJI_ID, md5: SAMPLE_MD5, desc: 'hi' });
+    const [cmd, bytes] = sender.sendRawPacket.mock.calls[0]!;
+    expect(cmd).toBe('OidbSvcTrpcTcp.0x902e_1');
+    expect(Buffer.from(bytes as Uint8Array).toString('hex')).toBe(MODIFY_WIRE_HEX);
+    // Structure decodes back.
+    const env = protobuf_decode<OidbBase<CustomFaceModifyBody>>(bytes as Uint8Array);
+    expect(env.command).toBe(0x902e);
+    expect(env.body?.opType).toBe(3);
+    expect(env.body?.entry?.desc).toBe('hi');
+  });
+
+  it('resolves on success (retCode 0 / empty body)', async () => {
+    const sender = makeSender();
+    await expect(ModifyCustomFace.invoke(sender, { emojiId: SAMPLE_EMOJI_ID, md5: SAMPLE_MD5, desc: '' }))
+      .resolves.toBeUndefined();
+  });
+
+  it('throws when the business body carries a non-zero retCode', () => {
+    expect(() => ModifyCustomFace.deserialize({} as any, { retCode: 5, errMsg: 'bad' }))
+      .toThrow();
+  });
+});

--- a/packages/protocol/tests/oidb-services/custom-face/move-custom-face.test.ts
+++ b/packages/protocol/tests/oidb-services/custom-face/move-custom-face.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { protobuf_decode } from '@snowluma/proton';
+import type { OidbBase } from '@snowluma/proto-defs/oidb';
+import type { CustomFaceMoveBody } from '@snowluma/proto-defs/oidb-actions/base';
+import type { SendPacketResult } from '@snowluma/common/packet-sender';
+
+import { MoveCustomFace } from '../../../src/oidb-services/custom-face/move-custom-face';
+
+const EMOJI_A_ID = '2550419068_0_0_0_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA_0_0';
+const EMOJI_A_MD5 = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const EMOJI_B_ID = '2550419068_0_0_0_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB_0_0';
+const EMOJI_B_MD5 = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+// Byte-oracle hand-decoded from the proto layout. Cross-checked against the
+// 9.9.26-44343 frida capture (fav25/fav27 ENC#3, the "upload new order" step
+// of the two-step move — step 2, must be preceded by OrderCustomFace 0x902f):
+//   08 aea002   f1 command = 0x902e          ← move step 2: 0x902e opType=2
+//   10 01       f2 subCommand = 1
+//   22 <len>    f4 body:
+//     08 01                f1 = 1
+//     12 0a "10.0.26200"   f2 osVersion
+//     18 02                f3 opType = 2     ← move upload
+//     22 59 <emoji A>      f4 repeated: {0a 35 emojiId, 12 20 md5}
+//     22 59 <emoji B>      f4 repeated
+//   60 01       f12 = 1   ← envelope reserved (uinForm=true); without it the
+//                            server accepts the request but does NOT reorder.
+const MOVE_WIRE_HEX =
+  '08aea002100122c6010801120a31302e302e3236323030180222590a35323535303431393036385f305f305f305f41414141414141414141414141414141414141414141414141414141414141415f305f301220414141414141414141414141414141414141414141414141414141414141414122590a35323535303431393036385f305f305f305f42424242424242424242424242424242424242424242424242424242424242425f305f30122042424242424242424242424242424242424242424242424242424242424242426001';
+
+function makeSender() {
+  const r: SendPacketResult = {
+    success: true, gotResponse: true, errorCode: 0, errorMessage: '',
+    responseData: Buffer.alloc(0),
+  };
+  return { sendRawPacket: vi.fn(async () => r) };
+}
+
+describe('MoveCustomFace namespace', () => {
+  it('declares command 0x902e sub 1 with uinForm (envelope reserved=1)', () => {
+    expect(MoveCustomFace.command).toBe(0x902e);
+    expect(MoveCustomFace.subCommand).toBe(1);
+    expect(MoveCustomFace.uinForm).toBe(true);
+  });
+
+  it('serializes opType=2 with the emoji list in f4 (repeated, in order)', () => {
+    const out = MoveCustomFace.serialize({} as any, {
+      emojis: [
+        { emojiId: EMOJI_A_ID, md5: EMOJI_A_MD5 },
+        { emojiId: EMOJI_B_ID, md5: EMOJI_B_MD5 },
+      ],
+    });
+    expect(out.opType).toBe(2);
+    expect(out.emojis?.map((e) => e.emojiId)).toEqual([EMOJI_A_ID, EMOJI_B_ID]);
+  });
+
+  it('routes to OidbSvcTrpcTcp.0x902e_1 and encodes the exact wire bytes (incl. envelope f12)', async () => {
+    const sender = makeSender();
+    await MoveCustomFace.invoke(sender, {
+      emojis: [
+        { emojiId: EMOJI_A_ID, md5: EMOJI_A_MD5 },
+        { emojiId: EMOJI_B_ID, md5: EMOJI_B_MD5 },
+      ],
+    });
+    const [cmd, bytes] = sender.sendRawPacket.mock.calls[0]!;
+    expect(cmd).toBe('OidbSvcTrpcTcp.0x902e_1');
+    expect(Buffer.from(bytes as Uint8Array).toString('hex')).toBe(MOVE_WIRE_HEX);
+    const env = protobuf_decode<OidbBase<CustomFaceMoveBody>>(bytes as Uint8Array);
+    expect(env.command).toBe(0x902e);
+    expect(env.reserved).toBe(1);
+    expect(env.body?.opType).toBe(2);
+    expect(env.body?.emojis?.map((e) => e.emojiId)).toEqual([EMOJI_A_ID, EMOJI_B_ID]);
+  });
+
+  it('resolves on success (retCode 0 / empty body)', async () => {
+    const sender = makeSender();
+    await expect(MoveCustomFace.invoke(sender, { emojis: [{ emojiId: EMOJI_A_ID, md5: EMOJI_A_MD5 }] }))
+      .resolves.toBeUndefined();
+  });
+
+  it('throws when the business body carries a non-zero retCode', () => {
+    expect(() => MoveCustomFace.deserialize({} as any, { retCode: 5, errMsg: 'bad' }))
+      .toThrow();
+  });
+});

--- a/packages/protocol/tests/oidb-services/custom-face/order-custom-face.test.ts
+++ b/packages/protocol/tests/oidb-services/custom-face/order-custom-face.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import { protobuf_decode } from '@snowluma/proton';
+import type { OidbBase } from '@snowluma/proto-defs/oidb';
+import type { CustomFaceOrderBody } from '@snowluma/proto-defs/oidb-actions/base';
+import type { SendPacketResult } from '@snowluma/common/packet-sender';
+
+import { OrderCustomFace } from '../../../src/oidb-services/custom-face/order-custom-face';
+
+const SAMPLE_EMOJI_ID = '2550419068_0_0_0_3BC06CE836D6134326EA2C1B37BF1584_0_0';
+
+// Byte-oracle taken DIRECTLY from the 9.9.26-44343 frida capture (fav27/fav28
+// ENC#2, the real "move to front" instruction — the first of the two-step move).
+//
+//   08 afa002   f1 command = 0x902f          ← move instruction cmd
+//   10 01       f2 subCommand = 1
+//   22 52       f4 body (82B):
+//     0a 17             f1 env (23B):
+//       08 8008         f1 = 1024 (client type flag)
+//       12 0a "10.0.26200"   f2 osVersion
+//       1a 06 "9.9.26"       f3 buildVersion (short)
+//     12 35 <emoji_id>  f2 emojiId
+//     18 01             f3 position = 1 (front)
+//   60 01       f12 = 1   ← envelope reserved (uinForm)
+const ORDER_WIRE_HEX =
+  '08afa002100122520a17088008120a31302e302e32363230301a06392e392e32361235323535303431393036385f305f305f305f33424330364345383336443631333433323645413243314233374246313538345f305f3018016001';
+
+function makeSender() {
+  const r: SendPacketResult = {
+    success: true, gotResponse: true, errorCode: 0, errorMessage: '',
+    responseData: Buffer.alloc(0),
+  };
+  return { sendRawPacket: vi.fn(async () => r) };
+}
+
+describe('OrderCustomFace namespace', () => {
+  it('declares command 0x902f sub 1 with uinForm (envelope reserved=1)', () => {
+    expect(OrderCustomFace.command).toBe(0x902f);
+    expect(OrderCustomFace.subCommand).toBe(1);
+    expect(OrderCustomFace.uinForm).toBe(true);
+  });
+
+  it('serializes env{1024, osVersion, "9.9.26"} + emojiId + position', () => {
+    const out = OrderCustomFace.serialize({} as any, { emojiId: SAMPLE_EMOJI_ID, position: 1 });
+    expect(out.env).toMatchObject({ field1: 1024, osVersion: '10.0.26200', buildVersion: '9.9.26' });
+    expect(out.emojiId).toBe(SAMPLE_EMOJI_ID);
+    expect(out.position).toBe(1);
+  });
+
+  it('routes to OidbSvcTrpcTcp.0x902f_1 and reproduces the captured wire exactly', async () => {
+    const sender = makeSender();
+    await OrderCustomFace.invoke(sender, { emojiId: SAMPLE_EMOJI_ID, position: 1 });
+    const [cmd, bytes] = sender.sendRawPacket.mock.calls[0]!;
+    expect(cmd).toBe('OidbSvcTrpcTcp.0x902f_1');
+    expect(Buffer.from(bytes as Uint8Array).toString('hex')).toBe(ORDER_WIRE_HEX);
+    const env = protobuf_decode<OidbBase<CustomFaceOrderBody>>(bytes as Uint8Array);
+    expect(env.command).toBe(0x902f);
+    expect(env.reserved).toBe(1);
+    expect(env.body?.emojiId).toBe(SAMPLE_EMOJI_ID);
+    expect(env.body?.position).toBe(1);
+  });
+
+  it('resolves on success (retCode 0 / empty body)', async () => {
+    const sender = makeSender();
+    await expect(OrderCustomFace.invoke(sender, { emojiId: SAMPLE_EMOJI_ID, position: 1 }))
+      .resolves.toBeUndefined();
+  });
+
+  it('throws when the business body carries a non-zero retCode', () => {
+    expect(() => OrderCustomFace.deserialize({} as any, { retCode: 5, errMsg: 'bad' }))
+      .toThrow();
+  });
+});


### PR DESCRIPTION
# 做了什么

实现收藏表情的 `modify`（改备注）和 `move`（移到最前）两个操作，纯协议实现（**不依赖** `NodeIKernelMsgService`），通过 OneBot action 暴露。接 #107 的 fetch/delete/add，凑齐五个收藏表情操作。

两个操作都走 OIDB 通道（`OidbSvcTrpcTcp.0x902e_1` / `0x902f_1`），和 fetch/delete/add 的 Faceroam.OpReq 是不同通道——这是 #107 时期没覆盖到的部分。

---

## 协议

### modify（改备注）

`OIDB 0x902e_1` opType=3，单包。业务体：

```
{ f1:1, f2:osVersion, f3:3(opType),
  f5:{ f1:{emojiId, md5}, f2:desc },
  f12:1 }
```

envelope 带 `f12=1`（reserved=1，UIN-form 变体）。

### move（移到最前）

两步流程，缺一不可：

1. `OIDB 0x902f_1` 移动指令：`{ f1:{f1:1024, f2:osVersion, f3:buildVersion}, f2:目标emojiId, f3:1 }`，f3=1 = 移到最前。
2. `OIDB 0x902e_1` opType=2 上传新顺序：`{ f1:1, f2:osVersion, f3:2, f4:[repeated{emojiId,md5}] }`，f4 = fetch 当前列表把目标挪到第一。

两步都带 envelope `f12=1`。

**为什么是两步**：单发 0x902f（移动指令）或单发 0x902e opType=2（上传新顺序）服务端都 retCode=0 但不改顺序；先 0x902f 后 0x902e 才生效。move 内部用 `fetchCustomFace` 拿当前列表构造新顺序，不需要 DB 显示顺序。

---

## 为什么只有 `move_custom_face_to_front`，没有移到任意位置

QQ 客户端收藏表情只有"移动到最前"这一个排序操作，没有"移到第 N 位"。协议层也是同样限制：

- `0x902f` 的 `f3` 字段，抓包和 IDA 反编译（`sub_180E9337A` `OrderEmoji` 实现，`f3=1` 硬编码）都确认是**固定标志 1**（=移到最前），不是位置变量。
- 实测 `f3=2`（移到第 2 位）服务端 retCode=0 但顺序不变——不支持移到其他位置。
- 实测上传"任意自定义排序的完整列表"（如反转）服务端也不接受——0x902e 的列表顺序必须是"当前顺序 + 单个 emoji 移到最前"的形态。

所以 action 命名 `move_custom_face_to_front`（而非 `move_custom_face`），参数只接受 `emoji_id`，不暴露 `position`，避免误导调用方以为能移到任意位置。

---

## API

### `modify_custom_face`

修改一个收藏表情的备注。

| 参数 | 类型 | 默认 | 说明 |
|------|------|------|------|
| `emoji_id` | string | 必填 | `<UIN>_0_0_0_<MD5>_0_0`，来自 `fetch_custom_face`（`return_type=id`）|
| `desc` | string | `""` | 新备注，空串清空 |

### `move_custom_face_to_front`

把一个收藏表情移到列表最前。

| 参数 | 类型 | 必填 | 说明 |
|------|------|------|------|
| `emoji_id` | string | 是 | 要移动的表情 |

---

## 实现

- `proto-defs`：`CustomFaceModifyBody`/`Resp`、`CustomFaceOrderBody`、`CustomFaceMoveBody`
- `protocol`：`ModifyCustomFace`（0x902e opType=3）、`OrderCustomFace`（0x902f）、`MoveCustomFace`（0x902e opType=2）三个 namespace + wire byte-oracle 单测
- `core`：`ProfileApi.modifyCustomFace` / `moveCustomFaceToFront`（后者内部 fetch + 两步发包）
- `onebot`：`modify_custom_face`、`move_custom_face_to_front` action

命名对齐 #107 的 `custom_face`（NapCat 风格），无 `fav_emoji` 残留。move 复用 `ProfileApi.fetchCustomFace`，不另起 fetch。

---

## 测试方式

- `pnpm -r typecheck` 全过
- `pnpm test` 全过（wire byte-oracle 锁字段编号）
- SL 真机实测（QQ 9.9.26-44343）：
  - `modify_custom_face` 改备注，QQ 客户端 GUI 显示生效，跨重启保持
  - `move_custom_face_to_front` 移动不同 emoji，QQ GUI 确认排到第一，跨重启保持
