### PR TITLE
fix: 修复合并转发中群聊文件无法下载、支持base64格式传入

### DIFF
--- a/packages/core/src/bridge/apis/forward.ts
+++ b/packages/core/src/bridge/apis/forward.ts
@@ -14,7 +14,7 @@ import { protobuf_decode, protobuf_encode } from '@snowluma/proton';
 import { randomUUID } from 'crypto';
 import { gunzipSync, gzipSync } from 'zlib';
 import type { Bridge } from '../bridge';
-import type { BridgeContext } from '../bridge-context';
+import type { BridgeContext, UploadedFileMeta } from '../bridge-context';
 import { resolveSelfUid, toInt } from './shared';
 
 function asBridge(ctx: BridgeContext): Bridge { return ctx as unknown as Bridge; }
@@ -202,12 +202,147 @@ function previewFromElements(elements: MessageElement[]): string {
   return '';
 }
 
+function cloneNodeWithElements(node: ForwardNodePayload, elements: MessageElement[]): ForwardNodePayload {
+  return {
+    userUin: node.userUin,
+    nickname: node.nickname,
+    elements,
+    time: node.time,
+    msgId: node.msgId,
+    msgSeq: node.msgSeq,
+    groupId: node.groupId,
+    senderCard: node.senderCard,
+    messageType: node.messageType,
+    innerForward: node.innerForward,
+  };
+}
+
+function stripFileSource(element: MessageElement): MessageElement {
+  const next: MessageElement = { ...element };
+  delete next.url;
+  return next;
+}
+
+function isCachedFileUsableInTarget(
+  cached: UploadedFileMeta | undefined,
+  groupId?: number,
+  userId?: number,
+): boolean {
+  if (!cached) return true;
+  if (groupId !== undefined) {
+    return cached.scope === 'group' && cached.groupId === groupId;
+  }
+  if (userId !== undefined) {
+    return cached.scope === 'private' && cached.userId === userId;
+  }
+  return true;
+}
+
+function fileNameForUpload(element: MessageElement, cached?: UploadedFileMeta): string {
+  return (element.fileName ?? cached?.fileName ?? '').trim();
+}
+
 export class ForwardApi {
   constructor(private readonly ctx: BridgeContext) { }
 
   async upload(nodes: ForwardNodePayload[], groupId?: number, userId?: number): Promise<string> {
     const { resId } = await this.uploadRecursive(nodes, groupId, userId);
     return resId;
+  }
+
+  private async downloadSourceFromCachedFile(cached: UploadedFileMeta): Promise<string> {
+    if (cached.scope === 'group' && cached.groupId !== undefined) {
+      return this.ctx.apis.groupFile.getUrl(cached.groupId, cached.fileId);
+    }
+    if (cached.scope === 'private' && cached.userId !== undefined && cached.fileHash) {
+      return this.ctx.apis.groupFile.getPrivateUrl(cached.userId, cached.fileId, cached.fileHash);
+    }
+    throw new Error('forward file_id belongs to another scope; pass file/base64/url so SnowLuma can re-upload it');
+  }
+
+  private async uploadForwardFileSource(
+    source: string,
+    name: string,
+    groupId?: number,
+    userId?: number,
+  ): Promise<MessageElement> {
+    if (groupId !== undefined) {
+      const uploaded = await this.ctx.apis.groupFile.upload(groupId, source, name, '/', true, false);
+      if (!uploaded.fileId) throw new Error('forward group file upload returned no file_id');
+      const cached = this.ctx.recallUploadedFile(uploaded.fileId);
+      const element: MessageElement = {
+        type: 'file',
+        fileId: uploaded.fileId,
+      };
+      const fileName = cached?.fileName || name;
+      if (fileName) element.fileName = fileName;
+      if (cached?.fileSize !== undefined) element.fileSize = cached.fileSize;
+      return element;
+    }
+    if (userId !== undefined) {
+      const uploaded = await this.ctx.apis.groupFile.uploadPrivate(userId, source, name, true, false);
+      if (!uploaded.fileId) throw new Error('forward private file upload returned no file_id');
+      const cached = this.ctx.recallUploadedFile(uploaded.fileId);
+      const element: MessageElement = {
+        type: 'file',
+        fileId: uploaded.fileId,
+      };
+      const fileName = cached?.fileName || name;
+      const fileHash = uploaded.fileHash ?? cached?.fileHash ?? '';
+      if (fileName) element.fileName = fileName;
+      if (cached?.fileSize !== undefined) element.fileSize = cached.fileSize;
+      if (fileHash) element.fileHash = fileHash;
+      return element;
+    }
+    throw new Error('forward file source requires group_id or user_id');
+  }
+
+  private async prepareForwardFileElement(
+    element: MessageElement,
+    groupId?: number,
+    userId?: number,
+  ): Promise<MessageElement> {
+    if (element.type !== 'file') return element;
+
+    const source = (element.url ?? '').trim();
+    if (source && !element.fileId) {
+      const uploaded = await this.uploadForwardFileSource(source, fileNameForUpload(element), groupId, userId);
+      return {
+        ...stripFileSource(element),
+        ...uploaded,
+      };
+    }
+
+    if (element.fileId) {
+      const cached = this.ctx.recallUploadedFile(element.fileId);
+      if (isCachedFileUsableInTarget(cached, groupId, userId)) return element;
+      const sourceFromCache = await this.downloadSourceFromCachedFile(cached!);
+      const uploaded = await this.uploadForwardFileSource(
+        sourceFromCache,
+        fileNameForUpload(element, cached),
+        groupId,
+        userId,
+      );
+      return {
+        ...stripFileSource(element),
+        ...uploaded,
+      };
+    }
+
+    return element;
+  }
+
+  private async prepareForwardFiles(
+    nodes: ForwardNodePayload[],
+    groupId?: number,
+    userId?: number,
+  ): Promise<ForwardNodePayload[]> {
+    return Promise.all(nodes.map(async (node) => {
+      const elements = await Promise.all(node.elements.map(
+        element => this.prepareForwardFileElement(element, groupId, userId),
+      ));
+      return cloneNodeWithElements(node, elements);
+    }));
   }
 
   /**
@@ -304,8 +439,10 @@ export class ForwardApi {
       }
     }
 
+    const uploadReadyNodes = await this.prepareForwardFiles(processedNodes, groupId, userId);
+
     // Encode this level's msgBody.
-    const msgBody = await Promise.all(processedNodes.map(
+    const msgBody = await Promise.all(uploadReadyNodes.map(
       node => buildForwardPushBody(bridge, node, groupId, userUid),
     ));
 
@@ -349,7 +486,7 @@ export class ForwardApi {
       throw new Error('upload forward message response missing res_id');
     }
 
-    forwardResCache.set(resId, processedNodes.map(node => ({
+    forwardResCache.set(resId, uploadReadyNodes.map(node => ({
       userUin: node.userUin,
       nickname: node.nickname,
       elements: [...node.elements],

--- a/packages/core/src/bridge/apis/group-file.ts
+++ b/packages/core/src/bridge/apis/group-file.ts
@@ -241,6 +241,7 @@ export class GroupFileApi {
     name = '',
     folderId = '/',
     uploadFile = true,
+    publishFile = uploadFile,
   ): Promise<UploadFileResult> {
     const bridge = asBridge(this.ctx);
     // Group/private files may legitimately be up to 4 GiB on QQ's wire,
@@ -316,11 +317,11 @@ export class GroupFileApi {
     // the chat shows nothing. The publish step goes via a dedicated OIDB
     // call (0x6D9_4), NOT via `MessageSvc.PbSendMsg` with a transElem(24)
     // payload — the QQ-NT server rejects that with `result=79`. Mirrors
-    // Lagrange.Core V2's `GroupSendFileService.cs`. Suppressed when the
-    // caller opts out via `uploadFile=false` (treat that as "I only
-    // wanted the slot allocated, hold the chat post"). Routes through
-    // `this.publish` so tests can mock at the same Api boundary.
-    if (uploadFile) {
+    // Lagrange.Core V2's `GroupSendFileService.cs`. Suppressed when a
+    // caller only needs a valid file_id embedded elsewhere, e.g. a
+    // forward-message long-msg payload. Routes through `this.publish` so
+    // tests can mock at the same Api boundary.
+    if (publishFile) {
       try {
         await this.publish(groupId, fileId);
       } catch (err) {
@@ -341,6 +342,7 @@ export class GroupFileApi {
     source: string,
     name = '',
     uploadFile = true,
+    publishFile = uploadFile,
   ): Promise<UploadFileResult> {
     const bridge = asBridge(this.ctx);
     const loaded = await loadBinarySource(source, 'file', FILE_UPLOAD_MAX_BYTES);
@@ -482,7 +484,7 @@ export class GroupFileApi {
     // which only knows about elems[]. NapCat does the same atomic
     // upload+send dance — without it the file sits on the server and
     // the recipient sees nothing.
-    if (uploadFile) {
+    if (publishFile) {
       try {
         await this.ctx.apis.message.sendC2cFile(userId, targetUid, {
           fileId,

--- a/packages/core/tests/actions/forward-file.test.ts
+++ b/packages/core/tests/actions/forward-file.test.ts
@@ -165,4 +165,156 @@ describe('actions/forward — file segment inside forward node', () => {
 
     expect(recallUploadedFile).toHaveBeenCalledWith('pfid-cached');
   });
+
+  it('group forward pre-uploads file sources into the target group without publishing a separate file message', async () => {
+    buildSendElemsMock.mockClear();
+    const upload = vi.fn(async () => ({ fileId: 'gfid-from-base64' }));
+    const publish = vi.fn();
+    const bridge = mockBridge({
+      sendRawPacket: vi.fn(async () => uploadResponseWithResId('res-grp-source')) as any,
+      apis: {
+        ...mockBridge().apis,
+        groupFile: {
+          ...mockBridge().apis.groupFile,
+          upload,
+          publish,
+        },
+      },
+      recallUploadedFile: vi.fn((id: string) => id === 'gfid-from-base64' ? {
+        fileId: 'gfid-from-base64',
+        scope: 'group' as const,
+        groupId: 12345,
+        fileName: 'note.txt',
+        fileSize: 3,
+        fileMd5: new Uint8Array(16),
+        fileSha1: new Uint8Array(20),
+        rememberedAt: 0,
+      } : undefined),
+    });
+
+    await new ForwardApi(bridge as any).upload([{
+      userUin: 10001,
+      nickname: 'alice',
+      elements: [{ type: 'file', url: 'base64://AQID', fileName: 'note.txt' } as any],
+    }], 12345);
+
+    expect(upload).toHaveBeenCalledWith(12345, 'base64://AQID', 'note.txt', '/', true, false);
+    expect(publish).not.toHaveBeenCalled();
+    const [elements] = buildSendElemsMock.mock.calls[0]!;
+    expect(elements).toEqual([expect.objectContaining({
+      type: 'file',
+      fileId: 'gfid-from-base64',
+      fileName: 'note.txt',
+      fileSize: 3,
+    })]);
+  });
+
+  it('private forward pre-uploads file sources without sending a standalone c2c file message', async () => {
+    buildSendElemsMock.mockClear();
+    const uploadPrivate = vi.fn(async () => ({ fileId: 'pfid-from-base64', fileHash: 'phash' }));
+    const sendC2cFile = vi.fn();
+    const bridge = mockBridge({
+      sendRawPacket: vi.fn(async () => uploadResponseWithResId('res-c2c-source')) as any,
+      apis: {
+        ...mockBridge().apis,
+        message: {
+          ...mockBridge().apis.message,
+          sendC2cFile,
+        },
+        groupFile: {
+          ...mockBridge().apis.groupFile,
+          uploadPrivate,
+        },
+      },
+      recallUploadedFile: vi.fn((id: string) => id === 'pfid-from-base64' ? {
+        fileId: 'pfid-from-base64',
+        scope: 'private' as const,
+        userId: 67890,
+        fileName: 'note.txt',
+        fileSize: 3,
+        fileMd5: new Uint8Array(16),
+        fileSha1: new Uint8Array(20),
+        fileHash: 'phash',
+        rememberedAt: 0,
+      } : undefined),
+    });
+
+    await new ForwardApi(bridge as any).upload([{
+      userUin: 10001,
+      nickname: 'alice',
+      elements: [{ type: 'file', url: 'base64://AQID', fileName: 'note.txt' } as any],
+    }], undefined, 67890);
+
+    expect(uploadPrivate).toHaveBeenCalledWith(67890, 'base64://AQID', 'note.txt', true, false);
+    expect(sendC2cFile).not.toHaveBeenCalled();
+    const [elements] = buildSendElemsMock.mock.calls[0]!;
+    expect(elements).toEqual([expect.objectContaining({
+      type: 'file',
+      fileId: 'pfid-from-base64',
+      fileName: 'note.txt',
+      fileSize: 3,
+      fileHash: 'phash',
+    })]);
+  });
+
+  it('group forward re-uploads a cached private file_id into the target group scope', async () => {
+    buildSendElemsMock.mockClear();
+    const getPrivateUrl = vi.fn(async () => 'https://download.test/private-file');
+    const upload = vi.fn(async () => ({ fileId: 'gfid-reuploaded' }));
+    const bridge = mockBridge({
+      sendRawPacket: vi.fn(async () => uploadResponseWithResId('res-cross-scope')) as any,
+      apis: {
+        ...mockBridge().apis,
+        groupFile: {
+          ...mockBridge().apis.groupFile,
+          getPrivateUrl,
+          upload,
+        },
+      },
+      recallUploadedFile: vi.fn((id: string) => {
+        if (id === 'pfid-cached') {
+          return {
+            fileId: 'pfid-cached',
+            scope: 'private' as const,
+            userId: 67890,
+            fileName: 'cached.txt',
+            fileSize: 5,
+            fileMd5: new Uint8Array(16),
+            fileSha1: new Uint8Array(20),
+            fileHash: 'cached-hash',
+            rememberedAt: 0,
+          };
+        }
+        if (id === 'gfid-reuploaded') {
+          return {
+            fileId: 'gfid-reuploaded',
+            scope: 'group' as const,
+            groupId: 12345,
+            fileName: 'cached.txt',
+            fileSize: 5,
+            fileMd5: new Uint8Array(16),
+            fileSha1: new Uint8Array(20),
+            rememberedAt: 1,
+          };
+        }
+        return undefined;
+      }),
+    });
+
+    await new ForwardApi(bridge as any).upload([{
+      userUin: 10001,
+      nickname: 'alice',
+      elements: [{ type: 'file', fileId: 'pfid-cached' } as any],
+    }], 12345);
+
+    expect(getPrivateUrl).toHaveBeenCalledWith(67890, 'pfid-cached', 'cached-hash');
+    expect(upload).toHaveBeenCalledWith(12345, 'https://download.test/private-file', 'cached.txt', '/', true, false);
+    const [elements] = buildSendElemsMock.mock.calls[0]!;
+    expect(elements).toEqual([expect.objectContaining({
+      type: 'file',
+      fileId: 'gfid-reuploaded',
+      fileName: 'cached.txt',
+      fileSize: 5,
+    })]);
+  });
 });

--- a/packages/core/tests/actions/group-file.test.ts
+++ b/packages/core/tests/actions/group-file.test.ts
@@ -170,6 +170,28 @@ describe('apis/group-file', () => {
     expect(publishSpy).not.toHaveBeenCalled();
   });
 
+  it('upload can PUT bytes without publishing a separate group file message', async () => {
+    const bridge = mockBridge();
+    bridge.sendRawPacket.mockResolvedValueOnce(packResponse(
+      protobuf_encode<OidbBase<OidbGroupFileResp>>({
+        body: {
+          upload: {
+            fileId: 'fid-forward',
+            uploadIp: '127.0.0.1',
+            uploadPort: 443,
+            fileKey: new Uint8Array([1]),
+            checkKey: new Uint8Array([2]),
+          } as any,
+        },
+      }),
+    ));
+    const api = new GroupFileApi(bridge as any);
+    const publishSpy = vi.spyOn(api, 'publish').mockResolvedValue();
+    await api.upload(12345, 'base64://AQID', 'forward.txt', '/', true, false);
+    expect(highwayClient.uploadHighwayHttp).toHaveBeenCalledOnce();
+    expect(publishSpy).not.toHaveBeenCalled();
+  });
+
   it('upload returns success even when the chat post fails (file is still uploaded)', async () => {
     const bridge = mockBridge();
     bridge.sendRawPacket.mockResolvedValueOnce(packResponse(
@@ -295,6 +317,28 @@ describe('apis/group-file', () => {
       }),
     ));
     await new GroupFileApi(bridge as any).uploadPrivate(67890, '/path/file', '', false);
+    expect(bridge.apis.message.sendC2cFile).not.toHaveBeenCalled();
+  });
+
+  it('uploadPrivate can PUT bytes without publishing a separate c2c file message', async () => {
+    const bridge = mockBridge();
+    vi.mocked(bridge.resolveUserUid).mockResolvedValueOnce('target-uid');
+    bridge.sendRawPacket.mockResolvedValueOnce(packResponse(
+      protobuf_encode<OidbBase<OidbPrivateFileUploadResp>>({
+        body: {
+          upload: {
+            uuid: 'pfid-forward',
+            fileAddon: 'phash-forward',
+            rtpMediaPlatformUploadAddress: [
+              { outIP: 0, outPort: 0, inIP: 16885952, inPort: 8080, iPType: 1 },
+            ],
+            mediaPlatformUploadKey: new Uint8Array([1, 2, 3]),
+          } as any,
+        },
+      }),
+    ));
+    await new GroupFileApi(bridge as any).uploadPrivate(67890, 'base64://AQID', 'forward.txt', true, false);
+    expect(highwayClient.uploadHighwayHttp).toHaveBeenCalledOnce();
     expect(bridge.apis.message.sendC2cFile).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
修复跨群/私聊作用域时，合并转发中文件无法下载的问题；

支持直接以base64格式在合并转发节点中嵌入文件；

## 变更说明
参考NapCat实现：
- [forward.ts](/SnowLuma/SnowLuma/packages/core/src/bridge/apis/forward.ts)：
  - 新增 forward 文件预处理层：
  - 如果文件元素带 url/base64/file source 且没有 fileId，先上传到目标群或目标私聊。
  - 如果已有 fileId，但缓存显示它属于另一个作用域，比如私聊文件要转发到群，就先取下载 URL，再重传到目标作用域。
  - 上传后把节点里的文件元素替换为新的 { type: 'file', fileId, fileName, fileSize, fileHash }。
  - 用处理后的 uploadReadyNodes 生成 long-msg payload，并写入 forwardResCache，保证后续 get_forward_msg 看到的也是目标作用域可用的文件引用。

- [group-file.ts](/SnowLuma/SnowLuma/packages/core/src/bridge/apis/group-file.ts)：
   - forward 预处理时传 publishFile=false，只完成 OIDB 预申请和 highway PUT，拿到可嵌入 long-msg 的 fileId/fileHash，不额外发一条独立文件消息。

- [forward-file.test.ts](/SnowLuma/SnowLuma/packages/core/tests/actions/forward-file.test.ts)：
  - 覆盖文件 source 预上传、私聊不单独发送、self uid namespace、跨作用域重传。

- [group-file.test.ts](/SnowLuma/SnowLuma/packages/core/tests/actions/group-file.test.ts)：
  - 覆盖 group/private 上传时 `publishFile=false` 仍 PUT bytes 但不发布消息。
