### PR TITLE
fix(webui): close picker after option selection

### DIFF
--- a/packages/webui/src/components/ui/picker.tsx
+++ b/packages/webui/src/components/ui/picker.tsx
@@ -50,6 +50,7 @@ export function Picker({
   const rootRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
+  const suppressTriggerClick = useRef(false);
 
   const selected = options.find((o) => o.value === value);
 
@@ -124,7 +125,13 @@ export function Picker({
         aria-label={ariaLabel}
         aria-haspopup="listbox"
         aria-expanded={open}
-        onClick={() => !disabled && setOpen((v) => !v)}
+        onClick={() => {
+          if (suppressTriggerClick.current) {
+            suppressTriggerClick.current = false;
+            return;
+          }
+          if (!disabled) setOpen((v) => !v);
+        }}
         className={cn(
           'flex h-9 w-full items-center gap-2 rounded-md border border-border bg-transparent px-3 text-sm outline-none transition-colors',
           'focus-visible:ring-[3px] focus-visible:ring-ring/40 focus-visible:border-ring disabled:opacity-50',
@@ -196,7 +203,11 @@ export function Picker({
                       role="option"
                       aria-selected={idx === active}
                       onMouseEnter={() => setActive(idx)}
-                      onClick={() => choose(idx)}
+                      onPointerDown={(e) => {
+                        e.preventDefault();
+                        suppressTriggerClick.current = true;
+                        choose(idx);
+                      }}
                       className={cn(
                         'absolute left-0 right-0 flex cursor-pointer items-center gap-2.5 px-3',
                         idx === active ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50',


### PR DESCRIPTION
<!-- 感谢贡献。请填写以下内容，方便评审。 -->

## 关联 Issue

本 PR 修复 WebUI 调试页面中 Action 选择器选中条目后下拉菜单不会自动收回的问题。

## 变更说明

- 在选项 `pointerdown` 阶段提交选择，避免被 blur / 重渲染时序干扰。
- 增加一次性 `suppressTriggerClick` 标记，吞掉选择后冒出的触发按钮点击，防止菜单重新展开。
- 影响范围限定在 `Picker` 组件，修复调试 Action 选择器及其他复用该组件的选择器交互一致性。

## 提交前检查

- [x] 本 PR 聚焦单一目标，未夹带无关改动
- [x] 已通过 `pnpm lint` 与 `pnpm typecheck`
- [ ] 已补充/更新相关测试，且 `pnpm test` 通过
- [x] 文件行尾为 LF（未引入 CRLF）
- [x] PR 描述与实际实现一致
