### PR TITLE
feat(qzone,onebot): support post visibility rights when publishing qzone posts

### DIFF
--- a/packages/core/src/bridge/apis/qzone.ts
+++ b/packages/core/src/bridge/apis/qzone.ts
@@ -55,10 +55,17 @@ export class QzoneApi {
    * 发表说说，返回新说说的 tid。始终发到机器人自己的空间。
    * `richType` / `richval`: 带图说说时传 richType=1 和 richval 字符串
    * (多图用 `\t` 连接多个 richval)。纯文字说说省略这两个参数。
+   * `ugcRight` / `targetUins`: 查看权限及其作用名单（ugcRight=16/128 时必填）。
    */
-  async publish(content: string, richType?: number, richval?: string): Promise<QzonePublishResult> {
+  async publish(
+    content: string,
+    richType?: number,
+    richval?: string,
+    ugcRight = 1,
+    targetUins?: string,
+  ): Promise<QzonePublishResult> {
     const cookieObject = await this.ctx.apis.web.getCookies('qzone.qq.com');
-    return publishQzoneMsg(cookieObject, this.ctx.identity.uin, content, richType, richval);
+    return publishQzoneMsg(cookieObject, this.ctx.identity.uin, content, richType, richval, ugcRight, targetUins);
   }
 
   /** 删除机器人自己空间的一条说说（按 tid）。 */

--- a/packages/core/tests/actions/qzone.test.ts
+++ b/packages/core/tests/actions/qzone.test.ts
@@ -74,7 +74,7 @@ describe('apis/qzone', () => {
     const pubSpy = vi.spyOn(qzoneWeb, 'publishQzoneMsg').mockResolvedValue({ tid: 'T', time: 1 });
     const out = await new QzoneApi(bridge as never).publish('hello');
     expect(getCookies).toHaveBeenCalledWith('qzone.qq.com');
-    expect(pubSpy).toHaveBeenCalledWith({ p_skey: 'PSK' }, '10001', 'hello', undefined, undefined);
+    expect(pubSpy).toHaveBeenCalledWith({ p_skey: 'PSK' }, '10001', 'hello', undefined, undefined, 1, undefined);
     expect(out).toEqual({ tid: 'T', time: 1 });
   });
 
@@ -85,7 +85,7 @@ describe('apis/qzone', () => {
     const richval = ',12345,abc,abc,22,800,600,,800,600';
     const out = await new QzoneApi(bridge as never).publish('look at this', 1, richval);
     expect(getCookies).toHaveBeenCalledWith('qzone.qq.com');
-    expect(pubSpy).toHaveBeenCalledWith({ p_skey: 'PSK' }, '10001', 'look at this', 1, richval);
+    expect(pubSpy).toHaveBeenCalledWith({ p_skey: 'PSK' }, '10001', 'look at this', 1, richval, 1, undefined);
     expect(out).toEqual({ tid: 'T2', time: 2 });
   });
 
@@ -96,8 +96,16 @@ describe('apis/qzone', () => {
     const richval = ',12345,a,a,22,800,600,,800,600\t,12346,b,b,22,1024,768,,1024,768';
     const out = await new QzoneApi(bridge as never).publish('two images', 1, richval);
     expect(getCookies).toHaveBeenCalledWith('qzone.qq.com');
-    expect(pubSpy).toHaveBeenCalledWith({ p_skey: 'PSK' }, '10001', 'two images', 1, richval);
+    expect(pubSpy).toHaveBeenCalledWith({ p_skey: 'PSK' }, '10001', 'two images', 1, richval, 1, undefined);
     expect(out).toEqual({ tid: 'T3', time: 3 });
+  });
+
+  it('publish threads qzone visibility params', async () => {
+    const getCookies = vi.fn(async () => ({ p_skey: 'PSK' }));
+    const bridge = mockBridge({ apis: { ...mockApiHub(), web: { getCookies } } as never });
+    const pubSpy = vi.spyOn(qzoneWeb, 'publishQzoneMsg').mockResolvedValue({ tid: 'T', time: 1 });
+    await new QzoneApi(bridge as never).publish('hello', undefined, undefined, 16, '10002|10003');
+    expect(pubSpy).toHaveBeenCalledWith({ p_skey: 'PSK' }, '10001', 'hello', undefined, undefined, 16, '10002|10003');
   });
 
   it('delete removes a feed by tid from the bot\'s own space', async () => {

--- a/packages/mcp/src/generated/catalog.json
+++ b/packages/mcp/src/generated/catalog.json
@@ -7183,7 +7183,7 @@
     {
       "name": "send_qzone_msg",
       "aliases": [],
-      "summary": "发表说说（QQ 空间，支持纯文字或带图；传 images 自动上传）",
+      "summary": "发表说说（QQ 空间，支持纯文字或带图；传 images 自动上传；可设置查看权限）",
       "readOnly": false,
       "params": [
         {
@@ -7208,9 +7208,36 @@
             }
           },
           "desc": "图片数组（可选），支持 file:// http:// base64://；自动上传"
+        },
+        {
+          "name": "ugc_right",
+          "type": "int",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "desc": "查看权限：1=所有人可见，4=好友可见，16=部分好友可见，64=仅自己可见，128=部分好友不可见",
+          "default": 1
+        },
+        {
+          "name": "target_uins",
+          "type": "uint[]",
+          "required": false,
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          "desc": "权限作用 QQ 号数组；ugc_right=16 时表示可见名单，128 时表示不可见名单"
         }
       ],
-      "invariants": [],
+      "invariants": [
+        "ugc_right must be one of 1, 4, 16, 64, 128",
+        "target_uins is required when ugc_right is 16 or 128"
+      ],
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -7226,6 +7253,20 @@
               "minLength": 1
             },
             "description": "图片数组（可选），支持 file:// http:// base64://；自动上传"
+          },
+          "ugc_right": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "查看权限：1=所有人可见，4=好友可见，16=部分好友可见，64=仅自己可见，128=部分好友不可见",
+            "default": 1
+          },
+          "target_uins": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "权限作用 QQ 号数组；ugc_right=16 时表示可见名单，128 时表示不可见名单"
           }
         },
         "required": [

--- a/packages/mcp/src/generated/catalog.ts
+++ b/packages/mcp/src/generated/catalog.ts
@@ -7186,7 +7186,7 @@ export const ACTIONS: CatalogAction[] = [
   {
     "name": "send_qzone_msg",
     "aliases": [],
-    "summary": "发表说说（QQ 空间，支持纯文字或带图；传 images 自动上传）",
+    "summary": "发表说说（QQ 空间，支持纯文字或带图；传 images 自动上传；可设置查看权限）",
     "readOnly": false,
     "params": [
       {
@@ -7211,9 +7211,36 @@ export const ACTIONS: CatalogAction[] = [
           }
         },
         "desc": "图片数组（可选），支持 file:// http:// base64://；自动上传"
+      },
+      {
+        "name": "ugc_right",
+        "type": "int",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "desc": "查看权限：1=所有人可见，4=好友可见，16=部分好友可见，64=仅自己可见，128=部分好友不可见",
+        "default": 1
+      },
+      {
+        "name": "target_uins",
+        "type": "uint[]",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "desc": "权限作用 QQ 号数组；ugc_right=16 时表示可见名单，128 时表示不可见名单"
       }
     ],
-    "invariants": [],
+    "invariants": [
+      "ugc_right must be one of 1, 4, 16, 64, 128",
+      "target_uins is required when ugc_right is 16 or 128"
+    ],
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -7229,6 +7256,20 @@ export const ACTIONS: CatalogAction[] = [
             "minLength": 1
           },
           "description": "图片数组（可选），支持 file:// http:// base64://；自动上传"
+        },
+        "ugc_right": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "查看权限：1=所有人可见，4=好友可见，16=部分好友可见，64=仅自己可见，128=部分好友不可见",
+          "default": 1
+        },
+        "target_uins": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "description": "权限作用 QQ 号数组；ugc_right=16 时表示可见名单，128 时表示不可见名单"
         }
       },
       "required": [

--- a/packages/onebot/src/actions/qzone.ts
+++ b/packages/onebot/src/actions/qzone.ts
@@ -21,6 +21,8 @@ async function uploadQzoneImages(
   return parts.join('\t');
 }
 
+const QZONE_UGC_RIGHTS = new Set<number>([1, 4, 16, 64, 128]);
+
 export const actions = [
   // get_qzone_msg_list — 获取 QQ 空间说说列表。无 go-cqhttp 标准，自定义命名。
   // 默认取机器人自己的空间；传 target_uin 可查看指定账号（需有权限）。
@@ -120,19 +122,25 @@ export const actions = [
   // 注意：发说说为主动行为，高频会被 Qzone 风控，调用方需自行限流。
   defineAction({
     name: 'send_qzone_msg',
-    summary: '发表说说（QQ 空间，支持纯文字或带图；传 images 自动上传）',
+    summary: '发表说说（QQ 空间，支持纯文字或带图；传 images 自动上传；可设置查看权限）',
     params: {
       content: f.string({ allowEmpty: false }).describe('说说正文'),
       images: f.array(f.string({ allowEmpty: false })).describe('图片数组（可选），支持 file:// http:// base64://；自动上传').optional(),
+      ugc_right: f.int({ min: 1 }).describe('查看权限：1=所有人可见，4=好友可见，16=部分好友可见，64=仅自己可见，128=部分好友不可见').default(1),
+      target_uins: f.array(f.uint()).describe('权限作用 QQ 号数组；ugc_right=16 时表示可见名单，128 时表示不可见名单').optional(),
     },
+    rules: (r) => [
+      r.rule('ugc_right must be one of 1, 4, 16, 64, 128', (p) => QZONE_UGC_RIGHTS.has(p.ugc_right)),
+      r.rule('target_uins is required when ugc_right is 16 or 128', (p) => (p.ugc_right !== 16 && p.ugc_right !== 128) || !!p.target_uins?.length),
+    ],
     run: async (p, ctx) => {
       try {
         if (p.images && p.images.length > 0) {
           const richval = await uploadQzoneImages(ctx, p.images, (upload) => upload.richval);
-          const res = await ctx.bridge.apis.qzone.publish(p.content, 1, richval);
+          const res = await ctx.bridge.apis.qzone.publish(p.content, 1, richval, p.ugc_right, p.target_uins?.join('|'));
           return okResponse(res as unknown as JsonValue);
         }
-        const res = await ctx.bridge.apis.qzone.publish(p.content);
+        const res = await ctx.bridge.apis.qzone.publish(p.content, undefined, undefined, p.ugc_right, p.target_uins?.join('|'));
         return okResponse(res as unknown as JsonValue);
       } catch (error) {
         const message = error instanceof Error ? error.message : 'failed to publish qzone msg';

--- a/packages/onebot/tests/qzone-actions.test.ts
+++ b/packages/onebot/tests/qzone-actions.test.ts
@@ -24,7 +24,7 @@ describe('qzone actions', () => {
     expect(res).toMatchObject({ status: 'ok', retcode: 0, data: { tid: 'T1', time: 1 } });
     expect(uploadImageFromSource).toHaveBeenNthCalledWith(1, 'file:///a.jpg');
     expect(uploadImageFromSource).toHaveBeenNthCalledWith(2, 'file:///b.jpg');
-    expect(publish).toHaveBeenCalledWith('hello', 1, 'RV1\tRV2');
+    expect(publish).toHaveBeenCalledWith('hello', 1, 'RV1\tRV2', 1, undefined);
   });
 
   it('comment_qzone uploads images and comments direct urls joined with tab', async () => {

--- a/packages/protocol/src/web/qzone.ts
+++ b/packages/protocol/src/web/qzone.ts
@@ -370,6 +370,8 @@ interface RawPublishResponse {
   now?: number;
 }
 
+export type QzoneUgcRight = 1 | 4 | 16 | 64 | 128;
+
 /** Result of publishing a 说说. */
 export interface QzonePublishResult {
   [key: string]: JsonValue;
@@ -377,6 +379,31 @@ export interface QzonePublishResult {
   tid: string;
   /** Unix seconds the 说说 was published. */
   time: number;
+}
+
+const QZONE_UGC_RIGHTS = new Set<number>([1, 4, 16, 64, 128]);
+
+function normalizeQzoneUgcRight(ugcRight: number): QzoneUgcRight {
+  if (!QZONE_UGC_RIGHTS.has(ugcRight)) {
+    throw new Error('ugc_right must be one of 1, 4, 16, 64, 128');
+  }
+  return ugcRight as QzoneUgcRight;
+}
+
+function normalizeTargetUins(targetUins?: string): string {
+  const raw = (targetUins ?? '').trim();
+  if (!raw) return '';
+
+  const seen = new Set<string>();
+  for (const part of raw.split('|')) {
+    const uin = part.trim();
+    if (!uin) continue;
+    if (!/^\d+$/.test(uin)) {
+      throw new Error('target_uins must contain QQ numbers separated by |');
+    }
+    seen.add(uin);
+  }
+  return [...seen].join('|');
 }
 
 /**
@@ -399,6 +426,8 @@ export async function publishQzoneMsg(
   content: string,
   richType?: number,
   richval?: string,
+  ugcRight = 1,
+  targetUins?: string,
 ): Promise<QzonePublishResult> {
   if (!cookieObject || typeof cookieObject !== 'object') {
     throw new Error('cookieObject is required');
@@ -408,9 +437,15 @@ export async function publishQzoneMsg(
   }
   assertRichParams(richType, richval);
 
+  const right = normalizeQzoneUgcRight(ugcRight);
+  const effectiveTargetUins = right === 16 || right === 128 ? normalizeTargetUins(targetUins) : '';
+  if ((right === 16 || right === 128) && !effectiveTargetUins) {
+    throw new Error('target_uins is required when ugc_right is 16 or 128');
+  }
+
   const bkn = getBknFromCookie(cookieObject);
   const url = `https://h5.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_publish_v6?g_tk=${bkn}`;
-  const body = new URLSearchParams({
+  const bodyParams = new URLSearchParams({
     syn_tweet_verson: '1',
     paramstr: '1',
     pic_template: '',
@@ -421,14 +456,16 @@ export async function publishQzoneMsg(
     con: content,
     feedversion: '1',
     ver: '1',
-    ugc_right: '1',
+    ugc_right: String(right),
     to_sign: '0',
     who: '1',
     hostuin: hostUin,
     code_version: '1',
     format: 'json',
     qzreferrer: `https://user.qzone.qq.com/${hostUin}`,
-  }).toString();
+  });
+  if (effectiveTargetUins) bodyParams.set('allow_uins', effectiveTargetUins);
+  const body = bodyParams.toString();
 
   const text = await RequestUtil.HttpGetText(url, 'POST', body, {
     Cookie: cookieToString(cookieObject),

--- a/packages/protocol/tests/web/qzone.test.ts
+++ b/packages/protocol/tests/web/qzone.test.ts
@@ -218,6 +218,8 @@ describe('qzone / publishQzoneMsg (HTTP layer)', () => {
     expect(form.get('con')).toBe('hello 世界 & friends');
     expect(form.get('hostuin')).toBe('10000');
     expect(form.get('who')).toBe('1');
+    expect(form.get('ugc_right')).toBe('1');
+    expect(form.has('allow_uins')).toBe(false);
     expect(form.get('format')).toBe('json');
     expect(form.get('qzreferrer')).toBe('https://user.qzone.qq.com/10000');
   });
@@ -235,6 +237,39 @@ describe('qzone / publishQzoneMsg (HTTP layer)', () => {
     expect(form.get('richval')).toBe(richval);
   });
 
+  it('threads publish permission fields for restricted visibility', async () => {
+    const spy = vi.spyOn(RequestUtil, 'HttpGetText').mockResolvedValue(
+      '{"code":0,"t1_tid":"RIGHTTID","t1_time":"1700000000"}',
+    );
+
+    await expect(publishQzoneMsg(cookies, '10000', 'limited', undefined, undefined, 16, '10001 | 10002|10001')).resolves.toEqual({
+      tid: 'RIGHTTID',
+      time: 1700000000,
+    });
+
+    const [, , body] = spy.mock.calls[0]!;
+    const form = new URLSearchParams(body as string);
+    expect(form.get('ugc_right')).toBe('16');
+    expect(form.get('allow_uins')).toBe('10001|10002');
+    expect(form.get('who')).toBe('1');
+  });
+
+  it('ignores target_uins for non-restricted visibility', async () => {
+    const spy = vi.spyOn(RequestUtil, 'HttpGetText').mockResolvedValue(
+      '{"code":0,"t1_tid":"FRIENDTID","t1_time":"1700000000"}',
+    );
+
+    await expect(publishQzoneMsg(cookies, '10000', 'friends', undefined, undefined, 4, 'not-a-uin')).resolves.toEqual({
+      tid: 'FRIENDTID',
+      time: 1700000000,
+    });
+
+    const [, , body] = spy.mock.calls[0]!;
+    const form = new URLSearchParams(body as string);
+    expect(form.get('ugc_right')).toBe('4');
+    expect(form.has('allow_uins')).toBe(false);
+  });
+
   it('falls back to tid/now for alternate client builds', async () => {
     vi.spyOn(RequestUtil, 'HttpGetText').mockResolvedValue('{"code":0,"tid":"ALT","now":1700000001}');
     await expect(publishQzoneMsg(cookies, '10000', 'hi')).resolves.toEqual({ tid: 'ALT', time: 1700000001 });
@@ -250,6 +285,12 @@ describe('qzone / publishQzoneMsg (HTTP layer)', () => {
     const spy = vi.spyOn(RequestUtil, 'HttpGetText');
     await expect(publishQzoneMsg(cookies, '10000', 'hi', 1)).rejects.toThrow('richType and richval');
     await expect(publishQzoneMsg(cookies, '10000', 'hi', undefined, ',123')).rejects.toThrow('richType and richval');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('rejects restricted visibility without target_uins before any request', async () => {
+    const spy = vi.spyOn(RequestUtil, 'HttpGetText');
+    await expect(publishQzoneMsg(cookies, '10000', 'hi', undefined, undefined, 128)).rejects.toThrow('target_uins is required');
     expect(spy).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
<!-- 感谢贡献。请填写以下内容，方便评审。 -->

## 关联 Issue
feat: 支持发布带权限的说说

`/send_qzone_msg`端点新增两个可选传入字段：`ugc_right` & `target_uins`
- ugc_right: 查看权限id 与实际请求ugcRight字段一致
  1=所有人可见，4=好友可见，16=部分好友可见，64=仅自己可见，128=部分好友不可见
- target_uins: 目标作用QQ号，当urcRight=16/128时可选传入并生效
## 变更说明

-  packages/protocol/src/web/qzone.ts
   - 新增 `QzoneUgcRight` 类型（1|4|16|64|128）与内部校验函数。
   - `normalizeQzoneUgcRight`：校验 ugc_right 取值合法，非法即抛错。
   - `normalizeTargetUins`：解析 `|` 分隔的 QQ 号名单，去重、校验为纯数字，非法抛错。
   - `publishQzoneMsg` 新增 `ugcRight=1`、`targetUins?` 两个参数；仅当 ugc_right 为16/128 时要求并写入 `allow_uins` 字段，缺名单则在发请求前直接拒绝；请求体 ugc_right由硬编码 '1' 改为按入参写入。
   - 目的：在协议层支持「部分可见 / 部分不可见」等受限可见性发说说。

-  packages/core/src/bridge/apis/qzone.ts
   - `QzoneApi.publish` 新增 `ugcRight=1`、`targetUins?` 参数并透传给 publishQzoneMsg。
   - 更新方法注释说明权限参数。
   - 目的：把权限能力从协议层暴露到 bridge API。

-  packages/onebot/src/actions/qzone.ts
   - `send_qzone_msg` 新增 `ugc_right`（默认 1）、`target_uins`（QQ 号数组）两个入参。
   - 新增 rules 校验：ugc_right 必须是 1/4/16/64/128；ugc_right 为 16/128 时 target_uins 必填。
   - run 中把 target_uins 以 `|` 连接后透传给 bridge.publish（带图/纯文字两条路径均更新）。
   - 更新 action summary 说明可设置查看权限。
   - 目的：把权限控制开放给 OneBot 调用方，并在用户输入边界做校验。

-  packages/mcp/src/generated/catalog.json / catalog.ts
   - 由 `pnpm run gen` 自动重新生成：send_qzone_msg 新增 ugc_right / target_uins 参数
  的 schema、描述、默认值与 invariants，summary 同步更新。
   - 目的：保持 MCP 目录与 OneBot action 定义同步（非手工编辑，重新生成无漂移）。

-  packages/protocol/tests/web/qzone.test.ts
   - 新增用例：受限可见性透传 ugc_right=16 与去重后的 allow_uins；非受限可见性忽略 target_uins 且不带 allow_uins；缺名单时在发请求前抛错。
   - 既有用例补充断言默认 ugc_right=1、无 allow_uins。

-  packages/core/tests/actions/qzone.test.ts
   - 既有 publish 用例补充新增参数的默认值断言（…, 1, undefined）。
   - 新增用例：验证 publish 正确透传可见性参数（16 / '10002|10003'）。

-  packages/onebot/tests/qzone-actions.test.ts
   - 更新 publish 调用断言，补上新增的 ugc_right / target_uins 默认参数。


## 提交前检查

- [x] 本 PR 聚焦单一目标，未夹带无关改动
- [x] 已通过 `pnpm lint` 与 `pnpm typecheck`
- [x] 已补充/更新相关测试，且 `pnpm test` 通过
- [x] 文件行尾为 LF（未引入 CRLF）
- [x] PR 描述与实际实现一致
- [x] 已在实机测试通过