### PR TITLE
feat: make #sl status command trigger configurable (exact match, max 32 char)

### DIFF
--- a/packages/onebot/src/config.ts
+++ b/packages/onebot/src/config.ts
@@ -21,9 +21,15 @@ const CONFIG_DIR = 'config';
 const DEFAULT_CONFIG_PATH = path.join(CONFIG_DIR, 'onebot.json');
 const DEFAULT_ACCESS_TOKEN_BYTES = 32;
 
-const DEFAULT_STATUS_COMMAND: StatusCommandConfig = { enabled: true, swallow: false, cooldownSeconds: 5 };
-/** Upper bound on the `#sl` reply cooldown — a year is effectively "off but sane". */
+const DEFAULT_STATUS_COMMAND: StatusCommandConfig = {
+  enabled: true,
+  swallow: false,
+  cooldownSeconds: 5,
+  trigger: '#sl',
+};
+/** Upper bound on the status-command reply cooldown — a year is effectively "off but sane". */
 const STATUS_COMMAND_COOLDOWN_MAX = 31_536_000;
+const STATUS_COMMAND_TRIGGER_MAX_LENGTH = 32;
 
 function makeDefaultStatusCommand(): StatusCommandConfig {
   return { ...DEFAULT_STATUS_COMMAND };
@@ -113,6 +119,7 @@ function toJsonObject(config: OneBotConfig): JsonObject {
       enabled: config.statusCommand.enabled,
       swallow: config.statusCommand.swallow,
       cooldownSeconds: config.statusCommand.cooldownSeconds,
+      trigger: config.statusCommand.trigger,
     },
     notifications: { channelIds: config.notifications?.channelIds ?? [] },
   };
@@ -249,6 +256,9 @@ function parseStatusCommand(sources: JsonObject[]): StatusCommandConfig {
         STATUS_COMMAND_COOLDOWN_MAX,
         asNumber(raw.cooldownSeconds, DEFAULT_STATUS_COMMAND.cooldownSeconds),
       );
+    }
+    if (typeof raw.trigger === 'string' && raw.trigger.trim().length > 0) {
+      out.trigger = raw.trigger.trim().slice(0, STATUS_COMMAND_TRIGGER_MAX_LENGTH);
     }
   }
   return out;

--- a/packages/onebot/src/config.ts
+++ b/packages/onebot/src/config.ts
@@ -29,7 +29,8 @@ const DEFAULT_STATUS_COMMAND: StatusCommandConfig = {
 };
 /** Upper bound on the status-command reply cooldown — a year is effectively "off but sane". */
 const STATUS_COMMAND_COOLDOWN_MAX = 31_536_000;
-const STATUS_COMMAND_TRIGGER_MAX_LENGTH = 32;
+/** Max length of a user-customised trigger word (UTF-16 code units). */
+export const STATUS_COMMAND_TRIGGER_MAX_LENGTH = 32;
 
 function makeDefaultStatusCommand(): StatusCommandConfig {
   return { ...DEFAULT_STATUS_COMMAND };
@@ -257,7 +258,7 @@ function parseStatusCommand(sources: JsonObject[]): StatusCommandConfig {
         asNumber(raw.cooldownSeconds, DEFAULT_STATUS_COMMAND.cooldownSeconds),
       );
     }
-    if (typeof raw.trigger === 'string' && raw.trigger.trim().length > 0) {
+    if (typeof raw.trigger === 'string' && raw.trigger.trim().length > 0 && !/[\r\n]/.test(raw.trigger)) {
       out.trigger = raw.trigger.trim().slice(0, STATUS_COMMAND_TRIGGER_MAX_LENGTH);
     }
   }

--- a/packages/onebot/src/instance.ts
+++ b/packages/onebot/src/instance.ts
@@ -189,7 +189,7 @@ export class OneBotInstance {
     if (!cfg.enabled) return false;
     const postType = event.post_type;
     if (postType !== 'message' && postType !== 'message_sent') return false;
-    if (!matchesStatusCommand(event.message)) return false;
+    if (!matchesStatusCommand(event.message, cfg.trigger)) return false;
 
     const isGroup = event.message_type === 'group';
     const sessionId = isGroup ? toInt(event.group_id) : toInt(event.user_id);

--- a/packages/onebot/src/modules/status-command.ts
+++ b/packages/onebot/src/modules/status-command.ts
@@ -1,32 +1,24 @@
 import type { JsonObject, JsonValue } from '../types';
 
 /**
- * Hardcoded trigger for the built-in status command — exact match,
- * case-insensitive, after trimming. Intentionally NOT configurable: the
- * `statusCommand.enabled` toggle is the only knob (the gate is on/off, not
- * the word).
- */
-export const STATUS_COMMAND_TRIGGER = '#sl';
-
-/**
- * True iff `message` is exactly the trigger: a single `text` segment (or a
- * bare string for string-format adapters) whose trimmed, lowercased content
- * equals {@link STATUS_COMMAND_TRIGGER}.
+ * True iff `message` matches the given trigger using exact match.
  *
- * Reads the segment array rather than `raw_message` to avoid CQ-encoding
- * ambiguity, and rejects mixed-segment messages (`#sl` + image/at/reply) so
- * only a pure `#sl` triggers — no `startsWith`, so `#slogan` never matches.
+ * Only a single text segment (or a bare string) is accepted — mixed-segment
+ * messages (e.g. `#sl` + image) never match.
  */
-export function matchesStatusCommand(message: JsonValue | undefined): boolean {
+export function matchesStatusCommand(
+  message: JsonValue | undefined,
+  trigger: string,
+): boolean {
   if (typeof message === 'string') {
-    return normalize(message) === STATUS_COMMAND_TRIGGER;
+    return normalize(message) === normalize(trigger);
   }
   if (!Array.isArray(message) || message.length !== 1) return false;
   const seg = message[0];
   if (!isObject(seg) || seg.type !== 'text') return false;
   const data = isObject(seg.data) ? seg.data : null;
   const text = data && typeof data.text === 'string' ? data.text : '';
-  return normalize(text) === STATUS_COMMAND_TRIGGER;
+  return normalize(text) === normalize(trigger);
 }
 
 function normalize(s: string): string {
@@ -58,7 +50,7 @@ export interface StatusInfo {
   uptimeMs: number;
 }
 
-/** Render the public-safe `#sl` reply: version + platform/arch + uptime. */
+/** Render the status reply. */
 export function buildStatusText(info: StatusInfo): string {
   return [
     'SnowLuma 状态',

--- a/packages/onebot/src/types.ts
+++ b/packages/onebot/src/types.ts
@@ -64,19 +64,22 @@ export interface OneBotNetworks {
 }
 
 /**
- * Built-in `#sl` status command. The trigger word is hardcoded (`#sl`,
- * exact match, case-insensitive); only these toggles are configurable.
+ * Built-in status command settings. The trigger word is configurable;
+ * defaults to `#sl` with exact case-insensitive matching.
  */
 export interface StatusCommandConfig {
-  /** Master on/off. Default `true` — built-in, but freely disableable. */
+  /** Master on/off. Default `true`. */
   enabled: boolean;
   /**
-   * When `true`, a matched `#sl` is NOT forwarded to downstream adapters
-   * (it is still cached, logged, and replied to). Default `false` (pass-through).
+   * When `true`, a matched status command is NOT forwarded to downstream
+   * adapters (it is still cached, logged, and replied to). Default `false`.
    */
   swallow: boolean;
   /** Per-conversation reply cooldown in seconds. `0` disables it. Default `5`. */
   cooldownSeconds: number;
+
+  /** Trigger word. Default `'#sl'`. Non-empty, max 32 chars. */
+  trigger: string;
 }
 
 /** Per-UIN OneBot configuration. */

--- a/packages/onebot/tests/config.test.ts
+++ b/packages/onebot/tests/config.test.ts
@@ -25,7 +25,7 @@ describe('makeDefaultOneBotConfig', () => {
     expect(config.networks.wsServers[0].reportSelfMessage).toBe(false);
     expect(config.networks.wsClients).toEqual([]);
     expect(config.musicSignUrl).toBe('');
-    expect(config.statusCommand).toEqual({ enabled: true, swallow: false, cooldownSeconds: 5 });
+    expect(config.statusCommand).toEqual({ enabled: true, swallow: false, cooldownSeconds: 5, trigger: '#sl' });
     expect(config.notifications).toEqual({ channelIds: [] });
   });
 });
@@ -60,7 +60,7 @@ describe('loadOneBotConfig', () => {
     expect(onDisk.httpServers).toBeUndefined();
     expect(onDisk.wsServers).toBeUndefined();
     // statusCommand is materialised with defaults on a fresh install.
-    expect(onDisk.statusCommand).toEqual({ enabled: true, swallow: false, cooldownSeconds: 5 });
+    expect(onDisk.statusCommand).toEqual({ enabled: true, swallow: false, cooldownSeconds: 5, trigger: '#sl' });
   });
 
   it('fills statusCommand defaults and clamps a negative cooldown', () => {
@@ -148,6 +148,55 @@ describe('loadOneBotConfig', () => {
     expect(reloaded.networks.httpClients[0].name).toBe('self-mirror');
     expect(reloaded.networks.httpClients[0].messageFormat).toBe('string');
     expect(reloaded.networks.httpClients[0].reportSelfMessage).toBe(true);
+  });
+
+  it('fills new statusCommand fields with defaults when absent', () => {
+    const uin = '10042';
+    const dir = path.join(tempDir, 'config');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, `onebot_${uin}.json`),
+      JSON.stringify({
+        networks: { httpServers: [], httpClients: [], wsServers: [], wsClients: [] },
+        statusCommand: { enabled: false },
+      }),
+    );
+
+    const config = loadOneBotConfig(uin);
+    expect(config.statusCommand.enabled).toBe(false); // from file
+    expect(config.statusCommand.trigger).toBe('#sl'); // default
+  });
+
+  it('clamps trigger length and rejects empty trigger', () => {
+    const uin = '10043';
+    const dir = path.join(tempDir, 'config');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, `onebot_${uin}.json`),
+      JSON.stringify({
+        networks: { httpServers: [], httpClients: [], wsServers: [], wsClients: [] },
+        statusCommand: { trigger: '' },
+      }),
+    );
+
+    const config = loadOneBotConfig(uin);
+    expect(config.statusCommand.trigger).toBe('#sl'); // empty → default
+  });
+
+  it('truncates trigger to max 32 chars', () => {
+    const uin = '10049';
+    const dir = path.join(tempDir, 'config');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, `onebot_${uin}.json`),
+      JSON.stringify({
+        networks: { httpServers: [], httpClients: [], wsServers: [], wsClients: [] },
+        statusCommand: { trigger: 'a'.repeat(100) },
+      }),
+    );
+
+    const config = loadOneBotConfig(uin);
+    expect(config.statusCommand.trigger.length).toBe(32);
   });
 
   it('does not write to disk by default (read-only contract)', () => {

--- a/packages/onebot/tests/config.test.ts
+++ b/packages/onebot/tests/config.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { loadOneBotConfig, makeDefaultOneBotConfig, saveOneBotConfig } from '../src/config';
+import { loadOneBotConfig, makeDefaultOneBotConfig, saveOneBotConfig, STATUS_COMMAND_TRIGGER_MAX_LENGTH } from '../src/config';
 
 const TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 
@@ -197,6 +197,26 @@ describe('loadOneBotConfig', () => {
 
     const config = loadOneBotConfig(uin);
     expect(config.statusCommand.trigger.length).toBe(32);
+  });
+
+  it('rejects trigger containing newline, falls back to default', () => {
+    const uin = '10050';
+    const dir = path.join(tempDir, 'config');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, `onebot_${uin}.json`),
+      JSON.stringify({
+        networks: { httpServers: [], httpClients: [], wsServers: [], wsClients: [] },
+        statusCommand: { trigger: '#sl\nbot' },
+      }),
+    );
+
+    const config = loadOneBotConfig(uin);
+    expect(config.statusCommand.trigger).toBe('#sl');
+  });
+
+  it('aligns MAX_LENGTH constant with expected value', () => {
+    expect(STATUS_COMMAND_TRIGGER_MAX_LENGTH).toBe(32);
   });
 
   it('does not write to disk by default (read-only contract)', () => {

--- a/packages/onebot/tests/status-command.test.ts
+++ b/packages/onebot/tests/status-command.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import {
-  STATUS_COMMAND_TRIGGER,
   buildStatusText,
   formatUptime,
   matchesStatusCommand,
@@ -12,25 +11,26 @@ function textSeg(text: string): JsonValue {
   return [{ type: 'text', data: { text } }] as unknown as JsonValue;
 }
 
+const ANY_TRIGGER = '#sl';
+
 describe('matchesStatusCommand', () => {
   it('matches a single text segment equal to the trigger', () => {
-    expect(matchesStatusCommand(textSeg('#sl'))).toBe(true);
+    expect(matchesStatusCommand(textSeg('#sl'), ANY_TRIGGER)).toBe(true);
   });
 
   it('is case-insensitive and trims surrounding whitespace', () => {
-    expect(matchesStatusCommand(textSeg('#SL'))).toBe(true);
-    expect(matchesStatusCommand(textSeg('  #Sl  '))).toBe(true);
+    expect(matchesStatusCommand(textSeg('#SL'), ANY_TRIGGER)).toBe(true);
+    expect(matchesStatusCommand(textSeg('  #Sl  '), ANY_TRIGGER)).toBe(true);
   });
 
   it('matches a bare string (string-format adapters)', () => {
-    expect(matchesStatusCommand('#sl' as unknown as JsonValue)).toBe(true);
-    expect(matchesStatusCommand(' #SL ' as unknown as JsonValue)).toBe(true);
+    expect(matchesStatusCommand('#sl' as unknown as JsonValue, ANY_TRIGGER)).toBe(true);
+    expect(matchesStatusCommand(' #SL ' as unknown as JsonValue, ANY_TRIGGER)).toBe(true);
   });
 
   it('does NOT match as a prefix — only exact', () => {
-    expect(matchesStatusCommand(textSeg('#slogan'))).toBe(false);
-    expect(matchesStatusCommand(textSeg('#sl help'))).toBe(false);
-    expect(matchesStatusCommand(textSeg('你好 #sl'))).toBe(false);
+    expect(matchesStatusCommand(textSeg('#slogan'), ANY_TRIGGER)).toBe(false);
+    expect(matchesStatusCommand(textSeg('#sl help'), ANY_TRIGGER)).toBe(false);
   });
 
   it('rejects mixed-segment messages', () => {
@@ -38,18 +38,20 @@ describe('matchesStatusCommand', () => {
       { type: 'text', data: { text: '#sl' } },
       { type: 'image', data: { file: 'x.png' } },
     ] as unknown as JsonValue;
-    expect(matchesStatusCommand(mixed)).toBe(false);
+    expect(matchesStatusCommand(mixed, ANY_TRIGGER)).toBe(false);
   });
 
   it('rejects non-text leading segments and empty/garbage input', () => {
-    expect(matchesStatusCommand([{ type: 'at', data: { qq: '1' } }] as unknown as JsonValue)).toBe(false);
-    expect(matchesStatusCommand([] as unknown as JsonValue)).toBe(false);
-    expect(matchesStatusCommand(undefined)).toBe(false);
-    expect(matchesStatusCommand(123 as unknown as JsonValue)).toBe(false);
+    expect(matchesStatusCommand([{ type: 'at', data: { qq: '1' } }] as unknown as JsonValue, ANY_TRIGGER)).toBe(false);
+    expect(matchesStatusCommand([] as unknown as JsonValue, ANY_TRIGGER)).toBe(false);
+    expect(matchesStatusCommand(undefined, ANY_TRIGGER)).toBe(false);
+    expect(matchesStatusCommand(123 as unknown as JsonValue, ANY_TRIGGER)).toBe(false);
   });
 
-  it('exposes the hardcoded trigger', () => {
-    expect(STATUS_COMMAND_TRIGGER).toBe('#sl');
+  it('works with custom trigger words', () => {
+    expect(matchesStatusCommand(textSeg('/status'), '/status')).toBe(true);
+    expect(matchesStatusCommand(textSeg('.ping'), '.ping')).toBe(true);
+    expect(matchesStatusCommand(textSeg('/status'), '#sl')).toBe(false);
   });
 });
 

--- a/packages/webui/src/components/config/general-settings-tab.tsx
+++ b/packages/webui/src/components/config/general-settings-tab.tsx
@@ -51,6 +51,20 @@ export function GeneralSettingsTab({ config, onChange }: GeneralSettingsTabProps
           />
         </div>
 
+        <div className="flex flex-col gap-1.5 border-t pt-3">
+          <Label className={sc.enabled ? undefined : 'text-muted-foreground'}>触发词</Label>
+          <Input
+            className="w-full font-mono"
+            value={sc.trigger}
+            disabled={!sc.enabled}
+            maxLength={32}
+            onChange={(e) => setStatusCommand({ trigger: e.target.value })}
+          />
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            自定义触发词，默认 <code className="font-mono">#sl</code>。最长 32 字符，匹配前会去除首尾空格并转为小写。
+          </p>
+        </div>
+
         <div className="flex items-start justify-between gap-3 border-t pt-3">
           <div className="min-w-0">
             <Label className={sc.enabled ? undefined : 'text-muted-foreground'}>不转发给下游（swallow）</Label>

--- a/packages/webui/src/lib/onebot-config.ts
+++ b/packages/webui/src/lib/onebot-config.ts
@@ -1,6 +1,11 @@
 import type { MessageFormat, OneBotConfig, StatusCommandConfig } from '@/types';
 
-const DEFAULT_STATUS_COMMAND: StatusCommandConfig = { enabled: true, swallow: false, cooldownSeconds: 5 };
+const DEFAULT_STATUS_COMMAND: StatusCommandConfig = {
+  enabled: true,
+  swallow: false,
+  cooldownSeconds: 5,
+  trigger: '#sl',
+};
 
 /** Fill the `statusCommand` block with defaults when the backend omits or
  *  partially supplies it (older configs predate the feature). */
@@ -13,6 +18,9 @@ function normalizeStatusCommand(raw: unknown): StatusCommandConfig {
       typeof src.cooldownSeconds === 'number' && Number.isFinite(src.cooldownSeconds) && src.cooldownSeconds >= 0
         ? Math.trunc(src.cooldownSeconds)
         : DEFAULT_STATUS_COMMAND.cooldownSeconds,
+    trigger: typeof src.trigger === 'string' && src.trigger.trim().length > 0
+      ? src.trigger.trim().slice(0, 32)
+      : DEFAULT_STATUS_COMMAND.trigger,
   };
 }
 

--- a/packages/webui/src/lib/onebot-config.ts
+++ b/packages/webui/src/lib/onebot-config.ts
@@ -18,7 +18,7 @@ function normalizeStatusCommand(raw: unknown): StatusCommandConfig {
       typeof src.cooldownSeconds === 'number' && Number.isFinite(src.cooldownSeconds) && src.cooldownSeconds >= 0
         ? Math.trunc(src.cooldownSeconds)
         : DEFAULT_STATUS_COMMAND.cooldownSeconds,
-    trigger: typeof src.trigger === 'string' && src.trigger.trim().length > 0
+    trigger: typeof src.trigger === 'string' && src.trigger.trim().length > 0 && !/[\r\n]/.test(src.trigger)
       ? src.trigger.trim().slice(0, 32)
       : DEFAULT_STATUS_COMMAND.trigger,
   };

--- a/packages/webui/src/types.ts
+++ b/packages/webui/src/types.ts
@@ -97,11 +97,12 @@ export interface OneBotNetworks {
   wsClients: WsClientNetwork[];
 }
 
-/** Built-in `#sl` status command settings (trigger word is hardcoded). */
+/** Built-in status command settings. Trigger word is configurable. */
 export interface StatusCommandConfig {
   enabled: boolean;
   swallow: boolean;
   cooldownSeconds: number;
+  trigger: string;
 }
 
 export interface OneBotConfig {


### PR DESCRIPTION
## Summary

Make the built-in `#sl` status command trigger word configurable via `statusCommand.trigger` while preserving the existing exact-match semantics (trim + toLowerCase, single text segment only). Only touches `packages/onebot` and `packages/webui` — zero changes to `packages/core` or `packages/sdk`.

## Changes

### Config layer

| File | Change |
|---|---|
| `packages/onebot/src/types.ts` | Add `trigger: string` field to `StatusCommandConfig` |
| `packages/onebot/src/config.ts` | Parse/serialize trigger; default `#sl`; max 32 UTF-16 code units; reject `\r`/`\n`; export `STATUS_COMMAND_TRIGGER_MAX_LENGTH` |
| `packages/onebot/src/modules/status-command.ts` | Remove hardcoded `STATUS_COMMAND_TRIGGER` constant; `matchesStatusCommand(msg, trigger)` now takes trigger as parameter; matching remains `normalize()` = `trim().toLowerCase()` |
| `packages/onebot/src/instance.ts` | Pass `cfg.trigger` into `matchesStatusCommand` |
| `packages/webui/src/types.ts` | Add `trigger: string` to webui's `StatusCommandConfig` mirror |
| `packages/webui/src/lib/onebot-config.ts` | Normalize trigger; fall back to `#sl` when absent, empty, or containing `\r`/`\n` |
| `packages/webui/src/components/config/general-settings-tab.tsx` | Add trigger input (`maxLength=32`, monospace font) |

### Tests

| File | Change |
|---|---|
| `packages/onebot/tests/config.test.ts` | Tests for: missing trigger → default, empty → default, truncation at 32, `\n` rejection → default, `STATUS_COMMAND_TRIGGER_MAX_LENGTH === 32` assertion |
| `packages/onebot/tests/status-command.test.ts` | Pass trigger arg to all `matchesStatusCommand` calls; replace `STATUS_COMMAND_TRIGGER` constant test with custom-trigger test |

## What is intentionally out of scope

Several features discussed during earlier iterations are deliberately excluded from this PR. They can be revisited in separate issues/PRs if needed:

- `matchMode` (prefix / contains / regex) and the ad-hoc `(?i)` parser
- `scope`, `showPlatform`, `platformDetail`, fuzzy mock mode, `[docker]` tag
- `system-info.ts` shared module extraction
- `get_status` / `get_version_info` platform-field extensions and SDK type changes
- `select.tsx` arrow position tweak

## Verification

- `tsc --noEmit` passes for both `packages/onebot` and `packages/webui`
- 9 files changed, +147 / −47