### PR TITLE
feat(webui): add load button to process probe dialog

### DIFF
--- a/packages/webui/src/components/pages/processes-page.tsx
+++ b/packages/webui/src/components/pages/processes-page.tsx
@@ -263,6 +263,12 @@ export function ProcessesPage() {
           processName={probeDialog.name}
           open={!!probeDialog}
           onOpenChange={(open) => !open && setProbeDialog(null)}
+          onLoad={() => {
+            if (probeDialog) {
+              void load(probeDialog.pid);
+              setProbeDialog(null);
+            }
+          }}
         />
       )}
     </div>

--- a/packages/webui/src/components/process-probe-dialog.tsx
+++ b/packages/webui/src/components/process-probe-dialog.tsx
@@ -25,13 +25,14 @@ interface ProcessProbeDialogProps {
   processName: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onLoad?: () => void;
 }
 
 function qqAvatarUrl(uin: string) {
   return `/avatar/${encodeURIComponent(uin)}`;
 }
 
-export function ProcessProbeDialog({ pid, processName, open, onOpenChange }: ProcessProbeDialogProps) {
+export function ProcessProbeDialog({ pid, processName, open, onOpenChange, onLoad }: ProcessProbeDialogProps) {
   const api = useApi();
   const [loading, setLoading] = useState(false);
   const [info, setInfo] = useState<QqPortLoginInfo | null>(null);
@@ -127,6 +128,11 @@ export function ProcessProbeDialog({ pid, processName, open, onOpenChange }: Pro
             <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
               关闭
             </Button>
+            {!loading && info?.loggedIn && onLoad && (
+              <Button size="sm" onClick={onLoad}>
+                加载
+              </Button>
+            )}
             {!loading && (
               <Button size="sm" onClick={probe}>
                 <Eye className="size-3.5" /> 重新探测


### PR DESCRIPTION
<!-- 感谢贡献。请填写以下内容，方便评审。 -->

## 关联 Issue

无。为探测弹窗增加加载按钮，便于探测后一键注入（现有情况是先关弹窗再注入）
示例效果：
<img width="608" height="363" alt="image" src="https://github.com/user-attachments/assets/5987f9e7-6f74-4f14-b8d1-6c5af9690492" />


## 变更说明

## 改动总结

- packages/webui/src/components/process-probe-dialog.tsx
  - `ProcessProbeDialogProps` 接口新增可选属性 `onLoad?: () => void`
  - 组件解构参数中接收 `onLoad`
  - 在操作按钮区域新增"加载"按钮，条件为：非加载中 && 已登录 (`info?.loggedIn`) && `onLoad` 存在时才渲染

**目的：** 将"探测成功后直接加载该进程"的能力通过回调暴露给父组件，使 Dialog 本身保持无状态、职责单一。

- packages/webui/src/components/pages/processes-page.tsx
  - 在 `<ProcessProbeDialog>` 的使用处传入 `onLoad` 回调
  - 回调逻辑：调用 `load(probeDialog.pid)` 加载对应进程，然后关闭 Dialog（`setProbeDialog(null)`）

**目的：** 在进程探测 Dialog 中探测到已登录的进程后，用户可以直接点击"加载"一键完成加载，无需手动关闭 Dialog 再回到列表操作，提升交互效率。

## 提交前检查

- [x] 本 PR 聚焦单一目标，未夹带无关改动
- [x] 已通过 `pnpm lint` 与 `pnpm typecheck`
- [x] 已补充/更新相关测试，且 `pnpm test` 通过
- [x] 文件行尾为 LF（未引入 CRLF）
- [x] PR 描述与实际实现一致
- [x] 已通过实机测试，加载按钮功能正常
