### PR TITLE
feat(core,onebot): implement trans_group_file action

### DIFF
--- a/packages/core/src/bridge/apis/group-file.ts
+++ b/packages/core/src/bridge/apis/group-file.ts
@@ -23,6 +23,7 @@ import { MoveGroupFile } from '@snowluma/protocol/oidb-services/group-file/move-
 import { PublishGroupFile } from '@snowluma/protocol/oidb-services/group-file/publish-group-file';
 import { RenameGroupFile } from '@snowluma/protocol/oidb-services/group-file/rename-group-file';
 import { RenameGroupFolder } from '@snowluma/protocol/oidb-services/group-file/rename-group-folder';
+import { TransGroupFile, type TransGroupFileResult } from '@snowluma/protocol/oidb-services/group-file/trans-group-file';
 import { UploadGroupFileRequest } from '@snowluma/protocol/oidb-services/group-file/upload-group-file-request';
 import { UploadPrivateFileRequest } from '@snowluma/protocol/oidb-services/group-file/upload-private-file-request';
 import { ensureRetCodeZero } from '@snowluma/protocol/oidb-services/shared';
@@ -225,6 +226,11 @@ export class GroupFileApi {
   publish(groupId: number, fileId: string): Promise<void> {
     if (!fileId) throw new Error('publish requires fileId');
     return PublishGroupFile.invoke(this.ctx, { groupId, fileId });
+  }
+
+  trans(groupId: number, fileId: string): Promise<TransGroupFileResult> {
+    if (!fileId) throw new Error('trans requires fileId');
+    return TransGroupFile.invoke(this.ctx, { groupId, fileId });
   }
 
   // ─────────────── count ───────────────

--- a/packages/core/tests/actions/_helpers.ts
+++ b/packages/core/tests/actions/_helpers.ts
@@ -65,6 +65,7 @@ export interface MockGroupFileApi {
   upload: ReturnType<typeof vi.fn>;
   uploadPrivate: ReturnType<typeof vi.fn>;
   publish: ReturnType<typeof vi.fn>;
+  trans: ReturnType<typeof vi.fn>;
   getCount: ReturnType<typeof vi.fn>;
   list: ReturnType<typeof vi.fn>;
   getUrl: ReturnType<typeof vi.fn>;
@@ -85,6 +86,7 @@ export function mockGroupFileApi(): MockGroupFileApi {
     upload: vi.fn(async () => ({ fileId: 'stub-fid' })),
     uploadPrivate: vi.fn(async () => ({ fileId: 'stub-pfid', fileHash: 'stub-hash' })),
     publish: vi.fn(async () => undefined),
+    trans: vi.fn(async () => ({ saveBusId: 102, saveFilePath: '/stub-path' })),
     getCount: vi.fn(async () => ({ fileCount: 0, maxCount: 10000 })),
     list: vi.fn(async () => ({ files: [], folders: [] })),
     getUrl: vi.fn(async () => 'stub://url'),

--- a/packages/core/tests/actions/group-file.test.ts
+++ b/packages/core/tests/actions/group-file.test.ts
@@ -8,6 +8,7 @@ import type {
   OidbGroupFileViewResp,
   OidbGroupFileFolderResp,
   OidbGroupSendFileReq,
+  OidbGroupSendFileResp,
 } from '@snowluma/proto-defs/oidb-actions/group-file';
 import type {
   OidbPrivateFileUploadResp,
@@ -243,6 +244,26 @@ describe('apis/group-file', () => {
         fileId: 'fid-publish',
         field5: true,
       }),
+    });
+  });
+
+  it('trans hits OIDB 0x6d9_0 and returns the saved path metadata', async () => {
+    const bridge = mockBridge();
+    bridge.sendRawPacket.mockResolvedValueOnce(packResponse(
+      protobuf_encode<OidbBase<OidbGroupSendFileResp>>({
+        body: { transFile: { saveBusId: 102, saveFilePath: '/saved/path' } },
+      }),
+    ));
+    const out = await new GroupFileApi(bridge as any).trans(12345, 'fid-trans');
+    expect(out).toEqual({ saveBusId: 102, saveFilePath: '/saved/path' });
+    const [wire, bytes] = bridge.sendRawPacket.mock.calls[0]!;
+    expect(wire).toBe('OidbSvcTrpcTcp.0x6d9_0');
+    const env = protobuf_decode<OidbBase<OidbGroupSendFileReq>>(bytes);
+    expect(env.body?.transFile).toMatchObject({
+      groupUin: 12345n,
+      appId: 7,
+      busId: 102,
+      fileId: 'fid-trans',
     });
   });
 

--- a/packages/mcp/src/generated/catalog.json
+++ b/packages/mcp/src/generated/catalog.json
@@ -8463,13 +8463,46 @@
     {
       "name": "trans_group_file",
       "aliases": [],
-      "summary": "转存群文件（未实现）",
+      "summary": "转存群文件",
+      "returns": "{ ok: true }",
       "readOnly": false,
-      "params": [],
+      "params": [
+        {
+          "name": "group_id",
+          "type": "uint",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        {
+          "name": "file_id",
+          "type": "string",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ],
       "invariants": [],
       "inputSchema": {
         "type": "object",
-        "properties": {},
+        "properties": {
+          "group_id": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "file_id": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "group_id",
+          "file_id"
+        ],
         "additionalProperties": true
       },
       "category": "扩展"

--- a/packages/mcp/src/generated/catalog.ts
+++ b/packages/mcp/src/generated/catalog.ts
@@ -8466,13 +8466,46 @@ export const ACTIONS: CatalogAction[] = [
   {
     "name": "trans_group_file",
     "aliases": [],
-    "summary": "转存群文件（未实现）",
+    "summary": "转存群文件",
+    "returns": "{ ok: true }",
     "readOnly": false,
-    "params": [],
+    "params": [
+      {
+        "name": "group_id",
+        "type": "uint",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "file_id",
+        "type": "string",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    ],
     "invariants": [],
     "inputSchema": {
       "type": "object",
-      "properties": {},
+      "properties": {
+        "group_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "file_id": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "group_id",
+        "file_id"
+      ],
       "additionalProperties": true
     },
     "category": "扩展"

--- a/packages/onebot/src/actions/extended.ts
+++ b/packages/onebot/src/actions/extended.ts
@@ -1622,10 +1622,15 @@ export const actions = [
 
   defineAction({
     name: 'trans_group_file',
-    summary: '转存群文件（未实现）',
-    params: {},
-    run: async () => {
-      return failedResponse(RETCODE.ACTION_FAILED, 'not yet implemented');
+    summary: '转存群文件',
+    returns: '{ ok: true }',
+    params: {
+      group_id: f.uint(),
+      file_id: f.string({ allowEmpty: false }),
+    },
+    run: async (p, ctx) => {
+      await ctx.bridge.apis.groupFile.trans(p.group_id, p.file_id);
+      return okResponse({ ok: true });
     },
   }),
 

--- a/packages/onebot/tests/extended-actions.test.ts
+++ b/packages/onebot/tests/extended-actions.test.ts
@@ -641,6 +641,31 @@ describe('extended-actions / get_group_shut_list', () => {
   });
 });
 
+// ─── Wave 1: trans_group_file (0x6D9_0) ───
+
+describe('extended-actions / trans_group_file', () => {
+  it('forwards group_id + file_id to apis.groupFile.trans and returns ok:true', async () => {
+    const trans = vi.fn(async () => ({ saveBusId: 102, saveFilePath: '/saved/path' }));
+    const bridge = fakeBridge({ apis: { groupFile: { trans } } });
+    const res = await makeHandler(fakeCtx(bridge)).handle('trans_group_file', {
+      group_id: 12345,
+      file_id: 'fid-trans',
+    });
+    expect(trans).toHaveBeenCalledWith(12345, 'fid-trans');
+    expect(res).toMatchObject({ status: 'ok', retcode: 0, data: { ok: true } });
+  });
+
+  it('rejects missing required params', async () => {
+    const trans = vi.fn();
+    const bridge = fakeBridge({ apis: { groupFile: { trans } } });
+    const r1 = await makeHandler(fakeCtx(bridge)).handle('trans_group_file', { file_id: 'fid' });
+    const r2 = await makeHandler(fakeCtx(bridge)).handle('trans_group_file', { group_id: 12345 });
+    expect(r1).toMatchObject({ status: 'failed', retcode: 1400 });
+    expect(r2).toMatchObject({ status: 'failed', retcode: 1400 });
+    expect(trans).not.toHaveBeenCalled();
+  });
+});
+
 // ─── Wave 1: get_file (compose image→record cache) ───
 
 describe('extended-actions / get_file', () => {

--- a/packages/proto-defs/src/oidb-actions/group-file.ts
+++ b/packages/proto-defs/src/oidb-actions/group-file.ts
@@ -132,6 +132,19 @@ export interface OidbGroupFileResp {
   rename?:   pb<5, OidbGroupFileRetResp>;
   move?:     pb<6, OidbGroupFileRetResp>;
 }
+export interface OidbGroupTransFileReq {
+  groupUin?: pb<1, uint_64>;
+  appId?:    pb<2, uint_32>;
+  busId?:    pb<3, uint_32>;
+  fileId?:   pb<4, string>;
+}
+export interface OidbGroupTransFileResp {
+  retCode?:       pb<1, int_32>;
+  retMsg?:        pb<2, string>;
+  clientWording?: pb<3, string>;
+  saveBusId?:     pb<4, uint_32>;
+  saveFilePath?:  pb<5, string>;
+}
 export interface OidbGroupSendFileInfo {
   busiType?: pb<1, uint_32>;
   fileId?:   pb<2, string>;
@@ -145,7 +158,11 @@ export interface OidbGroupSendFileBody {
   info?:     pb<3, OidbGroupSendFileInfo>;
 }
 export interface OidbGroupSendFileReq {
+  transFile?: pb<1, OidbGroupTransFileReq>;
   body?: pb<5, OidbGroupSendFileBody>;
+}
+export interface OidbGroupSendFileResp {
+  transFile?: pb<1, OidbGroupTransFileResp>;
 }
 export interface OidbGroupFileCreateFolderReq {
   groupUin?:      pb<1, uint_32>;

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -332,6 +332,10 @@
       "types": "./src/oidb-services/group-file/publish-group-file.ts",
       "default": "./src/oidb-services/group-file/publish-group-file.ts"
     },
+    "./oidb-services/group-file/trans-group-file": {
+      "types": "./src/oidb-services/group-file/trans-group-file.ts",
+      "default": "./src/oidb-services/group-file/trans-group-file.ts"
+    },
     "./oidb-services/group-file/get-group-file-count": {
       "types": "./src/oidb-services/group-file/get-group-file-count.ts",
       "default": "./src/oidb-services/group-file/get-group-file-count.ts"

--- a/packages/protocol/src/oidb-services/group-file/trans-group-file.ts
+++ b/packages/protocol/src/oidb-services/group-file/trans-group-file.ts
@@ -1,0 +1,52 @@
+// 0x6D9_0 — transfer a temporary group file into permanent group storage.
+// Mirrors LagrangeV2's TransFileReqBody shape under the 0x6D9 family.
+
+import { protobuf_decode, protobuf_encode } from '@snowluma/proton';
+import type { OidbBase } from '@snowluma/proto-defs/oidb';
+import type {
+  OidbGroupSendFileReq,
+  OidbGroupSendFileResp,
+} from '@snowluma/proto-defs/oidb-actions/group-file';
+import { invokeOidb, type OidbSender } from '../../oidb-service';
+import { ensureRetCodeZero, toInt } from '../shared';
+
+export interface TransGroupFileResult {
+  saveBusId: number;
+  saveFilePath: string;
+}
+
+export namespace TransGroupFile {
+  export const command = 0x6D9;
+  export const subCommand = 0;
+
+  export interface Params { groupId: number; fileId: string; }
+  export type Deps = OidbSender;
+
+  export const serialize = (_ctx: Deps, p: Params): OidbGroupSendFileReq => ({
+    transFile: {
+      groupUin: BigInt(p.groupId),
+      appId: 7,
+      busId: 102,
+      fileId: p.fileId,
+    },
+  });
+
+  export const deserialize = (_ctx: Deps, body: OidbGroupSendFileResp): TransGroupFileResult => {
+    const result = body.transFile;
+    if (!result) throw new Error('group file transfer response missing');
+    ensureRetCodeZero('group file transfer', result.retCode, result.retMsg, result.clientWording);
+    return {
+      saveBusId: toInt(result.saveBusId),
+      saveFilePath: typeof result.saveFilePath === 'string' ? result.saveFilePath : '',
+    };
+  };
+
+  export const encode = (env: OidbBase<OidbGroupSendFileReq>): Uint8Array =>
+    protobuf_encode<OidbBase<OidbGroupSendFileReq>>(env);
+
+  export const decode = (bytes: Uint8Array): OidbBase<OidbGroupSendFileResp> =>
+    protobuf_decode<OidbBase<OidbGroupSendFileResp>>(bytes);
+
+  export const invoke = (deps: Deps, params: Params): Promise<TransGroupFileResult> =>
+    invokeOidb(deps, TransGroupFile, params);
+}

--- a/packages/protocol/tests/oidb-services/group-file/trans-group-file.test.ts
+++ b/packages/protocol/tests/oidb-services/group-file/trans-group-file.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { protobuf_decode, protobuf_encode } from '@snowluma/proton';
+import type { OidbBase } from '@snowluma/proto-defs/oidb';
+import type {
+  OidbGroupSendFileReq, OidbGroupSendFileResp,
+} from '@snowluma/proto-defs/oidb-actions/group-file';
+import type { SendPacketResult } from '@snowluma/common/packet-sender';
+
+import { TransGroupFile } from '../../../src/oidb-services/group-file/trans-group-file';
+
+function makeDeps(body?: OidbGroupSendFileResp) {
+  const responseData = body !== undefined
+    ? Buffer.from(protobuf_encode<OidbBase<OidbGroupSendFileResp>>({ body }))
+    : Buffer.alloc(0);
+  const r: SendPacketResult = { success: true, gotResponse: true, errorCode: 0, errorMessage: '', responseData };
+  return { sendRawPacket: vi.fn(async () => r) };
+}
+
+describe('TransGroupFile namespace', () => {
+  it('declares 0x6D9_0', () => {
+    expect(TransGroupFile.command).toBe(0x6D9);
+    expect(TransGroupFile.subCommand).toBe(0);
+  });
+
+  it('packages group + file id under the transFile slot', async () => {
+    const deps = makeDeps({ transFile: { saveBusId: 102, saveFilePath: '/abc' } });
+    const out = await TransGroupFile.invoke(deps, { groupId: 12345, fileId: 'fid' });
+    expect(out).toEqual({ saveBusId: 102, saveFilePath: '/abc' });
+    expect(deps.sendRawPacket).toHaveBeenCalledOnce();
+    const [wire, bytes] = deps.sendRawPacket.mock.calls[0]!;
+    expect(wire).toBe('OidbSvcTrpcTcp.0x6d9_0');
+    const env = protobuf_decode<OidbBase<OidbGroupSendFileReq>>(bytes);
+    expect(env.body?.transFile).toEqual({
+      groupUin: 12345n,
+      appId: 7,
+      busId: 102,
+      fileId: 'fid',
+    });
+  });
+
+  it('throws on missing transFile sub-message', async () => {
+    const deps = makeDeps({});
+    await expect(TransGroupFile.invoke(deps, { groupId: 1, fileId: 'f' }))
+      .rejects.toThrow(/transfer response missing/);
+  });
+
+  it('throws on non-zero retCode', async () => {
+    const deps = makeDeps({ transFile: { retCode: 7, retMsg: 'denied' } });
+    await expect(TransGroupFile.invoke(deps, { groupId: 1, fileId: 'f' }))
+      .rejects.toThrow(/code=7/);
+  });
+});


### PR DESCRIPTION
<!-- 感谢贡献。请填写以下内容，方便评审。 -->

## 关联 Issue
#160
 
## 变更说明
参考NapCat，完善了`/trans_group_file`端点，实现群文件转存永久

- packages/protocol/src/oidb-services/group-file/trans-group-file.ts
新增 `TransGroupFile` OIDB 服务，封装 `0x6D9_0`，序列化 `groupId/fileId` 到 `transFile`，反序列化返回 `saveBusId/saveFilePath`。用于协议层支持群文件转存。

- packages/protocol/tests/oidb-services/group-file/trans-group-file.test.ts
新增协议层单测，覆盖命令号、请求包结构、缺失响应、非零 retCode。用于验证新增 OIDB 服务行为。

- packages/proto-defs/src/oidb-actions/group-file.ts
补充 `transFile` 请求/响应 protobuf 类型，并接入 `OidbGroupSendFileReq/Resp`。用于提供类型化协议结构。

- packages/protocol/package.json
新增 `./oidb-services/group-file/trans-group-file` 子路径导出。用于让 core 从 `@snowluma/protocol/...` 正常导入。

- packages/core/src/bridge/apis/group-file.ts
在 `GroupFileApi` 增加 `trans(groupId, fileId)`，并校验空 `fileId`。用于把协议层群文件转存能力暴露给 bridge API。

- packages/core/tests/actions/_helpers.ts
mock group file API 增加 `trans`。用于支持相关 action 测试注入。

- packages/core/tests/actions/group-file.test.ts
新增 `GroupFileApi.trans` 的 OIDB 打包与返回值测试。用于验证 core 层调用落到 `0x6d9_0`。

- packages/onebot/src/actions/extended.ts
把原本“未实现”的 `trans_group_file` 改为真实 action，接收 `group_id/file_id`，调用 `ctx.bridge.apis.groupFile.trans`，返回 `{ ok: true }`。用于对外实现 OneBot 扩展接口。

- packages/onebot/tests/extended-actions.test.ts
新增 `trans_group_file` 的 action 转发和缺参校验测试。用于覆盖 OneBot 层行为。

- packages/mcp/src/generated/catalog.ts
同步 `trans_group_file` 的 summary、returns、参数 schema。用于让 MCP action catalog 与 OneBot action 定义一致。

- packages/mcp/src/generated/catalog.json
同步 `trans_group_file` 的 summary、returns、参数 schema。用于让 JSON catalog 与生成的 TS catalog 保持一致。

## 提交前检查

- [x] 本 PR 聚焦单一目标，未夹带无关改动
- [ ] 已通过 `pnpm lint` 与 `pnpm typecheck`
- [x] 已补充/更新相关测试，且 `pnpm test` 通过
- [x] 文件行尾为 LF（未引入 CRLF）
- [x] PR 描述与实际实现一致
- [x] 已在真机测试能顺利跑通

注：`pnpm test:all`未通过
```
│ 14:43:59 WARN               [Bridge] session-started listener threw: peer down
│  ✓ tests/webui-state-wiring.test.ts (5 tests) 40ms
│  ✓ tests/group-history-walkback.test.ts (4 tests) 5296ms
│      ✓ walks back across short-capped windows, dedups, returns newest `want` ascending  1256ms
│      ✓ stops at the sequence floor when fewer messages exist than requested  306ms
│      ✓ caps the request count and bounds the request loop  3731ms
│ ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
│  FAIL  tests/bridge-private-routing.test.ts > Bridge private media routing > includes resolved uid in the final c2c…
│ Error: Test timed out in 5000ms.
│ If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeou…
│  ❯ tests/bridge-private-routing.test.ts:12990:3
│     158|     expect(request?.contentHead?.c2cCmd ?? 0).toBe(0);
│     159|   });
│     160| });
│        |               ^
│     161|
│ ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯
│  FAIL  tests/bridge-private-routing.test.ts > Bridge private media routing > sendC2cFileMessage uses trans0x211 rou…
│ Error: Test timed out in 5000ms.
│ If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeou…
│  ❯ tests/bridge-private-routing.test.ts:13031:3
│     158|     expect(request?.contentHead?.c2cCmd ?? 0).toBe(0);
│     159|   });
│     160| });
│        |               ^
│     161|
│ ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯
│  Test Files  1 failed | 45 passed (46)
│       Tests  2 failed | 447 passed (449)
│    Start at  14:43:41
│    Duration  20.15s (transform 152.46s, setup 0ms, import 181.41s, tests 18.01s, environment 8ms)
└─ Failed in 21.2s at \packages\core
```
`pnpm lint`报错
```
\packages\core\src\webui\connection-diff-loop.ts
  70:9  warning  Unused eslint-disable directive (no problems were reported from 'no-console')

\packages\core\src\webui\consent.ts
  88:57  error  Unnecessary escape character: \-  no-useless-escape

\packages\core\src\webui\server.ts
  373:1  error  Expected indentation of 14 spaces but found 16  indent
  374:1  error  Expected indentation of 14 spaces but found 16  indent
  375:1  error  Expected indentation of 12 spaces but found 14  indent

\packages\core\tests\group-history-walkback.test.ts
  18:1  warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-explicit-any')
  26:1  warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-explicit-any')

\packages\core\tests\webui-connection-diff-loop.test.ts
  106:1  error  Expected indentation of 14 spaces but found 16  indent
  107:1  error  Expected indentation of 14 spaces but found 16  indent
  108:1  error  Expected indentation of 12 spaces but found 14  indent

\packages\mcp\src\generated\catalog.ts
  2:1  warning  Unused eslint-disable directive (no problems were reported)

\packages\onebot\tests\send-private-strip-at.test.ts
  137:54  warning  'elements' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

\packages\protocol\src\oidb-services\misc\request-decrypt-key.ts
  58:21  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

✖ 13 problems (8 errors, 5 warnings)
  6 errors and 4 warnings potentially fixable with the `--fix` option.

 ELIFECYCLE  Command failed with exit code 1.
```
均非本次改动引起？