### PR TITLE
Fix/debug account picker style

### DIFF
--- a/packages/bridge/src/hook-session.ts
+++ b/packages/bridge/src/hook-session.ts
@@ -4,8 +4,14 @@ import { EventEmitter } from 'events';
 import { HookPacketClient } from './hook-packet-client';
 import type { HookInjectResult } from './injector';
 import type { QqHookClient, QqHookLoginState, QqHookPacket } from './qq-hook-client';
+import { probeQqLoginInfo, type QqPortLoginInfo } from './qq-port-probe';
 import { statusFor } from './hook-status';
 import type { HookProcessInfo, HookProcessStatus } from './types';
+
+/** How often to actively re-probe QQ's login state while connected but not yet
+ *  logged in — the safety net for a login the native hook never pushed (Docker
+ *  auto-login races/bypasses the pushed loginState frame). */
+const LOGIN_RECONCILE_INTERVAL_MS = 3000;
 
 export type HookSessionDeps = {
   injector: {
@@ -13,6 +19,10 @@ export type HookSessionDeps = {
     unload: (pid: number, handle: HookInjectResult['handle']) => void;
   };
   makeClient: (pid: number) => QqHookClient;
+  /** Active, pipe-independent login probe (reads QQ's ptlogin/deeplink ports).
+   *  Drives the login-reconcile safety net; injectable for tests. Defaults to
+   *  `probeQqLoginInfo`. */
+  probeLogin?: (pid: number) => Promise<QqPortLoginInfo | null>;
   /** Sync fast-path check used by load() to skip re-injection when a
    * prior SnowLuma run left a working pipe behind. `tickNow` forces a
    * fresh poll — used after unload to dodge the up-to-1500ms cache
@@ -50,6 +60,7 @@ export class HookSession extends EventEmitter {
 
   private readonly injector: HookSessionDeps['injector'];
   private readonly makeClient: HookSessionDeps['makeClient'];
+  private readonly probeLogin: (pid: number) => Promise<QqPortLoginInfo | null>;
   private readonly pipeWatcher: HookSessionDeps['pipeWatcher'];
   private readonly onPacket: PacketSink | null;
   private readonly log: Logger;
@@ -70,12 +81,15 @@ export class HookSession extends EventEmitter {
   private bound = false;
   private opChain: Promise<unknown> = Promise.resolve();
   private disposed = false;
+  private loginProbeTimer: ReturnType<typeof setInterval> | null = null;
+  private probing = false;
 
   constructor(pid: number, deps: HookSessionDeps) {
     super();
     this.pid = pid;
     this.injector = deps.injector;
     this.makeClient = deps.makeClient;
+    this.probeLogin = deps.probeLogin ?? probeQqLoginInfo;
     this.pipeWatcher = deps.pipeWatcher;
     this.onPacket = deps.onPacket ?? null;
     this.log = deps.log ?? createLogger('HookSession');
@@ -347,8 +361,15 @@ export class HookSession extends EventEmitter {
       // handleLoginState owns the connected+loggedIn → 'online' (+ login
       // emit) transition; defer to it so the status is set once. Otherwise
       // we're connected-but-not-logged-in → 'loaded'.
-      if (loginState.loggedIn) this.handleLoginState(loginState);
-      else this.applyStatus();
+      if (loginState.loggedIn) {
+        this.handleLoginState(loginState);
+      } else {
+        this.applyStatus();
+        // The native hook only PUSHES a loginState frame on the login edge;
+        // if QQ logged in before/around connect (Docker auto-login) that edge
+        // is missed and we'd wait forever. Actively re-probe until logged in.
+        this.startLoginReconcile();
+      }
       this.log.info('pipe connected: PID=%d', this.pid);
     } catch (error) {
       this._error = errMsg(error);
@@ -381,6 +402,7 @@ export class HookSession extends EventEmitter {
   }
 
   private tearDownClient(): void {
+    this.stopLoginReconcile();
     const client = this.client;
     if (client) {
       client.removeAllListeners();
@@ -398,6 +420,9 @@ export class HookSession extends EventEmitter {
     const previousUin = this._uin;
     this._uin = state.uin || state.uinNumber.toString();
     this.loggedIn = state.loggedIn && isRealUin(this._uin);
+    // However login was observed (pushed frame or the active probe), the
+    // safety net's job is done.
+    if (this.loggedIn) this.stopLoginReconcile();
 
     // Only the connected/logged-in states are ours to set here; when fully
     // down we leave the status the teardown path already settled.
@@ -414,6 +439,55 @@ export class HookSession extends EventEmitter {
 
     this.emit('login', this._uin, this.sender);
     this.log.success('login detected: PID=%d UIN=%s', this.pid, this._uin);
+  }
+
+  // ─────────────── login reconcile (Docker auto-login safety net) ───────────
+  // The hook's loginState frame is edge-triggered (pushed only when the native
+  // observes the login transition). When that edge is missed — QQ auto-logged
+  // in before connect, or a silent session-restore path the hook doesn't
+  // intercept — we'd sit at 'loaded'/'connecting' forever. So while connected
+  // but not logged in, actively re-probe QQ's own ports and synthesize the
+  // login once it reports a real uin. Idempotent with the pushed-frame path
+  // (handleLoginState's wasLoggedIn guard dedups the 'login' emit).
+
+  private startLoginReconcile(): void {
+    if (this.loginProbeTimer || this.disposed) return;
+    void this.probeLoginOnce(); // immediate — catch already-logged-in fast
+    this.loginProbeTimer = setInterval(() => void this.probeLoginOnce(), LOGIN_RECONCILE_INTERVAL_MS);
+    this.loginProbeTimer.unref?.();
+  }
+
+  private stopLoginReconcile(): void {
+    if (this.loginProbeTimer) {
+      clearInterval(this.loginProbeTimer);
+      this.loginProbeTimer = null;
+    }
+  }
+
+  private async probeLoginOnce(): Promise<void> {
+    // A port-scan probe can outlast the interval; skip overlapping ticks so a
+    // slow probe never stacks concurrent subprocess-spawning scans.
+    if (this.probing) return;
+    if (this.disposed || !this.connected || this.loggedIn) { this.stopLoginReconcile(); return; }
+    this.probing = true;
+    try {
+      let info: QqPortLoginInfo | null;
+      try {
+        info = await this.probeLogin(this.pid);
+      } catch {
+        return; // best-effort; the interval retries
+      }
+      // The await yielded — re-check we still want this before mutating state.
+      if (this.disposed || !this.connected || this.loggedIn) { this.stopLoginReconcile(); return; }
+      if (info?.loggedIn && isRealUin(info.uin)) {
+        this.log.info('login reconciled via active probe: PID=%d UIN=%s', this.pid, info.uin);
+        // isRealUin guarantees a pure non-empty digit string, so BigInt() here
+        // cannot throw (keep that contract if isRealUin's regex is ever changed).
+        this.handleLoginState({ loggedIn: true, uin: info.uin, uinNumber: BigInt(info.uin) });
+      }
+    } finally {
+      this.probing = false;
+    }
   }
 
   private handlePacket(packet: QqHookPacket): void {

--- a/packages/bridge/tests/hook-session.test.ts
+++ b/packages/bridge/tests/hook-session.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 import { HookSession } from '../src/hook-session';
 import type { ManualMapHandle } from '../src/injector';
 import type { QqHookClient, QqHookPacket } from '../src/qq-hook-client';
+import type { QqPortLoginInfo } from '../src/qq-port-probe';
 import type { PacketSink } from '@snowluma/common/protocol-types';
 
 const DUMMY_HANDLE: ManualMapHandle = { base: 0n, entry: 0n, exceptionTable: 0n, size: 0 };
@@ -42,6 +43,7 @@ function makeSession(opts: {
   pipeLive?: boolean;
   clientFailsConnect?: boolean;
   onPacket?: PacketSink;
+  probeLogin?: (pid: number) => Promise<QqPortLoginInfo | null>;
 } = {}) {
   const pid = opts.pid ?? 1234;
   let pipeLive = opts.pipeLive ?? false;
@@ -50,6 +52,9 @@ function makeSession(opts: {
     inject: vi.fn(() => ({ method: 'loadModuleManual' as const, handle: DUMMY_HANDLE })),
     unload: vi.fn(),
   };
+  // Default probe reports "not logged in" so the reconcile safety net is inert
+  // unless a test opts into a logged-in probe (never hits the real port scan).
+  const probeLogin = opts.probeLogin ?? (async () => ({ port: 0, uin: '', loggedIn: false }));
 
   const session = new HookSession(pid, {
     injector,
@@ -60,6 +65,7 @@ function makeSession(opts: {
       // Cast: FakeClient mirrors only the surface HookSession touches.
       return c as unknown as QqHookClient;
     },
+    probeLogin,
     pipeWatcher: { isPipeLive: () => pipeLive },
     onPacket: opts.onPacket,
   });
@@ -531,5 +537,138 @@ describe('HookSession — packet forwarding', () => {
     ctx.currentClient().firePacket({
       seq: 1, error: 0, cmd: 'foo', uin: '10001', body: Buffer.from([7]),
     });
+  });
+});
+
+describe('HookSession — login reconcile (Docker auto-login safety net)', () => {
+  it('reconciles login via the active probe when the pushed frame is missed', async () => {
+    // Probe reports logged-in; the FakeClient never fires a loginState frame
+    // (the missed-edge Docker case). The immediate reconcile probe must detect
+    // it and emit "login".
+    const ctx = makeSession({
+      pipeLive: true,
+      probeLogin: async () => ({ port: 4301, uin: '10001', loggedIn: true }),
+    });
+    const loginSpy = vi.fn();
+    ctx.session.on('login', loginSpy);
+
+    await ctx.session.load();
+    ctx.session.onPipeUp();
+    await flush();   // connect (not logged in via frame) → starts reconcile
+    await flush();   // immediate probe resolves → handleLoginState
+
+    expect(loginSpy).toHaveBeenCalledOnce();
+    expect(loginSpy.mock.calls[0]![0]).toBe('10001');
+    expect(ctx.session.status).toBe('online');
+    expect(ctx.session.uin).toBe('10001');
+  });
+
+  it('does not log in when the probe reports not-logged-in', async () => {
+    const ctx = makeSession({
+      pipeLive: true,
+      probeLogin: async () => ({ port: 0, uin: '', loggedIn: false }),
+    });
+    const loginSpy = vi.fn();
+    ctx.session.on('login', loginSpy);
+    await ctx.session.load();
+    ctx.session.onPipeUp();
+    await flush(); await flush();
+
+    expect(loginSpy).not.toHaveBeenCalled();
+    expect(ctx.session.status).toBe('loaded');
+  });
+
+  it('ignores a probe with a non-real uin (0)', async () => {
+    const ctx = makeSession({
+      pipeLive: true,
+      probeLogin: async () => ({ port: 4301, uin: '0', loggedIn: true }),
+    });
+    const loginSpy = vi.fn();
+    ctx.session.on('login', loginSpy);
+    await ctx.session.load();
+    ctx.session.onPipeUp();
+    await flush(); await flush();
+
+    expect(loginSpy).not.toHaveBeenCalled();
+  });
+
+  it('tolerates a throwing probe (best-effort, no crash/login)', async () => {
+    const ctx = makeSession({
+      pipeLive: true,
+      probeLogin: async () => { throw new Error('port scan failed'); },
+    });
+    const loginSpy = vi.fn();
+    ctx.session.on('login', loginSpy);
+    await ctx.session.load();
+    ctx.session.onPipeUp();
+    await flush(); await flush();
+
+    expect(loginSpy).not.toHaveBeenCalled();
+    expect(ctx.session.status).toBe('loaded');
+  });
+
+  it('detects a login that lands on a LATER interval probe', async () => {
+    vi.useFakeTimers();
+    try {
+      let loggedIn = false;
+      const ctx = makeSession({
+        pipeLive: true,
+        probeLogin: async () => ({ port: 4301, uin: '10001', loggedIn }),
+      });
+      const loginSpy = vi.fn();
+      ctx.session.on('login', loginSpy);
+
+      await ctx.session.load();
+      ctx.session.onPipeUp();
+      await vi.advanceTimersByTimeAsync(0);   // connect + immediate probe (not logged in yet)
+      expect(loginSpy).not.toHaveBeenCalled();
+
+      loggedIn = true;                          // QQ finishes auto-login
+      await vi.advanceTimersByTimeAsync(3000);  // next interval probe picks it up
+
+      expect(loginSpy).toHaveBeenCalledOnce();
+      expect(ctx.session.status).toBe('online');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not double-emit when the pushed frame logs in first', async () => {
+    // Pushed-frame login wins; a subsequent probe with the same uin must not
+    // re-emit (handleLoginState dedups), and the reconcile timer is stopped.
+    const probeLogin = vi.fn(async () => ({ port: 4301, uin: '10001', loggedIn: true }));
+    const ctx = makeSession({ pipeLive: true, probeLogin });
+    const loginSpy = vi.fn();
+    ctx.session.on('login', loginSpy);
+
+    await ctx.session.load();
+    ctx.session.onPipeUp();
+    await flush();
+    ctx.currentClient().fireLogin('10001'); // pushed-frame login first
+    await flush();
+
+    expect(loginSpy).toHaveBeenCalledOnce();
+    expect(ctx.session.status).toBe('online');
+  });
+});
+
+describe('HookSession — login reconcile does not stack concurrent probes', () => {
+  it('skips overlapping ticks while a slow probe is in flight', async () => {
+    vi.useFakeTimers();
+    try {
+      // A probe that never resolves — simulates a slow port scan spanning
+      // multiple intervals. The in-flight guard must call it only once.
+      const probeLogin = vi.fn(() => new Promise<never>(() => { /* pending */ }));
+      const ctx = makeSession({ pipeLive: true, probeLogin });
+
+      await ctx.session.load();
+      ctx.session.onPipeUp();
+      await vi.advanceTimersByTimeAsync(0);      // connect + immediate probe (starts, stays pending)
+      await vi.advanceTimersByTimeAsync(9000);   // 3 more interval ticks
+
+      expect(probeLogin).toHaveBeenCalledTimes(1); // not stacked
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/core/src/bridge/apis/group-file.ts
+++ b/packages/core/src/bridge/apis/group-file.ts
@@ -23,6 +23,7 @@ import { MoveGroupFile } from '@snowluma/protocol/oidb-services/group-file/move-
 import { PublishGroupFile } from '@snowluma/protocol/oidb-services/group-file/publish-group-file';
 import { RenameGroupFile } from '@snowluma/protocol/oidb-services/group-file/rename-group-file';
 import { RenameGroupFolder } from '@snowluma/protocol/oidb-services/group-file/rename-group-folder';
+import { TransGroupFile, type TransGroupFileResult } from '@snowluma/protocol/oidb-services/group-file/trans-group-file';
 import { UploadGroupFileRequest } from '@snowluma/protocol/oidb-services/group-file/upload-group-file-request';
 import { UploadPrivateFileRequest } from '@snowluma/protocol/oidb-services/group-file/upload-private-file-request';
 import { ensureRetCodeZero } from '@snowluma/protocol/oidb-services/shared';
@@ -236,6 +237,11 @@ export class GroupFileApi {
   publish(groupId: number, fileId: string): Promise<void> {
     if (!fileId) throw new Error('publish requires fileId');
     return PublishGroupFile.invoke(this.ctx, { groupId, fileId });
+  }
+
+  trans(groupId: number, fileId: string): Promise<TransGroupFileResult> {
+    if (!fileId) throw new Error('trans requires fileId');
+    return TransGroupFile.invoke(this.ctx, { groupId, fileId });
   }
 
   // ─────────────── count ───────────────

--- a/packages/core/src/bridge/apis/qzone.ts
+++ b/packages/core/src/bridge/apis/qzone.ts
@@ -55,10 +55,17 @@ export class QzoneApi {
    * 发表说说，返回新说说的 tid。始终发到机器人自己的空间。
    * `richType` / `richval`: 带图说说时传 richType=1 和 richval 字符串
    * (多图用 `\t` 连接多个 richval)。纯文字说说省略这两个参数。
+   * `ugcRight` / `targetUins`: 查看权限及其作用名单（ugcRight=16/128 时必填）。
    */
-  async publish(content: string, richType?: number, richval?: string): Promise<QzonePublishResult> {
+  async publish(
+    content: string,
+    richType?: number,
+    richval?: string,
+    ugcRight = 1,
+    targetUins?: string,
+  ): Promise<QzonePublishResult> {
     const cookieObject = await this.ctx.apis.web.getCookies('qzone.qq.com');
-    return publishQzoneMsg(cookieObject, this.ctx.identity.uin, content, richType, richval);
+    return publishQzoneMsg(cookieObject, this.ctx.identity.uin, content, richType, richval, ugcRight, targetUins);
   }
 
   /** 删除机器人自己空间的一条说说（按 tid）。 */

--- a/packages/core/tests/actions/_helpers.ts
+++ b/packages/core/tests/actions/_helpers.ts
@@ -65,6 +65,7 @@ export interface MockGroupFileApi {
   upload: ReturnType<typeof vi.fn>;
   uploadPrivate: ReturnType<typeof vi.fn>;
   publish: ReturnType<typeof vi.fn>;
+  trans: ReturnType<typeof vi.fn>;
   getCount: ReturnType<typeof vi.fn>;
   list: ReturnType<typeof vi.fn>;
   getUrl: ReturnType<typeof vi.fn>;
@@ -85,6 +86,7 @@ export function mockGroupFileApi(): MockGroupFileApi {
     upload: vi.fn(async () => ({ fileId: 'stub-fid' })),
     uploadPrivate: vi.fn(async () => ({ fileId: 'stub-pfid', fileHash: 'stub-hash' })),
     publish: vi.fn(async () => undefined),
+    trans: vi.fn(async () => ({ saveBusId: 102, saveFilePath: '/stub-path' })),
     getCount: vi.fn(async () => ({ fileCount: 0, maxCount: 10000 })),
     list: vi.fn(async () => ({ files: [], folders: [] })),
     getUrl: vi.fn(async () => 'stub://url'),

--- a/packages/core/tests/actions/group-file.test.ts
+++ b/packages/core/tests/actions/group-file.test.ts
@@ -8,6 +8,7 @@ import type {
   OidbGroupFileViewResp,
   OidbGroupFileFolderResp,
   OidbGroupSendFileReq,
+  OidbGroupSendFileResp,
 } from '@snowluma/proto-defs/oidb-actions/group-file';
 import type {
   OidbPrivateFileUploadResp,
@@ -243,6 +244,26 @@ describe('apis/group-file', () => {
         fileId: 'fid-publish',
         field5: true,
       }),
+    });
+  });
+
+  it('trans hits OIDB 0x6d9_0 and returns the saved path metadata', async () => {
+    const bridge = mockBridge();
+    bridge.sendRawPacket.mockResolvedValueOnce(packResponse(
+      protobuf_encode<OidbBase<OidbGroupSendFileResp>>({
+        body: { transFile: { saveBusId: 102, saveFilePath: '/saved/path' } },
+      }),
+    ));
+    const out = await new GroupFileApi(bridge as any).trans(12345, 'fid-trans');
+    expect(out).toEqual({ saveBusId: 102, saveFilePath: '/saved/path' });
+    const [wire, bytes] = bridge.sendRawPacket.mock.calls[0]!;
+    expect(wire).toBe('OidbSvcTrpcTcp.0x6d9_0');
+    const env = protobuf_decode<OidbBase<OidbGroupSendFileReq>>(bytes);
+    expect(env.body?.transFile).toMatchObject({
+      groupUin: 12345n,
+      appId: 7,
+      busId: 102,
+      fileId: 'fid-trans',
     });
   });
 

--- a/packages/core/tests/actions/qzone.test.ts
+++ b/packages/core/tests/actions/qzone.test.ts
@@ -74,7 +74,7 @@ describe('apis/qzone', () => {
     const pubSpy = vi.spyOn(qzoneWeb, 'publishQzoneMsg').mockResolvedValue({ tid: 'T', time: 1 });
     const out = await new QzoneApi(bridge as never).publish('hello');
     expect(getCookies).toHaveBeenCalledWith('qzone.qq.com');
-    expect(pubSpy).toHaveBeenCalledWith({ p_skey: 'PSK' }, '10001', 'hello', undefined, undefined);
+    expect(pubSpy).toHaveBeenCalledWith({ p_skey: 'PSK' }, '10001', 'hello', undefined, undefined, 1, undefined);
     expect(out).toEqual({ tid: 'T', time: 1 });
   });
 
@@ -85,7 +85,7 @@ describe('apis/qzone', () => {
     const richval = ',12345,abc,abc,22,800,600,,800,600';
     const out = await new QzoneApi(bridge as never).publish('look at this', 1, richval);
     expect(getCookies).toHaveBeenCalledWith('qzone.qq.com');
-    expect(pubSpy).toHaveBeenCalledWith({ p_skey: 'PSK' }, '10001', 'look at this', 1, richval);
+    expect(pubSpy).toHaveBeenCalledWith({ p_skey: 'PSK' }, '10001', 'look at this', 1, richval, 1, undefined);
     expect(out).toEqual({ tid: 'T2', time: 2 });
   });
 
@@ -96,8 +96,16 @@ describe('apis/qzone', () => {
     const richval = ',12345,a,a,22,800,600,,800,600\t,12346,b,b,22,1024,768,,1024,768';
     const out = await new QzoneApi(bridge as never).publish('two images', 1, richval);
     expect(getCookies).toHaveBeenCalledWith('qzone.qq.com');
-    expect(pubSpy).toHaveBeenCalledWith({ p_skey: 'PSK' }, '10001', 'two images', 1, richval);
+    expect(pubSpy).toHaveBeenCalledWith({ p_skey: 'PSK' }, '10001', 'two images', 1, richval, 1, undefined);
     expect(out).toEqual({ tid: 'T3', time: 3 });
+  });
+
+  it('publish threads qzone visibility params', async () => {
+    const getCookies = vi.fn(async () => ({ p_skey: 'PSK' }));
+    const bridge = mockBridge({ apis: { ...mockApiHub(), web: { getCookies } } as never });
+    const pubSpy = vi.spyOn(qzoneWeb, 'publishQzoneMsg').mockResolvedValue({ tid: 'T', time: 1 });
+    await new QzoneApi(bridge as never).publish('hello', undefined, undefined, 16, '10002|10003');
+    expect(pubSpy).toHaveBeenCalledWith({ p_skey: 'PSK' }, '10001', 'hello', undefined, undefined, 16, '10002|10003');
   });
 
   it('delete removes a feed by tid from the bot\'s own space', async () => {

--- a/packages/core/tests/bridge-private-routing.test.ts
+++ b/packages/core/tests/bridge-private-routing.test.ts
@@ -10,10 +10,15 @@ vi.mock('@snowluma/protocol/element-builder', () => ({
   buildSendElems: vi.fn(async () => [{ text: { str: 'stub media elem' } }]),
 }));
 
+// Imported statically (not via `await import` inside each `it`) so the heavy
+// Bridge dependency-tree load happens once at file collection — not against a
+// single test's 5s timeout, which tipped over on slower CI runners. vi.mock is
+// hoisted above these by vitest, so element-builder is still mocked.
+import { Bridge } from '../src/bridge/bridge';
+import { IdentityService } from '@snowluma/protocol/identity-service';
+
 describe('Bridge private media routing', () => {
   it('includes resolved uid in the final c2c send request for media messages', async () => {
-    const { Bridge } = await import('../src/bridge/bridge');
-    const { IdentityService } = await import('@snowluma/protocol/identity-service');
 
     class TestBridge extends Bridge {
       capturedBody: Uint8Array | null = null;
@@ -61,8 +66,6 @@ describe('Bridge private media routing', () => {
     // BuildPacketBase` + `FileEntity.PackMessageContent`. Previous
     // implementation wrote c2c routing + richText.notOnlineFile +
     // c2cCmd=11 — the QQ-NT server rejected every c2c file send.
-    const { Bridge } = await import('../src/bridge/bridge');
-    const { IdentityService } = await import('@snowluma/protocol/identity-service');
 
     class TestBridge extends Bridge {
       capturedBody: Uint8Array | null = null;
@@ -160,8 +163,6 @@ describe('Bridge private media routing', () => {
   });
 
   it('c2c file send survives a failing 0xE37_800 finalize — sends without field6 (#157 best-effort)', async () => {
-    const { Bridge } = await import('../src/bridge/bridge');
-    const { IdentityService } = await import('@snowluma/protocol/identity-service');
 
     class TestBridge extends Bridge {
       capturedBody: Uint8Array | null = null;

--- a/packages/mcp/src/generated/catalog.json
+++ b/packages/mcp/src/generated/catalog.json
@@ -9102,6 +9102,7 @@
           "name": "group_id",
           "type": "uint",
           "required": true,
+          "role": "group_id",
           "schema": {
             "type": "integer",
             "minimum": 1
@@ -9111,6 +9112,7 @@
           "name": "file_id",
           "type": "string",
           "required": true,
+          "role": "file_id",
           "schema": {
             "type": "string",
             "minLength": 1
@@ -9123,11 +9125,13 @@
         "properties": {
           "group_id": {
             "type": "integer",
-            "minimum": 1
+            "minimum": 1,
+            "x-role": "group_id"
           },
           "file_id": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "x-role": "file_id"
           }
         },
         "required": [

--- a/packages/mcp/src/generated/catalog.json
+++ b/packages/mcp/src/generated/catalog.json
@@ -9094,13 +9094,46 @@
     {
       "name": "trans_group_file",
       "aliases": [],
-      "summary": "转存群文件（未实现）",
+      "summary": "转存群文件",
+      "returns": "{ ok: true }",
       "readOnly": false,
-      "params": [],
+      "params": [
+        {
+          "name": "group_id",
+          "type": "uint",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        {
+          "name": "file_id",
+          "type": "string",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ],
       "invariants": [],
       "inputSchema": {
         "type": "object",
-        "properties": {},
+        "properties": {
+          "group_id": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "file_id": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "group_id",
+          "file_id"
+        ],
         "additionalProperties": true
       },
       "category": "扩展"

--- a/packages/mcp/src/generated/catalog.json
+++ b/packages/mcp/src/generated/catalog.json
@@ -7183,7 +7183,7 @@
     {
       "name": "send_qzone_msg",
       "aliases": [],
-      "summary": "发表说说（QQ 空间，支持纯文字或带图；传 images 自动上传）",
+      "summary": "发表说说（QQ 空间，支持纯文字或带图；传 images 自动上传；可设置查看权限）",
       "readOnly": false,
       "params": [
         {
@@ -7208,9 +7208,36 @@
             }
           },
           "desc": "图片数组（可选），支持 file:// http:// base64://；自动上传"
+        },
+        {
+          "name": "ugc_right",
+          "type": "int",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "desc": "查看权限：1=所有人可见，4=好友可见，16=部分好友可见，64=仅自己可见，128=部分好友不可见",
+          "default": 1
+        },
+        {
+          "name": "target_uins",
+          "type": "uint[]",
+          "required": false,
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          "desc": "权限作用 QQ 号数组；ugc_right=16 时表示可见名单，128 时表示不可见名单"
         }
       ],
-      "invariants": [],
+      "invariants": [
+        "ugc_right must be one of 1, 4, 16, 64, 128",
+        "target_uins is required when ugc_right is 16 or 128"
+      ],
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -7226,6 +7253,20 @@
               "minLength": 1
             },
             "description": "图片数组（可选），支持 file:// http:// base64://；自动上传"
+          },
+          "ugc_right": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "查看权限：1=所有人可见，4=好友可见，16=部分好友可见，64=仅自己可见，128=部分好友不可见",
+            "default": 1
+          },
+          "target_uins": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "权限作用 QQ 号数组；ugc_right=16 时表示可见名单，128 时表示不可见名单"
           }
         },
         "required": [

--- a/packages/mcp/src/generated/catalog.ts
+++ b/packages/mcp/src/generated/catalog.ts
@@ -9097,13 +9097,46 @@ export const ACTIONS: CatalogAction[] = [
   {
     "name": "trans_group_file",
     "aliases": [],
-    "summary": "转存群文件（未实现）",
+    "summary": "转存群文件",
+    "returns": "{ ok: true }",
     "readOnly": false,
-    "params": [],
+    "params": [
+      {
+        "name": "group_id",
+        "type": "uint",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "file_id",
+        "type": "string",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    ],
     "invariants": [],
     "inputSchema": {
       "type": "object",
-      "properties": {},
+      "properties": {
+        "group_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "file_id": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "group_id",
+        "file_id"
+      ],
       "additionalProperties": true
     },
     "category": "扩展"

--- a/packages/mcp/src/generated/catalog.ts
+++ b/packages/mcp/src/generated/catalog.ts
@@ -9105,6 +9105,7 @@ export const ACTIONS: CatalogAction[] = [
         "name": "group_id",
         "type": "uint",
         "required": true,
+        "role": "group_id",
         "schema": {
           "type": "integer",
           "minimum": 1
@@ -9114,6 +9115,7 @@ export const ACTIONS: CatalogAction[] = [
         "name": "file_id",
         "type": "string",
         "required": true,
+        "role": "file_id",
         "schema": {
           "type": "string",
           "minLength": 1
@@ -9126,11 +9128,13 @@ export const ACTIONS: CatalogAction[] = [
       "properties": {
         "group_id": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 1,
+          "x-role": "group_id"
         },
         "file_id": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "x-role": "file_id"
         }
       },
       "required": [

--- a/packages/mcp/src/generated/catalog.ts
+++ b/packages/mcp/src/generated/catalog.ts
@@ -7186,7 +7186,7 @@ export const ACTIONS: CatalogAction[] = [
   {
     "name": "send_qzone_msg",
     "aliases": [],
-    "summary": "发表说说（QQ 空间，支持纯文字或带图；传 images 自动上传）",
+    "summary": "发表说说（QQ 空间，支持纯文字或带图；传 images 自动上传；可设置查看权限）",
     "readOnly": false,
     "params": [
       {
@@ -7211,9 +7211,36 @@ export const ACTIONS: CatalogAction[] = [
           }
         },
         "desc": "图片数组（可选），支持 file:// http:// base64://；自动上传"
+      },
+      {
+        "name": "ugc_right",
+        "type": "int",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "desc": "查看权限：1=所有人可见，4=好友可见，16=部分好友可见，64=仅自己可见，128=部分好友不可见",
+        "default": 1
+      },
+      {
+        "name": "target_uins",
+        "type": "uint[]",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "desc": "权限作用 QQ 号数组；ugc_right=16 时表示可见名单，128 时表示不可见名单"
       }
     ],
-    "invariants": [],
+    "invariants": [
+      "ugc_right must be one of 1, 4, 16, 64, 128",
+      "target_uins is required when ugc_right is 16 or 128"
+    ],
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -7229,6 +7256,20 @@ export const ACTIONS: CatalogAction[] = [
             "minLength": 1
           },
           "description": "图片数组（可选），支持 file:// http:// base64://；自动上传"
+        },
+        "ugc_right": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "查看权限：1=所有人可见，4=好友可见，16=部分好友可见，64=仅自己可见，128=部分好友不可见",
+          "default": 1
+        },
+        "target_uins": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "description": "权限作用 QQ 号数组；ugc_right=16 时表示可见名单，128 时表示不可见名单"
         }
       },
       "required": [

--- a/packages/onebot/src/actions/extended.ts
+++ b/packages/onebot/src/actions/extended.ts
@@ -1636,10 +1636,15 @@ export const actions = [
 
   defineAction({
     name: 'trans_group_file',
-    summary: '转存群文件（未实现）',
-    params: {},
-    run: async () => {
-      return failedResponse(RETCODE.ACTION_FAILED, 'not yet implemented');
+    summary: '转存群文件',
+    returns: '{ ok: true }',
+    params: {
+      group_id: f.uint(),
+      file_id: f.string({ allowEmpty: false }),
+    },
+    run: async (p, ctx) => {
+      await ctx.bridge.apis.groupFile.trans(p.group_id, p.file_id);
+      return okResponse({ ok: true });
     },
   }),
 

--- a/packages/onebot/src/actions/extended.ts
+++ b/packages/onebot/src/actions/extended.ts
@@ -1639,8 +1639,8 @@ export const actions = [
     summary: '转存群文件',
     returns: '{ ok: true }',
     params: {
-      group_id: f.uint(),
-      file_id: f.string({ allowEmpty: false }),
+      group_id: f.groupId(),
+      file_id: f.fileId(),
     },
     run: async (p, ctx) => {
       await ctx.bridge.apis.groupFile.trans(p.group_id, p.file_id);

--- a/packages/onebot/src/actions/qzone.ts
+++ b/packages/onebot/src/actions/qzone.ts
@@ -21,6 +21,8 @@ async function uploadQzoneImages(
   return parts.join('\t');
 }
 
+const QZONE_UGC_RIGHTS = new Set<number>([1, 4, 16, 64, 128]);
+
 export const actions = [
   // get_qzone_msg_list — 获取 QQ 空间说说列表。无 go-cqhttp 标准，自定义命名。
   // 默认取机器人自己的空间；传 target_uin 可查看指定账号（需有权限）。
@@ -120,19 +122,25 @@ export const actions = [
   // 注意：发说说为主动行为，高频会被 Qzone 风控，调用方需自行限流。
   defineAction({
     name: 'send_qzone_msg',
-    summary: '发表说说（QQ 空间，支持纯文字或带图；传 images 自动上传）',
+    summary: '发表说说（QQ 空间，支持纯文字或带图；传 images 自动上传；可设置查看权限）',
     params: {
       content: f.string({ allowEmpty: false }).describe('说说正文'),
       images: f.array(f.string({ allowEmpty: false })).describe('图片数组（可选），支持 file:// http:// base64://；自动上传').optional(),
+      ugc_right: f.int({ min: 1 }).describe('查看权限：1=所有人可见，4=好友可见，16=部分好友可见，64=仅自己可见，128=部分好友不可见').default(1),
+      target_uins: f.array(f.uint()).describe('权限作用 QQ 号数组；ugc_right=16 时表示可见名单，128 时表示不可见名单').optional(),
     },
+    rules: (r) => [
+      r.rule('ugc_right must be one of 1, 4, 16, 64, 128', (p) => QZONE_UGC_RIGHTS.has(p.ugc_right)),
+      r.rule('target_uins is required when ugc_right is 16 or 128', (p) => (p.ugc_right !== 16 && p.ugc_right !== 128) || !!p.target_uins?.length),
+    ],
     run: async (p, ctx) => {
       try {
         if (p.images && p.images.length > 0) {
           const richval = await uploadQzoneImages(ctx, p.images, (upload) => upload.richval);
-          const res = await ctx.bridge.apis.qzone.publish(p.content, 1, richval);
+          const res = await ctx.bridge.apis.qzone.publish(p.content, 1, richval, p.ugc_right, p.target_uins?.join('|'));
           return okResponse(res as unknown as JsonValue);
         }
-        const res = await ctx.bridge.apis.qzone.publish(p.content);
+        const res = await ctx.bridge.apis.qzone.publish(p.content, undefined, undefined, p.ugc_right, p.target_uins?.join('|'));
         return okResponse(res as unknown as JsonValue);
       } catch (error) {
         const message = error instanceof Error ? error.message : 'failed to publish qzone msg';

--- a/packages/onebot/tests/extended-actions.test.ts
+++ b/packages/onebot/tests/extended-actions.test.ts
@@ -641,6 +641,31 @@ describe('extended-actions / get_group_shut_list', () => {
   });
 });
 
+// ─── Wave 1: trans_group_file (0x6D9_0) ───
+
+describe('extended-actions / trans_group_file', () => {
+  it('forwards group_id + file_id to apis.groupFile.trans and returns ok:true', async () => {
+    const trans = vi.fn(async () => ({ saveBusId: 102, saveFilePath: '/saved/path' }));
+    const bridge = fakeBridge({ apis: { groupFile: { trans } } });
+    const res = await makeHandler(fakeCtx(bridge)).handle('trans_group_file', {
+      group_id: 12345,
+      file_id: 'fid-trans',
+    });
+    expect(trans).toHaveBeenCalledWith(12345, 'fid-trans');
+    expect(res).toMatchObject({ status: 'ok', retcode: 0, data: { ok: true } });
+  });
+
+  it('rejects missing required params', async () => {
+    const trans = vi.fn();
+    const bridge = fakeBridge({ apis: { groupFile: { trans } } });
+    const r1 = await makeHandler(fakeCtx(bridge)).handle('trans_group_file', { file_id: 'fid' });
+    const r2 = await makeHandler(fakeCtx(bridge)).handle('trans_group_file', { group_id: 12345 });
+    expect(r1).toMatchObject({ status: 'failed', retcode: 1400 });
+    expect(r2).toMatchObject({ status: 'failed', retcode: 1400 });
+    expect(trans).not.toHaveBeenCalled();
+  });
+});
+
 // ─── Wave 1: get_file (compose image→record cache) ───
 
 describe('extended-actions / get_file', () => {

--- a/packages/onebot/tests/qzone-actions.test.ts
+++ b/packages/onebot/tests/qzone-actions.test.ts
@@ -24,7 +24,7 @@ describe('qzone actions', () => {
     expect(res).toMatchObject({ status: 'ok', retcode: 0, data: { tid: 'T1', time: 1 } });
     expect(uploadImageFromSource).toHaveBeenNthCalledWith(1, 'file:///a.jpg');
     expect(uploadImageFromSource).toHaveBeenNthCalledWith(2, 'file:///b.jpg');
-    expect(publish).toHaveBeenCalledWith('hello', 1, 'RV1\tRV2');
+    expect(publish).toHaveBeenCalledWith('hello', 1, 'RV1\tRV2', 1, undefined);
   });
 
   it('comment_qzone uploads images and comments direct urls joined with tab', async () => {

--- a/packages/proto-defs/src/oidb-actions/group-file.ts
+++ b/packages/proto-defs/src/oidb-actions/group-file.ts
@@ -132,6 +132,19 @@ export interface OidbGroupFileResp {
   rename?:   pb<5, OidbGroupFileRetResp>;
   move?:     pb<6, OidbGroupFileRetResp>;
 }
+export interface OidbGroupTransFileReq {
+  groupUin?: pb<1, uint_64>;
+  appId?:    pb<2, uint_32>;
+  busId?:    pb<3, uint_32>;
+  fileId?:   pb<4, string>;
+}
+export interface OidbGroupTransFileResp {
+  retCode?:       pb<1, int_32>;
+  retMsg?:        pb<2, string>;
+  clientWording?: pb<3, string>;
+  saveBusId?:     pb<4, uint_32>;
+  saveFilePath?:  pb<5, string>;
+}
 export interface OidbGroupSendFileInfo {
   busiType?: pb<1, uint_32>;
   fileId?:   pb<2, string>;
@@ -145,7 +158,11 @@ export interface OidbGroupSendFileBody {
   info?:     pb<3, OidbGroupSendFileInfo>;
 }
 export interface OidbGroupSendFileReq {
+  transFile?: pb<1, OidbGroupTransFileReq>;
   body?: pb<5, OidbGroupSendFileBody>;
+}
+export interface OidbGroupSendFileResp {
+  transFile?: pb<1, OidbGroupTransFileResp>;
 }
 export interface OidbGroupFileCreateFolderReq {
   groupUin?:      pb<1, uint_32>;

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -332,6 +332,10 @@
       "types": "./src/oidb-services/group-file/publish-group-file.ts",
       "default": "./src/oidb-services/group-file/publish-group-file.ts"
     },
+    "./oidb-services/group-file/trans-group-file": {
+      "types": "./src/oidb-services/group-file/trans-group-file.ts",
+      "default": "./src/oidb-services/group-file/trans-group-file.ts"
+    },
     "./oidb-services/group-file/get-group-file-count": {
       "types": "./src/oidb-services/group-file/get-group-file-count.ts",
       "default": "./src/oidb-services/group-file/get-group-file-count.ts"

--- a/packages/protocol/src/oidb-services/group-file/trans-group-file.ts
+++ b/packages/protocol/src/oidb-services/group-file/trans-group-file.ts
@@ -1,0 +1,52 @@
+// 0x6D9_0 — transfer a temporary group file into permanent group storage.
+// Mirrors LagrangeV2's TransFileReqBody shape under the 0x6D9 family.
+
+import { protobuf_decode, protobuf_encode } from '@snowluma/proton';
+import type { OidbBase } from '@snowluma/proto-defs/oidb';
+import type {
+  OidbGroupSendFileReq,
+  OidbGroupSendFileResp,
+} from '@snowluma/proto-defs/oidb-actions/group-file';
+import { invokeOidb, type OidbSender } from '../../oidb-service';
+import { ensureRetCodeZero, toInt } from '../shared';
+
+export interface TransGroupFileResult {
+  saveBusId: number;
+  saveFilePath: string;
+}
+
+export namespace TransGroupFile {
+  export const command = 0x6D9;
+  export const subCommand = 0;
+
+  export interface Params { groupId: number; fileId: string; }
+  export type Deps = OidbSender;
+
+  export const serialize = (_ctx: Deps, p: Params): OidbGroupSendFileReq => ({
+    transFile: {
+      groupUin: BigInt(p.groupId),
+      appId: 7,
+      busId: 102,
+      fileId: p.fileId,
+    },
+  });
+
+  export const deserialize = (_ctx: Deps, body: OidbGroupSendFileResp): TransGroupFileResult => {
+    const result = body.transFile;
+    if (!result) throw new Error('group file transfer response missing');
+    ensureRetCodeZero('group file transfer', result.retCode, result.retMsg, result.clientWording);
+    return {
+      saveBusId: toInt(result.saveBusId),
+      saveFilePath: typeof result.saveFilePath === 'string' ? result.saveFilePath : '',
+    };
+  };
+
+  export const encode = (env: OidbBase<OidbGroupSendFileReq>): Uint8Array =>
+    protobuf_encode<OidbBase<OidbGroupSendFileReq>>(env);
+
+  export const decode = (bytes: Uint8Array): OidbBase<OidbGroupSendFileResp> =>
+    protobuf_decode<OidbBase<OidbGroupSendFileResp>>(bytes);
+
+  export const invoke = (deps: Deps, params: Params): Promise<TransGroupFileResult> =>
+    invokeOidb(deps, TransGroupFile, params);
+}

--- a/packages/protocol/src/web/qzone.ts
+++ b/packages/protocol/src/web/qzone.ts
@@ -370,6 +370,8 @@ interface RawPublishResponse {
   now?: number;
 }
 
+export type QzoneUgcRight = 1 | 4 | 16 | 64 | 128;
+
 /** Result of publishing a 说说. */
 export interface QzonePublishResult {
   [key: string]: JsonValue;
@@ -377,6 +379,31 @@ export interface QzonePublishResult {
   tid: string;
   /** Unix seconds the 说说 was published. */
   time: number;
+}
+
+const QZONE_UGC_RIGHTS = new Set<number>([1, 4, 16, 64, 128]);
+
+function normalizeQzoneUgcRight(ugcRight: number): QzoneUgcRight {
+  if (!QZONE_UGC_RIGHTS.has(ugcRight)) {
+    throw new Error('ugc_right must be one of 1, 4, 16, 64, 128');
+  }
+  return ugcRight as QzoneUgcRight;
+}
+
+function normalizeTargetUins(targetUins?: string): string {
+  const raw = (targetUins ?? '').trim();
+  if (!raw) return '';
+
+  const seen = new Set<string>();
+  for (const part of raw.split('|')) {
+    const uin = part.trim();
+    if (!uin) continue;
+    if (!/^\d+$/.test(uin)) {
+      throw new Error('target_uins must contain QQ numbers separated by |');
+    }
+    seen.add(uin);
+  }
+  return [...seen].join('|');
 }
 
 /**
@@ -399,6 +426,8 @@ export async function publishQzoneMsg(
   content: string,
   richType?: number,
   richval?: string,
+  ugcRight = 1,
+  targetUins?: string,
 ): Promise<QzonePublishResult> {
   if (!cookieObject || typeof cookieObject !== 'object') {
     throw new Error('cookieObject is required');
@@ -408,9 +437,15 @@ export async function publishQzoneMsg(
   }
   assertRichParams(richType, richval);
 
+  const right = normalizeQzoneUgcRight(ugcRight);
+  const effectiveTargetUins = right === 16 || right === 128 ? normalizeTargetUins(targetUins) : '';
+  if ((right === 16 || right === 128) && !effectiveTargetUins) {
+    throw new Error('target_uins is required when ugc_right is 16 or 128');
+  }
+
   const bkn = getBknFromCookie(cookieObject);
   const url = `https://h5.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_publish_v6?g_tk=${bkn}`;
-  const body = new URLSearchParams({
+  const bodyParams = new URLSearchParams({
     syn_tweet_verson: '1',
     paramstr: '1',
     pic_template: '',
@@ -421,14 +456,16 @@ export async function publishQzoneMsg(
     con: content,
     feedversion: '1',
     ver: '1',
-    ugc_right: '1',
+    ugc_right: String(right),
     to_sign: '0',
     who: '1',
     hostuin: hostUin,
     code_version: '1',
     format: 'json',
     qzreferrer: `https://user.qzone.qq.com/${hostUin}`,
-  }).toString();
+  });
+  if (effectiveTargetUins) bodyParams.set('allow_uins', effectiveTargetUins);
+  const body = bodyParams.toString();
 
   const text = await RequestUtil.HttpGetText(url, 'POST', body, {
     Cookie: cookieToString(cookieObject),

--- a/packages/protocol/tests/oidb-services/group-file/trans-group-file.test.ts
+++ b/packages/protocol/tests/oidb-services/group-file/trans-group-file.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { protobuf_decode, protobuf_encode } from '@snowluma/proton';
+import type { OidbBase } from '@snowluma/proto-defs/oidb';
+import type {
+  OidbGroupSendFileReq, OidbGroupSendFileResp,
+} from '@snowluma/proto-defs/oidb-actions/group-file';
+import type { SendPacketResult } from '@snowluma/common/packet-sender';
+
+import { TransGroupFile } from '../../../src/oidb-services/group-file/trans-group-file';
+
+function makeDeps(body?: OidbGroupSendFileResp) {
+  const responseData = body !== undefined
+    ? Buffer.from(protobuf_encode<OidbBase<OidbGroupSendFileResp>>({ body }))
+    : Buffer.alloc(0);
+  const r: SendPacketResult = { success: true, gotResponse: true, errorCode: 0, errorMessage: '', responseData };
+  return { sendRawPacket: vi.fn(async () => r) };
+}
+
+describe('TransGroupFile namespace', () => {
+  it('declares 0x6D9_0', () => {
+    expect(TransGroupFile.command).toBe(0x6D9);
+    expect(TransGroupFile.subCommand).toBe(0);
+  });
+
+  it('packages group + file id under the transFile slot', async () => {
+    const deps = makeDeps({ transFile: { saveBusId: 102, saveFilePath: '/abc' } });
+    const out = await TransGroupFile.invoke(deps, { groupId: 12345, fileId: 'fid' });
+    expect(out).toEqual({ saveBusId: 102, saveFilePath: '/abc' });
+    expect(deps.sendRawPacket).toHaveBeenCalledOnce();
+    const [wire, bytes] = deps.sendRawPacket.mock.calls[0]!;
+    expect(wire).toBe('OidbSvcTrpcTcp.0x6d9_0');
+    const env = protobuf_decode<OidbBase<OidbGroupSendFileReq>>(bytes);
+    expect(env.body?.transFile).toEqual({
+      groupUin: 12345n,
+      appId: 7,
+      busId: 102,
+      fileId: 'fid',
+    });
+  });
+
+  it('throws on missing transFile sub-message', async () => {
+    const deps = makeDeps({});
+    await expect(TransGroupFile.invoke(deps, { groupId: 1, fileId: 'f' }))
+      .rejects.toThrow(/transfer response missing/);
+  });
+
+  it('throws on non-zero retCode', async () => {
+    const deps = makeDeps({ transFile: { retCode: 7, retMsg: 'denied' } });
+    await expect(TransGroupFile.invoke(deps, { groupId: 1, fileId: 'f' }))
+      .rejects.toThrow(/code=7/);
+  });
+});

--- a/packages/protocol/tests/web/qzone.test.ts
+++ b/packages/protocol/tests/web/qzone.test.ts
@@ -218,6 +218,8 @@ describe('qzone / publishQzoneMsg (HTTP layer)', () => {
     expect(form.get('con')).toBe('hello 世界 & friends');
     expect(form.get('hostuin')).toBe('10000');
     expect(form.get('who')).toBe('1');
+    expect(form.get('ugc_right')).toBe('1');
+    expect(form.has('allow_uins')).toBe(false);
     expect(form.get('format')).toBe('json');
     expect(form.get('qzreferrer')).toBe('https://user.qzone.qq.com/10000');
   });
@@ -235,6 +237,39 @@ describe('qzone / publishQzoneMsg (HTTP layer)', () => {
     expect(form.get('richval')).toBe(richval);
   });
 
+  it('threads publish permission fields for restricted visibility', async () => {
+    const spy = vi.spyOn(RequestUtil, 'HttpGetText').mockResolvedValue(
+      '{"code":0,"t1_tid":"RIGHTTID","t1_time":"1700000000"}',
+    );
+
+    await expect(publishQzoneMsg(cookies, '10000', 'limited', undefined, undefined, 16, '10001 | 10002|10001')).resolves.toEqual({
+      tid: 'RIGHTTID',
+      time: 1700000000,
+    });
+
+    const [, , body] = spy.mock.calls[0]!;
+    const form = new URLSearchParams(body as string);
+    expect(form.get('ugc_right')).toBe('16');
+    expect(form.get('allow_uins')).toBe('10001|10002');
+    expect(form.get('who')).toBe('1');
+  });
+
+  it('ignores target_uins for non-restricted visibility', async () => {
+    const spy = vi.spyOn(RequestUtil, 'HttpGetText').mockResolvedValue(
+      '{"code":0,"t1_tid":"FRIENDTID","t1_time":"1700000000"}',
+    );
+
+    await expect(publishQzoneMsg(cookies, '10000', 'friends', undefined, undefined, 4, 'not-a-uin')).resolves.toEqual({
+      tid: 'FRIENDTID',
+      time: 1700000000,
+    });
+
+    const [, , body] = spy.mock.calls[0]!;
+    const form = new URLSearchParams(body as string);
+    expect(form.get('ugc_right')).toBe('4');
+    expect(form.has('allow_uins')).toBe(false);
+  });
+
   it('falls back to tid/now for alternate client builds', async () => {
     vi.spyOn(RequestUtil, 'HttpGetText').mockResolvedValue('{"code":0,"tid":"ALT","now":1700000001}');
     await expect(publishQzoneMsg(cookies, '10000', 'hi')).resolves.toEqual({ tid: 'ALT', time: 1700000001 });
@@ -250,6 +285,12 @@ describe('qzone / publishQzoneMsg (HTTP layer)', () => {
     const spy = vi.spyOn(RequestUtil, 'HttpGetText');
     await expect(publishQzoneMsg(cookies, '10000', 'hi', 1)).rejects.toThrow('richType and richval');
     await expect(publishQzoneMsg(cookies, '10000', 'hi', undefined, ',123')).rejects.toThrow('richType and richval');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('rejects restricted visibility without target_uins before any request', async () => {
+    const spy = vi.spyOn(RequestUtil, 'HttpGetText');
+    await expect(publishQzoneMsg(cookies, '10000', 'hi', undefined, undefined, 128)).rejects.toThrow('target_uins is required');
     expect(spy).not.toHaveBeenCalled();
   });
 

--- a/packages/webui/src/components/debug/action-tester.tsx
+++ b/packages/webui/src/components/debug/action-tester.tsx
@@ -8,7 +8,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { motion } from 'motion/react';
 import { AlertTriangle, FlaskConical, History, Loader2, Play, RotateCcw, ShieldCheck, Trash2, Zap } from 'lucide-react';
-import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { Picker } from '@/components/ui/picker';
 import { JsonTree } from '@/components/ui/json-tree';
@@ -26,6 +25,10 @@ const cardCls = 'rounded-2xl border border-border/60 bg-card/80 shadow-[0_1px_2p
 // positives just add one extra click; false negatives skip a confirm — both low
 // stakes (the amber banner already warns that any write is real).
 const DESTRUCTIVE_RE = /(kick|ban|mute|recall|withdraw|delete|del_|dismiss|disband|leave|quit|remove|revoke)/i;
+
+function qqAvatarUrl(uin: string) {
+  return `/avatar/${encodeURIComponent(uin)}`;
+}
 
 function coerceParam(type: string, raw: string): unknown {
   if (raw === '') return undefined;
@@ -81,6 +84,18 @@ export function ActionTester({ accounts, docs, presetAction }: { accounts: QQInf
   const effectiveMode = paramMode === 'json' || !doc ? 'json' : 'form';
   const isStream = !!doc?.stream;
   const isDestructive = DESTRUCTIVE_RE.test(actionName);
+
+  const accountOptions = useMemo(
+    () => accounts.length === 0
+      ? [{ value: '', label: '(无在线账号)' }]
+      : accounts.map((a) => ({
+          value: a.uin,
+          label: a.nickname || a.uin,
+          sub: a.nickname ? a.uin : undefined,
+          avatar: qqAvatarUrl(a.uin),
+        })),
+    [accounts],
+  );
 
   const actionOptions = useMemo(
     () => docs.map((d) => ({ value: d.name, label: d.name, sub: d.summary })),
@@ -201,10 +216,15 @@ export function ActionTester({ accounts, docs, presetAction }: { accounts: QQInf
 
         <div className="grid gap-4 sm:grid-cols-2">
           <Field label="账号">
-            <Select value={uin} onChange={(e) => setUin(e.target.value)}>
-              {accounts.length === 0 && <option value="">(无在线账号)</option>}
-              {accounts.map((a) => <option key={a.uin} value={a.uin}>{a.nickname || a.uin}</option>)}
-            </Select>
+            <Picker
+              ariaLabel="选择账号"
+              value={uin}
+              onChange={setUin}
+              options={accountOptions}
+              placeholder="选择账号…"
+              validateRaw={() => false}
+              disabled={accounts.length === 0}
+            />
           </Field>
           <Field label="Action">
             <Picker

--- a/packages/webui/src/components/ui/picker.tsx
+++ b/packages/webui/src/components/ui/picker.tsx
@@ -50,6 +50,7 @@ export function Picker({
   const rootRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
+  const suppressTriggerClick = useRef(false);
 
   const selected = options.find((o) => o.value === value);
 
@@ -124,7 +125,13 @@ export function Picker({
         aria-label={ariaLabel}
         aria-haspopup="listbox"
         aria-expanded={open}
-        onClick={() => !disabled && setOpen((v) => !v)}
+        onClick={() => {
+          if (suppressTriggerClick.current) {
+            suppressTriggerClick.current = false;
+            return;
+          }
+          if (!disabled) setOpen((v) => !v);
+        }}
         className={cn(
           'flex h-9 w-full items-center gap-2 rounded-md border border-border bg-transparent px-3 text-sm outline-none transition-colors',
           'focus-visible:ring-[3px] focus-visible:ring-ring/40 focus-visible:border-ring disabled:opacity-50',
@@ -196,7 +203,11 @@ export function Picker({
                       role="option"
                       aria-selected={idx === active}
                       onMouseEnter={() => setActive(idx)}
-                      onClick={() => choose(idx)}
+                      onPointerDown={(e) => {
+                        e.preventDefault();
+                        suppressTriggerClick.current = true;
+                        choose(idx);
+                      }}
                       className={cn(
                         'absolute left-0 right-0 flex cursor-pointer items-center gap-2.5 px-3',
                         idx === active ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50',


### PR DESCRIPTION
## 关联 Issue

本 PR 修复 WebUI 调试页面中「账号」下拉框与「Action」下拉框样式不一致的问题。

## 变更说明

调试页面的账号选择原先使用原生 `Select`，而 Action 选择使用自定义 `Picker`，两者视觉和交互不一致。

本 PR 将账号选择器改为复用 `Picker` 组件：

- 账号下拉框样式与 Action 下拉框保持一致。
- 账号选项展示昵称，存在昵称时将 UIN 作为副文本展示。
- 接入 `/avatar/:uin` 头像代理，在触发按钮和下拉列表中显示账号头像。
- 无在线账号时显示 `(无在线账号)` 并保持禁用态。
- 同步保留 Picker 选中后自动收起逻辑，避免选择后菜单被同一次点击再次展开。

## 提交前检查

- [x] 本 PR 聚焦单一目标，未夹带无关改动
- [x] 已通过 `pnpm lint` 与 `pnpm typecheck`
- [ ] 已补充/更新相关测试，且 `pnpm test` 通过
- [x] 文件行尾为 LF（未引入 CRLF）
- [x] PR 描述与实际实现一致

样图：
<img width="1227" height="654" alt="e968e9de47445623374c4a5626283e84" src="https://github.com/user-attachments/assets/149b136f-13fe-48b7-a017-f58c4d7e1299" />
原样式：
<img width="846" height="652" alt="image" src="https://github.com/user-attachments/assets/9c8cdec5-2565-4955-8f6f-c0c15a612522" />

