### PR TITLE
feat(webui): auto-compress per-core density grid to fixed container

### DIFF
--- a/packages/webui/src/components/pages/overview-page.tsx
+++ b/packages/webui/src/components/pages/overview-page.tsx
@@ -511,6 +511,23 @@ function StatTileWidget({ id }: { id: string }) {
 
 const HOST_GRID_COLS: Record<number, string> = { 1: 'lg:grid-cols-1', 2: 'lg:grid-cols-2', 3: 'lg:grid-cols-3' };
 
+function bestGrid(n: number, maxCols = 48): { cols: number; rows: number; waste: number } {
+  let best = { cols: 2, rows: Math.ceil(n / 2), waste: 0 };
+  let bestScore = Infinity;
+  const limit = Math.min(maxCols, n);
+  for (let cols = 2; cols <= limit; cols++) {
+    const rows = Math.ceil(n / cols);
+    const waste = cols * rows - n;
+    const balance = Math.abs(cols - rows);
+    const score = waste * 20 + balance;
+    if (score < bestScore) {
+      bestScore = score;
+      best = { cols, rows, waste };
+    }
+  }
+  return best;
+}
+
 function HostBlock({ config }: { config: HostConfig }) {
   const { systemInfo, refreshSystem } = useAppState();
   const panelCount = [config.cpu, config.memory, config.runtime].filter(Boolean).length;
@@ -547,13 +564,32 @@ function HostBlock({ config }: { config: HostConfig }) {
             负载: {systemInfo ? systemInfo.cpu.loadAvg.map((v) => v.toFixed(2)).join(' / ') : '—'}
             </p>
             {systemInfo && systemInfo.cpu.perCore.length > 0 && (
-              <div className="mt-3 grid grid-cols-8 gap-1">
-                {systemInfo.cpu.perCore.map((p, i) => (
-                  <div key={i} title={`Core ${i}: ${p.toFixed(1)}%`} className="h-6 rounded-sm bg-muted overflow-hidden flex items-end">
-                    <div className="w-full bg-primary/70 transition-[height] duration-500" style={{ height: `${Math.max(4, p)}%` }} />
+              (() => {
+                const n = systemInfo.cpu.perCore.length;
+                const { cols, rows } = bestGrid(n);
+                const total = cols * rows;
+                return (
+                  <div
+                    className="mt-3 overflow-hidden"
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: `repeat(${cols}, 1fr)`,
+                      gridTemplateRows: `repeat(${rows}, 1fr)`,
+                      gap: 2,
+                      height: 80,
+                    }}
+                  >
+                    {systemInfo.cpu.perCore.map((p, i) => (
+                      <div key={i} title={`Core ${i}: ${p.toFixed(1)}%`} className="rounded-sm bg-muted overflow-hidden relative">
+                        <div className="absolute bottom-0 left-0 right-0 bg-primary/70 transition-[height] duration-500" style={{ height: `${Math.max(2, p)}%` }} />
+                      </div>
+                    ))}
+                    {Array.from({ length: total - n }).map((_, i) => (
+                      <div key={`e-${i}`} className="rounded-sm bg-muted" style={{ visibility: 'hidden' }} />
+                    ))}
                   </div>
-                ))}
-              </div>
+                );
+              })()
             )}
           </div>
         )}


### PR DESCRIPTION
## 概述

将固定的 grid-cols-8 每核心条形图显示替换为动态计算的方形网格，该网格填充固定高度（80px）的容器。

## 关联

- Closes #140

---

## 变更清单

| 文件路径 | 变更描述 |
|---------|---------|
| `packages/webui/src/components/pages/overview-page.tsx` | 新增 bestGrid() 工具函数，用于计算最优网格布局 |
| `packages/webui/src/components/pages/overview-page.tsx` | 替换固定 grid-cols-8 布局为动态计算的网格 |
| `packages/webui/src/components/pages/overview-page.tsx` | 添加隐藏的占位元素以填充空单元格 |

---

## 设计决策

选择动态计算网格而非固定布局，原因：
1. 支持不同数量的CPU核心（测试最多256个）
2. 避免滚动条，保持界面整洁
3. 最小化空单元格，平衡网格宽高比

---

## 测试验证

1. 在不同CPU核心数的系统上测试（1-256核）
2. 验证网格自适应填充80px高度容器
3. 确认无滚动条出现
4. 检查颜色token保持一致（bg-muted, bg-primary/70）

---

## 未做的 / 后续计划

无（本PR专注于网格布局优化）

---

## 注意事项

- 网格计算算法使用 waste * 20 + balance 的评分机制
- 隐藏的占位元素确保布局稳定

---

### 自检

- [x] 基于 `dev` 分支，非 `main`
- [x] `pnpm typecheck` + `pnpm test` 通过
- [x] 一个 PR 只做一件事
- [x] Commit 格式：`feat(scope): <subject>`