### PR TITLE
fix(webui): align debug account picker styling

### DIFF
--- a/packages/webui/src/components/debug/action-tester.tsx
+++ b/packages/webui/src/components/debug/action-tester.tsx
@@ -8,7 +8,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { motion } from 'motion/react';
 import { AlertTriangle, FlaskConical, History, Loader2, Play, RotateCcw, ShieldCheck, Trash2, Zap } from 'lucide-react';
-import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { Picker } from '@/components/ui/picker';
 import { JsonTree } from '@/components/ui/json-tree';
@@ -26,6 +25,10 @@ const cardCls = 'rounded-2xl border border-border/60 bg-card/80 shadow-[0_1px_2p
 // positives just add one extra click; false negatives skip a confirm — both low
 // stakes (the amber banner already warns that any write is real).
 const DESTRUCTIVE_RE = /(kick|ban|mute|recall|withdraw|delete|del_|dismiss|disband|leave|quit|remove|revoke)/i;
+
+function qqAvatarUrl(uin: string) {
+  return `/avatar/${encodeURIComponent(uin)}`;
+}
 
 function coerceParam(type: string, raw: string): unknown {
   if (raw === '') return undefined;
@@ -81,6 +84,18 @@ export function ActionTester({ accounts, docs, presetAction }: { accounts: QQInf
   const effectiveMode = paramMode === 'json' || !doc ? 'json' : 'form';
   const isStream = !!doc?.stream;
   const isDestructive = DESTRUCTIVE_RE.test(actionName);
+
+  const accountOptions = useMemo(
+    () => accounts.length === 0
+      ? [{ value: '', label: '(无在线账号)' }]
+      : accounts.map((a) => ({
+          value: a.uin,
+          label: a.nickname || a.uin,
+          sub: a.nickname ? a.uin : undefined,
+          avatar: qqAvatarUrl(a.uin),
+        })),
+    [accounts],
+  );
 
   const actionOptions = useMemo(
     () => docs.map((d) => ({ value: d.name, label: d.name, sub: d.summary })),
@@ -201,10 +216,15 @@ export function ActionTester({ accounts, docs, presetAction }: { accounts: QQInf
 
         <div className="grid gap-4 sm:grid-cols-2">
           <Field label="账号">
-            <Select value={uin} onChange={(e) => setUin(e.target.value)}>
-              {accounts.length === 0 && <option value="">(无在线账号)</option>}
-              {accounts.map((a) => <option key={a.uin} value={a.uin}>{a.nickname || a.uin}</option>)}
-            </Select>
+            <Picker
+              ariaLabel="选择账号"
+              value={uin}
+              onChange={setUin}
+              options={accountOptions}
+              placeholder="选择账号…"
+              validateRaw={() => false}
+              disabled={accounts.length === 0}
+            />
           </Field>
           <Field label="Action">
             <Picker

--- a/packages/webui/src/components/ui/picker.tsx
+++ b/packages/webui/src/components/ui/picker.tsx
@@ -50,6 +50,7 @@ export function Picker({
   const rootRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
+  const suppressTriggerClick = useRef(false);
 
   const selected = options.find((o) => o.value === value);
 
@@ -124,7 +125,13 @@ export function Picker({
         aria-label={ariaLabel}
         aria-haspopup="listbox"
         aria-expanded={open}
-        onClick={() => !disabled && setOpen((v) => !v)}
+        onClick={() => {
+          if (suppressTriggerClick.current) {
+            suppressTriggerClick.current = false;
+            return;
+          }
+          if (!disabled) setOpen((v) => !v);
+        }}
         className={cn(
           'flex h-9 w-full items-center gap-2 rounded-md border border-border bg-transparent px-3 text-sm outline-none transition-colors',
           'focus-visible:ring-[3px] focus-visible:ring-ring/40 focus-visible:border-ring disabled:opacity-50',
@@ -196,7 +203,11 @@ export function Picker({
                       role="option"
                       aria-selected={idx === active}
                       onMouseEnter={() => setActive(idx)}
-                      onClick={() => choose(idx)}
+                      onPointerDown={(e) => {
+                        e.preventDefault();
+                        suppressTriggerClick.current = true;
+                        choose(idx);
+                      }}
                       className={cn(
                         'absolute left-0 right-0 flex cursor-pointer items-center gap-2.5 px-3',
                         idx === active ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50',


### PR DESCRIPTION
## 关联 Issue

本 PR 修复 WebUI 调试页面中「账号」下拉框与「Action」下拉框样式不一致的问题。

## 变更说明

调试页面的账号选择原先使用原生 `Select`，而 Action 选择使用自定义 `Picker`，两者视觉和交互不一致。

本 PR 将账号选择器改为复用 `Picker` 组件：

- 账号下拉框样式与 Action 下拉框保持一致。
- 账号选项展示昵称，存在昵称时将 UIN 作为副文本展示。
- 接入 `/avatar/:uin` 头像代理，在触发按钮和下拉列表中显示账号头像。
- 无在线账号时显示 `(无在线账号)` 并保持禁用态。
- 同步保留 Picker 选中后自动收起逻辑，避免选择后菜单被同一次点击再次展开。

## 提交前检查

- [x] 本 PR 聚焦单一目标，未夹带无关改动
- [x] 已通过 `pnpm lint` 与 `pnpm typecheck`
- [ ] 已补充/更新相关测试，且 `pnpm test` 通过
- [x] 文件行尾为 LF（未引入 CRLF）
- [x] PR 描述与实际实现一致

样图：
<img width="1227" height="654" alt="e968e9de47445623374c4a5626283e84" src="https://github.com/user-attachments/assets/149b136f-13fe-48b7-a017-f58c4d7e1299" />
原样式：
<img width="846" height="652" alt="image" src="https://github.com/user-attachments/assets/9c8cdec5-2565-4955-8f6f-c0c15a612522" />

