### PR TITLE
fix: 好友推荐卡无法发送

### DIFF
--- a/packages/onebot/src/message-parser.ts
+++ b/packages/onebot/src/message-parser.ts
@@ -9,6 +9,7 @@ export interface ParseMessageOptions {
   resolveReplySequence?: (replyMessageId: number) => number | null;
   resolveReplyMeta?: (replyMessageId: number) => { senderUin: number; time: number; random: number } | null;
   resolveMentionUid?: (targetUin: number) => string | null | Promise<string | null>;
+  resolveContactArk?: (contactType: string, contactId: number) => string | null | Promise<string | null>;
   musicSignUrl?: string;
 }
 
@@ -291,6 +292,13 @@ export async function segmentToElement(type: string, data: Record<string, unknow
       // Contact card — map to json card
       const contactType = String(data.type ?? 'qq');
       const contactId = String(data.id ?? '');
+      const numericId = intOr(contactId, 0);
+      const normalizedContactType = contactType.trim().toLowerCase();
+      if (numericId > 0 && options?.resolveContactArk && (normalizedContactType === 'qq' || normalizedContactType === 'group')) {
+        const ark = await options.resolveContactArk(contactType, numericId);
+        if (!ark) throw new Error(`contact ark unavailable for ${contactType}:${numericId}`);
+        return { type: 'json', text: ark };
+      }
       const jsonData = JSON.stringify({
         app: 'com.tencent.contact.lua',
         view: 'contact',

--- a/packages/onebot/src/modules/message-actions.ts
+++ b/packages/onebot/src/modules/message-actions.ts
@@ -448,6 +448,13 @@ async function cacheSelfSentMessage(
   }
 }
 
+function resolveContactArk(ref: OneBotInstanceContext, contactType: string, contactId: number): Promise<string> | null {
+  const normalized = contactType.trim().toLowerCase();
+  if (normalized === 'qq') return ref.bridge.apis.contacts.getBuddyRecommendArk(contactId, '');
+  if (normalized === 'group') return ref.bridge.apis.contacts.getGroupRecommendArk(contactId);
+  return null;
+}
+
 export async function sendPrivateMessage(
   ref: OneBotInstanceContext,
   userId: number,
@@ -492,6 +499,7 @@ export async function sendPrivateMessage(
       return null;
     },
     resolveMentionUid: (targetUin) => ref.bridge.resolveUserUid(targetUin),
+    resolveContactArk: (contactType, contactId) => resolveContactArk(ref, contactType, contactId),
     musicSignUrl: ref.musicSignUrl,
   });
   if (elements.length === 0) throw new Error('message is empty');
@@ -595,6 +603,7 @@ export async function sendGroupMessage(
       return null;
     },
     resolveMentionUid: (targetUin) => ref.bridge.resolveUserUid(targetUin, groupId),
+    resolveContactArk: (contactType, contactId) => resolveContactArk(ref, contactType, contactId),
     musicSignUrl: ref.musicSignUrl,
   });
   if (elements.length === 0) throw new Error('message is empty');

--- a/packages/proto-defs/src/oidb-actions/contact-ark.ts
+++ b/packages/proto-defs/src/oidb-actions/contact-ark.ts
@@ -1,8 +1,7 @@
 // Recommend-contact ARK card protobufs, RE'd from QQNT wrapper.linux.node.
 //
-// Buddy: OidbSvcTrpcTcp.0x9130_0 (getBuddyRecommendContactArkJson) — encoder
-//   `buddy_recommend_contact_ark_json.cc::EncodeRequest` writes {1:uin,
-//   2:phone,3:jump_url}; decoder reads {1:ark json}.
+// Buddy: OidbSvcTrpcTcp.0x12b6_0 (getBuddyRecommendContactArkJson) —
+//   request writes {1:uin, 2:phone, 3:jump_url}; response reads {1:ark}.
 // Group: OidbSvcTrpcTcp.0x8b7_5 (getGroupRecommendContactArkJson) — encoder
 //   `group_get_ark_json_worker.cc::EncodeRequest` writes {1:reqType=1,
 //   2:groupCode,5:flag=1}; response (group_info_mgr.cc `[gp_get_ark_json]`)
@@ -12,12 +11,12 @@
 import type { pb, uint_32 } from '@snowluma/proton';
 
 export interface OidbBuddyRecommendArkReq {
-  uin?:      pb<1, uint_32>;
-  phoneNum?: pb<2, string>;
-  jumpUrl?:  pb<3, string>;
+  uin?:         pb<1, uint_32>;
+  phoneNumber?: pb<2, string>;
+  jumpUrl?:     pb<3, string>;
 }
 export interface OidbBuddyRecommendArkResp {
-  arkJson?: pb<1, string>;
+  ark?: pb<1, string>;
 }
 
 export interface OidbGroupRecommendArkReq {

--- a/packages/protocol/src/oidb-services/contacts/get-buddy-recommend-ark.ts
+++ b/packages/protocol/src/oidb-services/contacts/get-buddy-recommend-ark.ts
@@ -1,8 +1,7 @@
-// 0x9130_0 — getBuddyRecommendContactArkJson: ask the server to build a
+// 0x12b6_0 — getBuddyRecommendContactArkJson: ask the server to build a
 // "recommend contact" ARK share card for a friend (by uin). Returns the
-// ark JSON string the card is rendered from. RE'd from QQNT
-// buddy_recommend_contact_ark_json.cc (EncodeRequest writes uin/phone/jump_url;
-// DecodeResponse reads field 1 = ark json). uin-form OIDB (envelope reserved=1).
+// ark JSON string the card is rendered from. The request body writes
+// uin/phone/jump_url; response body field 1 is the ark string.
 
 import { protobuf_decode, protobuf_encode } from '@snowluma/proton';
 import type { OidbBase } from '@snowluma/proto-defs/oidb';
@@ -12,22 +11,22 @@ import type {
 import { invokeOidb, type OidbSender } from '../../oidb-service';
 
 export namespace GetBuddyRecommendArk {
-  export const command = 0x9130;
+  export const command = 0x12B6;
   export const subCommand = 0;
-  export const uinForm = true;
+  export const uinForm = false;
 
   export interface Params { userId: number; phoneNumber?: string }
   export type Deps = OidbSender;
 
   export const serialize = (_ctx: Deps, p: Params): OidbBuddyRecommendArkReq => ({
     uin: p.userId,
-    phoneNum: p.phoneNumber ?? '',
+    phoneNumber: p.phoneNumber || '-',
     // Client-side jump_url the kernel hard-codes alongside the uin; the
     // server echoes it into the card. Mirrors the NT template exactly.
     jumpUrl: `mqqapi://card/show_pslcard?src_type=internal&source=sharecard&version=1&uin=${p.userId}`,
   });
 
-  export const deserialize = (_ctx: Deps, body: OidbBuddyRecommendArkResp): string => body.arkJson ?? '';
+  export const deserialize = (_ctx: Deps, body: OidbBuddyRecommendArkResp): string => body.ark ?? '';
 
   export const encode = (env: OidbBase<OidbBuddyRecommendArkReq>): Uint8Array =>
     protobuf_encode<OidbBase<OidbBuddyRecommendArkReq>>(env);

--- a/packages/protocol/tests/oidb-services/contacts/get-buddy-recommend-ark.test.ts
+++ b/packages/protocol/tests/oidb-services/contacts/get-buddy-recommend-ark.test.ts
@@ -6,8 +6,8 @@ import type { SendPacketResult } from '@snowluma/common/packet-sender';
 import { GetBuddyRecommendArk } from '../../../src/oidb-services/contacts/get-buddy-recommend-ark';
 import { env, v, s } from '../_pb-oracle';
 
-function makeSender(arkJson = '{"app":"com.tencent.contact.lua"}') {
-  const respEnv: OidbBase<OidbBuddyRecommendArkResp> = { command: 0x9130, subCommand: 0, body: { arkJson } };
+function makeSender(ark = '{"app":"com.tencent.contact.lua"}') {
+  const respEnv: OidbBase<OidbBuddyRecommendArkResp> = { command: 0x12B6, subCommand: 0, body: { ark } };
   const r: SendPacketResult = {
     success: true, gotResponse: true, errorCode: 0, errorMessage: '',
     responseData: Buffer.from(protobuf_encode<OidbBase<OidbBuddyRecommendArkResp>>(respEnv)),
@@ -16,38 +16,37 @@ function makeSender(arkJson = '{"app":"com.tencent.contact.lua"}') {
 }
 
 describe('GetBuddyRecommendArk namespace', () => {
-  it('declares command 0x9130 sub 0, uin form', () => {
-    expect(GetBuddyRecommendArk.command).toBe(0x9130);
+  it('declares command 0x12b6 sub 0, plain OIDB envelope', () => {
+    expect(GetBuddyRecommendArk.command).toBe(0x12B6);
     expect(GetBuddyRecommendArk.subCommand).toBe(0);
-    expect(GetBuddyRecommendArk.uinForm).toBe(true);
+    expect(GetBuddyRecommendArk.uinForm).toBe(false);
   });
 
-  it('serializes uin + the hard-coded jump_url template (phone defaults to empty)', () => {
+  it('serializes uin + phone placeholder + the hard-coded jump_url template', () => {
     const out = GetBuddyRecommendArk.serialize({} as any, { userId: 5 });
-    expect(out).toMatchObject({ uin: 5, phoneNum: '' });
+    expect(out).toMatchObject({ uin: 5, phoneNumber: '-' });
     expect(out.jumpUrl).toBe('mqqapi://card/show_pslcard?src_type=internal&source=sharecard&version=1&uin=5');
   });
 
-  it('byte-oracle: routes to 0x9130_0 and locks req tags {1:uin, 2:phone, 3:jumpUrl}', async () => {
+  it('byte-oracle: routes to 0x12b6_0 and locks req tags {1:uin, 2:phone, 3:jumpUrl}', async () => {
     const sender = makeSender();
     const ark = await GetBuddyRecommendArk.invoke(sender, { userId: 10000 });
     expect(ark).toBe('{"app":"com.tencent.contact.lua"}');
 
     const [cmd, bytes] = sender.sendRawPacket.mock.calls[0]!;
-    expect(cmd).toBe('OidbSvcTrpcTcp.0x9130_0');
+    expect(cmd).toBe('OidbSvcTrpcTcp.0x12b6_0');
     const jumpUrl = 'mqqapi://card/show_pslcard?src_type=internal&source=sharecard&version=1&uin=10000';
-    // phoneNum '' is a proto3 default → omitted; only tags 1 + 3 present.
-    const body = [...v(1, 10000), ...s(3, jumpUrl)];
-    expect(Buffer.from(bytes).toString('hex')).toBe(env(0x9130, 0, body, true));
+    const body = [...v(1, 10000), ...s(2, '-'), ...s(3, jumpUrl)];
+    expect(Buffer.from(bytes).toString('hex')).toBe(env(0x12B6, 0, body, false));
   });
 
   it('includes phone tag 2 when a phone number is provided', () => {
     const out = GetBuddyRecommendArk.serialize({} as any, { userId: 7, phoneNumber: '123' });
-    expect(out.phoneNum).toBe('123');
+    expect(out.phoneNumber).toBe('123');
   });
 
   it('deserialize returns the ark json string ("" when absent)', () => {
-    expect(GetBuddyRecommendArk.deserialize({} as any, { arkJson: 'x' })).toBe('x');
+    expect(GetBuddyRecommendArk.deserialize({} as any, { ark: 'x' })).toBe('x');
     expect(GetBuddyRecommendArk.deserialize({} as any, {})).toBe('');
   });
 });


### PR DESCRIPTION
## 解决的问题

#148 

本 PR 修复 OneBot 名片卡相关能力中服务端 ark 获取不正确的问题：好友名片 ark 请求使用了错误的 OIDB 命令、envelope 形态和响应字段，导致 `/share_peer` 可能返回空 ark；同时发送消息链路没有把名片卡转换为服务端生成的 ark，导致 `/send_msg` 无法正确发出好友名片卡。

## 文件改动说明

### `packages/protocol/src/oidb-services/contacts/get-buddy-recommend-ark.ts`

- 将好友推荐 ark 的 OIDB command 从 `0x9130` 改为 `0x12B6`。
- 将 `uinForm` 从 `true` 改为 `false`，匹配新的 plain OIDB envelope。
- 请求体字段从 `phoneNum` 改为 `phoneNumber`。
- 空手机号默认值从空字符串改为 `-`。
- 响应读取字段从 `arkJson` 改为 `ark`。

这部分是修复空 ark 的核心协议改动。

### `packages/proto-defs/src/oidb-actions/contact-ark.ts`

- 更新好友推荐 ark 的 protobuf 类型定义。
- 请求字段改为 `phoneNumber?: pb<2, string>`。
- 响应字段改为 `ark?: pb<1, string>`。
- 同步更新顶部注释中的 OIDB 命令与字段说明。

这部分保证协议层编码/解码字段和服务端实际返回一致。

### `packages/protocol/tests/oidb-services/contacts/get-buddy-recommend-ark.test.ts`

- 更新已有协议测试，使其锁定新的 `0x12b6_0` 路由。
- 更新 envelope 断言为非 uinForm。
- 更新 byte-oracle 请求体，包含 tag 2 的 `-` 占位手机号。
- 更新响应字段断言为 `ark`。

这部分用于防止好友 ark 协议形态再次回退。

### `packages/onebot/src/message-parser.ts`

- 新增解析选项 `resolveContactArk`。
- 在名片卡解析时，如果存在有效 id 且发送路径提供了 resolver，则优先使用服务端 ark。
- 没有 resolver 时仍保留原本的本地 JSON fallback，避免影响非发送场景或内部复用解析器的路径。

这部分让 OneBot 消息解析层具备“按需转服务端 ark”的能力。

### `packages/onebot/src/modules/message-actions.ts`

- 新增 `resolveContactArk` helper。
- 私聊和群聊发送路径都向 `parseMessage` 注入该 resolver。
- resolver 内部按名片类型路由到：
  - 好友名片：`getBuddyRecommendArk`
  - 群名片：`getGroupRecommendArk`

这部分把 `/send_msg` 的消息发送链路接到协议层 ark 获取能力上。