### PR TITLE
fix(protocol): drop QQNT auto-inserted reply-anchor @ (#127)

### DIFF
--- a/packages/protocol/src/msg-push/rich-body-decoder.ts
+++ b/packages/protocol/src/msg-push/rich-body-decoder.ts
@@ -33,6 +33,10 @@ export function decodeRichBody(body: PushMsgBody | undefined, isGroup: boolean):
 function convertElements(elems: ElemDecoded[]): MessageElement[] {
   const result: MessageElement[] = [];
   let skipNext = false;
+  // True between a srcMsg elem and the first "anchor" @ text elem that follows
+  // it — see the srcMsg / text branches for why QQNT's auto-inserted reply
+  // anchor @ must be dropped (#127).
+  let replyAnchorPending = false;
 
   for (const elem of elems) {
     if (skipNext) { skipNext = false; continue; }
@@ -55,6 +59,19 @@ function convertElements(elems: ElemDecoded[]): MessageElement[] {
       // back empty.
       const replySeq = elem.srcMsg.origSeqs?.[0] ?? 0;
       if (replySeq > 0) result.push({ type: 'reply', replySeq });
+      // A quoted reply is always followed by an "@<replied-to user>" anchor
+      // elem that QQNT auto-inserts as a reply prefix (Lagrange's
+      // ReplyEntity.Build sends it too — TextMsg=`@<nick>`, pbReserve with
+      // TextResvAttr.AtType=2 / AtMemberUid = replied-to uid). On the wire it
+      // carries attr6Buf AND a pbReserve, but its AtMemberUin (MentionExtra.uin,
+      // field4) is LEFT AT 0 — only the uid is filled. A genuine user-typed
+      // @mention fills AtMemberUin with the real UIN. So while the anchor and
+      // a real @ both send identical attr6Buf (both point at the same target),
+      // the anchor's mention.uin === 0 vs the real @'s mention.uin > 0. Without
+      // dropping it OneBot would report a phantom [CQ:at] for every quoted
+      // reply (#127). Only the FIRST such elem right after srcMsg qualifies —
+      // a later uin===0 type=2 would be a degenerate real @ we shouldn't eat.
+      replyAnchorPending = true;
     }
 
     // Text (with possible @ detection)
@@ -67,7 +84,15 @@ function convertElements(elems: ElemDecoded[]): MessageElement[] {
       const hasAttr6 = t.attr6Buf && t.attr6Buf.length > 11;
       const hasMention = mention && (mention.type === 1 || mention.type === 2);
 
-      if (hasAttr6 || hasMention) {
+      // Quoted-reply anchor @ (see the srcMsg branch above): type=2 mention
+      // with AtMemberUin == 0, sitting immediately after the srcMsg. Drop it
+      // so OneBot doesn't surface a phantom @ for the replied-to user.
+      const isReplyAnchor = replyAnchorPending && hasAttr6
+        && mention != null && mention.type === 2 && (mention.uin ?? 0) === 0;
+
+      if (isReplyAnchor) {
+        replyAnchorPending = false;
+      } else if (hasAttr6 || hasMention) {
         const me: MessageElement = { type: 'at', text: t.str ?? '' };
         if (hasAttr6) {
           const buf = t.attr6Buf!;
@@ -78,9 +103,14 @@ function convertElements(elems: ElemDecoded[]): MessageElement[] {
           if (!me.targetUin) me.targetUin = mention.uin ?? 0;
         }
         result.push(me);
+        // The pending reply anchor is consumed by any text elem carrying a
+        // real @ (the anchor and a real @ are mutually exclusive at the same
+        // slot — once a genuine @ shows up right after srcMsg, no later elem
+        // can be the auto-anchor).
+        if (hasMention) replyAnchorPending = false;
       } else {
         const text = t.str ?? '';
-        if (text) result.push({ type: 'text', text });
+        if (text.trim()) result.push({ type: 'text', text });
       }
     }
 

--- a/packages/protocol/tests/msg-push/rich-body-decoder.test.ts
+++ b/packages/protocol/tests/msg-push/rich-body-decoder.test.ts
@@ -15,7 +15,7 @@ import { decodeRichBody } from '../../src/msg-push/rich-body-decoder';
 import { buildSendElems } from '../../src/element-builder';
 import type { MessageElement } from '../../src/events';
 import type { MessageBody } from '@snowluma/proto-defs/message';
-import type { SrcMsgPbReserve } from '@snowluma/proto-defs/element';
+import type { MentionExtra, SrcMsgPbReserve } from '@snowluma/proto-defs/element';
 
 function lightAppBytes(json: unknown): Uint8Array {
   const buf = deflateSync(Buffer.from(JSON.stringify(json), 'utf8'));
@@ -165,13 +165,17 @@ describe('decodeRichBody / market face', () => {
   });
 });
 
-// Reply identity for c2c: a friend's reply carries the per-sender
-// clientSequence in srcMsg.origSeqs[0], but the *canonical* replied-to sequence
-// (the one the original message is keyed by) is srcMsg.pbReserve.friendSequence.
-// Reading origSeqs[0] made get_msg on the quoted message miss ("无法解析申请信息").
-describe('decodeRichBody / reply uses friendSequence for c2c', () => {
-  const CLIENT_SEQ = 23188; // origSeqs[0] — per-sender clientSequence
-  const FRIEND_SEQ = 888;   // pbReserve.friendSequence — canonical replied-to seq
+// Reply sequence: a reply's srcMsg.origSeqs[0] is the message sequence the
+// original is keyed by — for BOTH group and c2c — so reply.id matches the
+// replied-to message_id and get_msg(reply_id) resolves. Earlier code overrode
+// c2c with pbReserve.friendSequence, but that's a small friend-relationship
+// counter that does NOT match the original's head.sequence (e.g. 25 vs 12707),
+// so reply.id != the quoted message_id and get_msg missed (the #114 / #124
+// regression). Aligned with dev commit 839de51 — both group and c2c use
+// origSeqs[0]; friendSequence is no longer read.
+describe('decodeRichBody / reply uses origSeqs[0] for group and c2c', () => {
+  const CLIENT_SEQ = 23188; // origSeqs[0] — the replied-to message's sequence
+  const FRIEND_SEQ = 888;   // pbReserve.friendSequence — must be IGNORED (not the canonical seq)
 
   function replyBody(): MessageBody {
     return {
@@ -188,11 +192,11 @@ describe('decodeRichBody / reply uses friendSequence for c2c', () => {
     };
   }
 
-  it('c2c: replySeq = friendSequence, not origSeqs[0]', () => {
-    expect(decodeRichBody(replyBody(), false)).toContainEqual({ type: 'reply', replySeq: FRIEND_SEQ });
+  it('c2c: replySeq = origSeqs[0], friendSequence ignored', () => {
+    expect(decodeRichBody(replyBody(), false)).toContainEqual({ type: 'reply', replySeq: CLIENT_SEQ });
   });
 
-  it('group: replySeq = origSeqs[0] (friendSequence ignored)', () => {
+  it('group: replySeq = origSeqs[0], friendSequence ignored', () => {
     expect(decodeRichBody(replyBody(), true)).toContainEqual({ type: 'reply', replySeq: CLIENT_SEQ });
   });
 
@@ -201,5 +205,141 @@ describe('decodeRichBody / reply uses friendSequence for c2c', () => {
       richText: { elems: [{ srcMsg: { origSeqs: [CLIENT_SEQ] } } as any] },
     };
     expect(decodeRichBody(body, false)).toContainEqual({ type: 'reply', replySeq: CLIENT_SEQ });
+  });
+});
+
+// #127: a group quoted reply is always followed by an "@<replied-to user>"
+// anchor element that QQNT auto-inserts. On the wire it carries attr6Buf AND a
+// pbReserve, so it used to be decoded as a genuine `[CQ:at]` segment — every
+// reply surfaced a phantom @ plus an empty-text segment (#127). The anchor's
+// MentionExtra.AtMemberUin (field4 = `uin`) is left at 0 (only `uid` is set);
+// a real user-typed @mention fills `uin` with the target's real UIN. The
+// decoder drops the first such `type=2 / uin=0` text elem right after srcMsg.
+describe('decodeRichBody / reply anchor @ filter (#127)', () => {
+  const REPLIED_UIN = 2894267324;
+  const REPLIED_UID = 'u_AjZIs8j0pocxZrejdhpJNA';
+  const REAL_AT_UIN = 3124975529;
+  const REAL_AT_UID = 'u_someOtherRealUid000';
+
+  // QQNT's attr6Buf shape: 13 bytes, target UIN is bytes[7..10] big-endian.
+  // The decoder reads `me.targetUin` from there for backwards-compat clients
+  // that only have attr6 (no pbReserve), and also to recover the UIN when the
+  // real-@ case fills Attr6 but the mention.uin path isn't used.
+  function attr6(targetUin: number): Uint8Array {
+    const buf = new Uint8Array(13);
+    buf[0] = 0x00; buf[1] = 0x01;
+    buf[7] = (targetUin >>> 24) & 0xff;
+    buf[8] = (targetUin >>> 16) & 0xff;
+    buf[9] = (targetUin >>> 8) & 0xff;
+    buf[10] = targetUin & 0xff;
+    return buf;
+  }
+
+  // Anchor @: type=2, AtMemberUin=0, only uid filled — what QQNT inserts as the
+  // reply prefix. Real @: type=2, AtMemberUin = real UIN.
+  function atElem(display: string, targetUin: number, uid: string): any {
+    return {
+      text: {
+        str: display,
+        attr6Buf: attr6(targetUin),
+        pbReserve: protobuf_encode<MentionExtra>({ type: 2, uin: targetUin, field5: 0, uid }),
+      },
+    };
+  }
+
+  it('drops the auto-inserted replied-to anchor @ (uin=0) right after srcMsg', () => {
+    const body: MessageBody = {
+      richText: {
+        elems: [
+          { srcMsg: { origSeqs: [604118] } } as any,
+          atElem('@月年', 0, REPLIED_UID),
+          { text: { str: ' ' } } as any,
+          { text: { str: '叼毛' } } as any,
+        ],
+      },
+    };
+    const out = decodeRichBody(body, true);
+    expect(out).toEqual([
+      { type: 'reply', replySeq: 604118 },
+      { type: 'text', text: '叼毛' },
+    ]);
+  });
+
+  it('keeps a genuine user @ (uin>0) after srcMsg and drops only the anchor', () => {
+    // srcMsg + anchor@(replied-to, uin=0) + ' ' + real@(different user, uin>0) + body
+    const body: MessageBody = {
+      richText: {
+        elems: [
+          { srcMsg: { origSeqs: [604118] } } as any,
+          atElem('@月年', 0, REPLIED_UID),
+          { text: { str: ' ' } } as any,
+          atElem('@CuberOOK', REAL_AT_UIN, REAL_AT_UID),
+          { text: { str: ' 欧克' } } as any,
+        ],
+      },
+    };
+    const out = decodeRichBody(body, true);
+    expect(out).toEqual([
+      { type: 'reply', replySeq: 604118 },
+      { type: 'at', text: '@CuberOOK', targetUin: REAL_AT_UIN, uid: REAL_AT_UID },
+      { type: 'text', text: ' 欧克' },
+    ]);
+  });
+
+  it('keeps a real @ that targets the replied-to user themselves (uin>0)', () => {
+    // User replies to 月年 and then actually types @月年 themselves — the real
+    // @ has uin=REPLIED_UIN (>0) so must survive; only the anchor (uin=0) is dropped.
+    const body: MessageBody = {
+      richText: {
+        elems: [
+          { srcMsg: { origSeqs: [11769] } } as any,
+          atElem('@月年', 0, REPLIED_UID),
+          { text: { str: ' ' } } as any,
+          atElem('@月年', REPLIED_UIN, REPLIED_UID),
+          { text: { str: ' hello' } } as any,
+        ],
+      },
+    };
+    const out = decodeRichBody(body, true);
+    expect(out).toEqual([
+      { type: 'reply', replySeq: 11769 },
+      { type: 'at', text: '@月年', targetUin: REPLIED_UIN, uid: REPLIED_UID },
+      { type: 'text', text: ' hello' },
+    ]);
+  });
+
+  it('does not treat @all (type=1) as the reply anchor', () => {
+    // @全体成员 has type=1 / uin=0 — it's a real segment, not the auto-anchor
+    // (which is type=2). It must surface even when sitting right after srcMsg.
+    const body: MessageBody = {
+      richText: {
+        elems: [
+          { srcMsg: { origSeqs: [55] } } as any,
+          {
+            text: {
+              str: '@全体成员 ',
+              pbReserve: protobuf_encode<MentionExtra>({ type: 1, uin: 0, field5: 0, uid: 'all' }),
+            },
+          } as any,
+          { text: { str: 'go' } } as any,
+        ],
+      },
+    };
+    const out = decodeRichBody(body, true);
+    expect(out).toContainEqual({ type: 'at', text: '@全体成员 ', targetUin: 0, uid: 'all' });
+    expect(out.find(e => e.type === 'at' && (e as any).uid === 'all')).toBeDefined();
+  });
+
+  it('drops a pure-whitespace text element so no empty [空消息] segment leaks', () => {
+    const body: MessageBody = {
+      richText: {
+        elems: [
+          { text: { str: '   ' } } as any,
+          { text: { str: 'keep' } } as any,
+        ],
+      },
+    };
+    const out = decodeRichBody(body, true);
+    expect(out).toEqual([{ type: 'text', text: 'keep' }]);
   });
 });


### PR DESCRIPTION
## 这个 PR 做什么

修复 #127：群聊引用回复消息时，OneBot 上报会凭空多出一个 `[CQ:at,qq=被回复者]` 段，并在用户正文前夹一个 `[空消息]` 空文本段。导致下游应用端把"被回复者"误当真实 @ 处理。

## 复现

群聊里引用回复他人消息：

- **不 @ 任何人**：上报 `[CQ:reply,id=...] @被回复者 [空消息] 正文` —— 多了 `@被回复者` 和 `[空消息]`
- **真的 @ 一个人**（哪怕 @ 的是被回复者本人）：`[CQ:reply,...] @被回复者 [空消息] @被真@者 正文` —— `@被回复者` 重复（一条自动、一条用户真打）

NapCat 在同场景不报这两段。

## 根因

`rich-body-decoder.ts` 的 `convertElements` 看到 `text.attr6Buf` / `pbReserve(MentionExtra)` 就无条件转成 `at` 段。但 QQNT 客户端在构造群引用回复时，会自动在 `srcMsg` 后插入一条指向**被回复者**的"锚点 @"（Lagrange 的 `ReplyEntity.Build` 群聊分支也发同样的 anchor elem：`TextMsg=@<nick>` + `pbReserve(TextResvAttr.AtType=2, AtMemberUid=被回复者uid)`）。它不带用户意图，不该当真实 @ 报上去。

锚点@和用户真打的@在 wire 上的差异（frida + SnowLuma 调试 dump 实测，对照 Lagrange 源码印证）：

| 字段 | 自动锚点@ | 用户真@ |
|------|-----------|---------|
| `attr6Buf` | 指向被回复者（与真@可能字节相同） | 指向被真@者 |
| `pbReserve.MentionExtra.type` | `2` | `2` |
| **`pbReserve.MentionExtra.uin`** (AtMemberUin) | **`0`**（只填了 `uid`） | **被 @ 者的真实 UIN** |

锚点@ 把 `AtMemberUin` 留 0、只填 `AtMemberUid`；真@ 两者都填。这是唯一稳定的判别字段——`attr6Buf` 在两者上可能完全相同（同一目标 UIN 时），无法靠它区分。

## 改动

`packages/protocol/src/msg-push/rich-body-decoder.ts` 的 `convertElements`：

- 新增 `replyAnchorPending` 状态：遇到 `srcMsg` 置位，紧跟其后**第一条**满足 `attr6Buf ≥ 11` 且 `mention.type===2 && mention.uin===0` 的 text elem，判定为自动锚点@，**丢弃**（不上报为 `at` 段），并清除状态。
- 真 @（`mention.uin > 0`）或 `@全体成员`（`type===1`）正常保留 —— 锚点判定严格要求 `type===2`，不会误伤 `@全体`。
- 纯空白 `str`（`text.trim() === ''`，即 issue 里的 `[空消息]` 来源）的 text elem 不再 push 为 `text` 段 —— 与 NapCat 行为一致。

判据只匹配"紧跟 srcMsg 后的一条"——若用户真的在回复时 `@` 了被回复者本人，dump 实测会出现两条 `@<nick>`，前一条 `uin=0`（锚点）被丢、后一条 `uin=被回复者UIN`（真@）保留，正确。

## 测试

`packages/protocol/tests/msg-push/rich-body-decoder.test.ts` 新增 5 个用例：

- 锚点@（`uin=0`）紧跟 srcMsg → 输出只含 `reply` + 正文，无 `at`
- 锚点@ + 真@（`uin>0` 指向别人）→ 锚点丢弃、真@ 保留
- 锚点@ + 用户真@ 指向被回复者本人（`uin>0`）→ 锚点丢弃、真@ 保留
- `@全体成员`（`type=1`）紧跟 srcMsg 不被当锚点吞掉
- 纯空白 text elem 被丢，不再泄漏 `[空消息]`

```
pnpm --filter @snowluma/protocol test        # 516/516 全过
pnpm --filter @snowluma/protocol typecheck   # 通过
```

## 顺带修了一处陈旧测试

`decodeRichBody / reply uses friendSequence for c2c` 这条测试在干净 dev 上就失败：它断言 c2c reply 的 `replySeq = pbReserve.friendSequence`(888)，但 dev commit `839de51`（`fix(protocol): c2c reply uses origSeqs[0], not friendSequence (#114, #124)`）已经把 c2c reply 改回 `origSeqs[0]`(23188) —— 该 commit 漏更新这条测试，导致 dev CI 一直红。本次把它对齐 `839de51` 的现行逻辑（断言 c2c / group 都用 `origSeqs[0]，friendSequence 忽略`），让本 PR 的 CI 干净。逻辑代码无任何改动，只是把测试断言和 describe 名字与既有的 `839de51` 行为对齐。

## 线上验证

QQ 9.9.26 群聊实测两条对照：

- 引用回复 + 不@ → `[回复 ...] 正文`（伪@ 自消失，无 `[空消息]`）✅
- 引用回复 + 真@ 月年 → `[回复 ...] @月年 正文`（`@月年` 仅一次，锚点被吞）✅

## 局限 / 边界

- 仅群聊实测。私聊本就无 `at` 段语义，锚点@若出现在私聊路径也只会被丢弃（无副作用），但**未抓包验证**。判据字段（`uin=0`）来自 Lagrange `MentionEntity`/`ReplyEntity` 构造约定 + 实测，QQNT 跨版本若改变锚点@的 AtMemberUin 填法，规则可能失效回归。

## 关联

Closes #127