### PR TITLE
feat(qzone,onebot): add set_qzone_ban action for qzone blacklist management

### DIFF
--- a/packages/core/src/bridge/apis/qzone.ts
+++ b/packages/core/src/bridge/apis/qzone.ts
@@ -4,6 +4,7 @@ import {
   getQzoneFeeds,
   getQzoneMsgList,
   publishQzoneMsg,
+  setQzoneBlack,
   setQzoneLike,
   updateQzoneMsgRight,
   uploadQzoneImageFromSource,
@@ -113,5 +114,15 @@ export class QzoneApi {
     const owner = targetUin && targetUin > 0 ? targetUin.toString() : selfUin;
     const cookieObject = await this.ctx.apis.web.getCookies('qzone.qq.com');
     return commentQzoneMsg(cookieObject, selfUin, owner, tid, content, richType, richval);
+  }
+
+  /**
+   * 拉黑或解除拉黑某人（修改机器人自身 QQ 空间黑名单）。
+   * `ban=true` 拉黑，`ban=false` 解除拉黑。
+   */
+  async setBlack(targetUin: number, ban: boolean): Promise<void> {
+    const selfUin = this.ctx.identity.uin;
+    const cookieObject = await this.ctx.apis.web.getCookies('qzone.qq.com');
+    await setQzoneBlack(cookieObject, selfUin, targetUin.toString(), ban);
   }
 }

--- a/packages/mcp/src/generated/catalog.json
+++ b/packages/mcp/src/generated/catalog.json
@@ -8904,6 +8904,57 @@
       "category": "扩展"
     },
     {
+      "name": "set_qzone_ban",
+      "aliases": [],
+      "summary": "拉黑或解除拉黑某人（修改机器人自身 QQ 空间黑名单；enable=true 拉黑，false 解除）",
+      "readOnly": false,
+      "params": [
+        {
+          "name": "user_id",
+          "type": "uint",
+          "required": true,
+          "role": "user_id",
+          "schema": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "desc": "目标 QQ 号"
+        },
+        {
+          "name": "enable",
+          "type": "bool",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          },
+          "desc": "true 拉黑，false 解除拉黑",
+          "default": true
+        }
+      ],
+      "invariants": [],
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "目标 QQ 号",
+            "x-role": "user_id"
+          },
+          "enable": {
+            "type": "boolean",
+            "description": "true 拉黑，false 解除拉黑",
+            "default": true
+          }
+        },
+        "required": [
+          "user_id"
+        ],
+        "additionalProperties": true
+      },
+      "category": "空间"
+    },
+    {
       "name": "set_qzone_msg_right",
       "aliases": [],
       "summary": "修改一条已发说说的查看权限（QQ 空间，按 tid）",
@@ -9921,7 +9972,7 @@
     },
     {
       "category": "空间",
-      "count": 8
+      "count": 9
     },
     {
       "category": "流式接口",

--- a/packages/mcp/src/generated/catalog.ts
+++ b/packages/mcp/src/generated/catalog.ts
@@ -8907,6 +8907,57 @@ export const ACTIONS: CatalogAction[] = [
     "category": "扩展"
   },
   {
+    "name": "set_qzone_ban",
+    "aliases": [],
+    "summary": "拉黑或解除拉黑某人（修改机器人自身 QQ 空间黑名单；enable=true 拉黑，false 解除）",
+    "readOnly": false,
+    "params": [
+      {
+        "name": "user_id",
+        "type": "uint",
+        "required": true,
+        "role": "user_id",
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "desc": "目标 QQ 号"
+      },
+      {
+        "name": "enable",
+        "type": "bool",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "desc": "true 拉黑，false 解除拉黑",
+        "default": true
+      }
+    ],
+    "invariants": [],
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "user_id": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "目标 QQ 号",
+          "x-role": "user_id"
+        },
+        "enable": {
+          "type": "boolean",
+          "description": "true 拉黑，false 解除拉黑",
+          "default": true
+        }
+      },
+      "required": [
+        "user_id"
+      ],
+      "additionalProperties": true
+    },
+    "category": "空间"
+  },
+  {
     "name": "set_qzone_msg_right",
     "aliases": [],
     "summary": "修改一条已发说说的查看权限（QQ 空间，按 tid）",
@@ -9925,7 +9976,7 @@ export const CATEGORIES: CatalogCategory[] = [
   },
   {
     "category": "空间",
-    "count": 8
+    "count": 9
   },
   {
     "category": "流式接口",

--- a/packages/onebot/src/actions/qzone.ts
+++ b/packages/onebot/src/actions/qzone.ts
@@ -230,5 +230,20 @@ export const actions = [
       return okResponse(res as unknown as JsonValue);
     },
   }),
+
+  // set_qzone_ban — 拉黑/解除拉黑某人（修改机器人自身 QQ 空间黑名单）。写操作。
+  // enable=true 拉黑，enable=false 解除拉黑。
+  defineAction({
+    name: 'set_qzone_ban',
+    summary: '拉黑或解除拉黑某人（修改机器人自身 QQ 空间黑名单；enable=true 拉黑，false 解除）',
+    params: {
+      user_id: f.userId().describe('目标 QQ 号'),
+      enable: f.bool().describe('true 拉黑，false 解除拉黑').default(true),
+    },
+    run: async (p, ctx) => {
+      await ctx.bridge.apis.qzone.setBlack(p.user_id, p.enable);
+      return okResponse(null);
+    },
+  }),
 ];
 

--- a/packages/onebot/tests/qzone-actions.test.ts
+++ b/packages/onebot/tests/qzone-actions.test.ts
@@ -89,4 +89,34 @@ describe('qzone actions', () => {
     expect(updateRight).not.toHaveBeenCalled();
   });
 
+  it('set_qzone_ban with enable=true calls setBlack with ban=true', async () => {
+    const setBlack = vi.fn().mockResolvedValue(undefined);
+    const handler = makeHandler({ setBlack });
+
+    const res = await handler.handle('set_qzone_ban', { user_id: 12345, enable: true });
+
+    expect(res).toMatchObject({ status: 'ok', retcode: 0 });
+    expect(setBlack).toHaveBeenCalledWith(12345, true);
+  });
+
+  it('set_qzone_ban with enable=false calls setBlack with ban=false', async () => {
+    const setBlack = vi.fn().mockResolvedValue(undefined);
+    const handler = makeHandler({ setBlack });
+
+    const res = await handler.handle('set_qzone_ban', { user_id: 12345, enable: false });
+
+    expect(res).toMatchObject({ status: 'ok', retcode: 0 });
+    expect(setBlack).toHaveBeenCalledWith(12345, false);
+  });
+
+  it('set_qzone_ban defaults enable to true', async () => {
+    const setBlack = vi.fn().mockResolvedValue(undefined);
+    const handler = makeHandler({ setBlack });
+
+    const res = await handler.handle('set_qzone_ban', { user_id: 12345 });
+
+    expect(res).toMatchObject({ status: 'ok', retcode: 0 });
+    expect(setBlack).toHaveBeenCalledWith(12345, true);
+  });
+
 });

--- a/packages/protocol/src/web/qzone.ts
+++ b/packages/protocol/src/web/qzone.ts
@@ -1066,9 +1066,10 @@ export async function setQzoneBlack(
   // parser that handles both real JSON and non-JSON object literals.
   let data: RawBlackActionResponse;
   try {
-    data = parseQzoneJson<RawBlackActionResponse>(text.replace("{name", "{\"name\""));
+    data = parseQzoneJson<RawBlackActionResponse>(text.replace(/\{\s*name\s*:/, '{"name":'));
   } catch {
-    throw new Error(`qzone ${ban ? 'ban' : 'unban'} failed: ${text}`);
+    const snippet = text.trim().slice(0, 300);
+    throw new Error(`qzone ${ban ? 'ban' : 'unban'} failed: ${snippet}${text.length > 300 ? '…' : ''}`);
   }
 
   const verb = ban ? 'ban' : 'unban';

--- a/packages/protocol/src/web/qzone.ts
+++ b/packages/protocol/src/web/qzone.ts
@@ -64,30 +64,53 @@ export interface QzoneMsgListResult {
 
 /**
  * Parse a Qzone CGI body that may be raw JSON or a JSONP callback wrapper
- * (`_Callback({...});` / `callback({...})`). We first attempt to slice from
- * the first `{` to the last `}`, when failed attempt from the first `back({`
- * to the last `})` and JSON.parse that — robust to either form without
- * pinning the callback name, which Qzone varies. Throws if no object body
- * is present (e.g. an HTML error page), which the caller turns into a
- * failed response rather than a silent empty list.
+ * (`_Callback({...});` / `callback({...})`). Uses a layered fallback approach:
+ *
+ * 1. Try direct JSON.parse on the first `{` to last `}` slice.
+ * 2. Try `back({...})` pattern (the original approach).
+ * 3. Extract `back(...)` content, trim, then locate `{}` inside.
+ *
+ * This is robust to the various callback name variants Qzone uses.
+ * Throws if no object body is present (e.g. an HTML error page).
  */
 export function parseQzoneJson<T>(text: string): T {
   const s = text.trim();
+
+  // 1st: try direct JSON parse via {}
   try {
     const start = s.indexOf('{');
     const end = s.lastIndexOf('}');
     if (start !== -1 && end !== -1 && end > start) {
       return JSON.parse(s.slice(start, end + 1)) as T;
     }
-  } catch {
+  } catch { /* fallback */ }
 
-  }
-  const start = s.indexOf('back({');
-  const end = s.lastIndexOf('})');
-  if (start === -1 || end === -1 || end < start) {
+  // 2nd: try back({...}) as a whole
+  try {
+    const start = s.indexOf('back({');
+    const end = s.lastIndexOf('})');
+    if (start !== -1 && end !== -1 && end > start) {
+      return JSON.parse(s.slice(start + 5, end + 1)) as T;
+    }
+  } catch { /* fallback */ }
+
+  // 3rd: find last back(...); occurrence, then extract {} from within
+  const backStart = s.lastIndexOf('back(');
+  if (backStart === -1) {
     throw new Error('invalid response from qzone api');
   }
-  return JSON.parse(s.slice(start + 5, end + 1)) as T;
+  // find the nearest ');' after back( to delimit the callback invocation
+  const callEnd = s.indexOf(');', backStart);
+  if (callEnd === -1) {
+    throw new Error('invalid response from qzone api');
+  }
+  const inner = s.slice(backStart + 5, callEnd).trim();
+  const braceStart = inner.indexOf('{');
+  const braceEnd = inner.lastIndexOf('}');
+  if (braceStart === -1 || braceEnd === -1 || braceEnd < braceStart) {
+    throw new Error('invalid response from qzone api');
+  }
+  return JSON.parse(inner.slice(braceStart, braceEnd + 1)) as T;
 }
 
 /**
@@ -988,6 +1011,79 @@ export interface QzoneCommentResult {
  * transport failure or a non-zero Qzone `code`/`subcode` (e.g. comments
  * disabled, no permission, or auth failure).
  */
+// ─────────────── 拉黑/解拉黑 (ban/unban) — cgi_black_action_new ───────────────
+// Adds or removes a user from the bot's QQ-Zone blacklist. The CGI is
+// w.qzone.qq.com/cgi-bin/right/cgi_black_action_new (proxied through
+// h5.qzone.qq.com). POST form-urlencoded with `action=1` to ban,
+// `action=2` to unban. Response is a callback-wrapped body
+// (frameElement.callback style). Confirmed against
+// php-qzone/qzone.class.php:setQzoneRight. WRITE OP.
+
+interface RawBlackActionResponse {
+  code?: number;
+  subcode?: number;
+  message?: string;
+  msg?: string;
+}
+
+/**
+ * Ban (blacklist) or unban a user in the bot's QQ-Zone space via
+ * w.qzone.qq.com's cgi_black_action_new CGI (proxied through
+ * h5.qzone.qq.com). `ban=true` adds the target to the blacklist
+ * (action=1); `ban=false` removes them (action=2). Resolves on success;
+ * THROWS on a transport failure or a non-zero Qzone `subcode`.
+ * Confirmed against php-qzone/qzone.class.php:setQzoneRight.
+ */
+export async function setQzoneBlack(
+  cookieObject: Record<string, string>,
+  selfUin: string,
+  targetUin: string,
+  ban: boolean,
+): Promise<void> {
+  if (!cookieObject || typeof cookieObject !== 'object') {
+    throw new Error('cookieObject is required');
+  }
+  if (!targetUin) {
+    throw new Error('targetUin is required');
+  }
+
+  const bkn = getBknFromCookie(cookieObject);
+  const url = `https://h5.qzone.qq.com/proxy/domain/w.qzone.qq.com/cgi-bin/right/cgi_black_action_new?g_tk=${bkn}`;
+  const body = new URLSearchParams({
+    uin: selfUin,
+    act_uin: targetUin,
+    action: ban ? '1' : '2',
+    fupdate: '1',
+    qzreferrer: `https://user.qzone.qq.com/${selfUin}/main`,
+  }).toString();
+
+  const text = await RequestUtil.HttpGetText(url, 'POST', body, {
+    Cookie: cookieToString(cookieObject),
+    'Content-Type': 'application/x-www-form-urlencoded',
+  });
+  // Response is callback-wrapped (frameElement.callback style) and may
+  // contain JS-object-literal syntax (unquoted keys) — use the JS-literal
+  // parser that handles both real JSON and non-JSON object literals.
+  let data: RawBlackActionResponse;
+  try {
+    data = parseQzoneJson<RawBlackActionResponse>(text.replace("{name", "{\"name\""));
+  } catch {
+    throw new Error(`qzone ${ban ? 'ban' : 'unban'} failed: ${text}`);
+  }
+
+  const verb = ban ? 'ban' : 'unban';
+  if (typeof data.subcode === 'number' && data.subcode !== 0) {
+    const msg = data.message ?? data.msg ?? '';
+    log.warn('setQzoneBlack(%s): non-zero subcode (target=%s) subcode=%d msg=%s', verb, targetUin, data.subcode, msg);
+    throw new Error(`qzone ${verb} failed: subcode=${data.subcode} ${msg}`.trim());
+  }
+  if (typeof data.code === 'number' && data.code !== 0) {
+    const msg = data.message ?? data.msg ?? '';
+    log.warn('setQzoneBlack(%s): non-zero code (target=%s) code=%d msg=%s', verb, targetUin, data.code, msg);
+    throw new Error(`qzone ${verb} failed: code=${data.code} ${msg}`.trim());
+  }
+}
+
 export async function commentQzoneMsg(
   cookieObject: Record<string, string>,
   selfUin: string,

--- a/packages/protocol/src/web/qzone.ts
+++ b/packages/protocol/src/web/qzone.ts
@@ -1061,9 +1061,9 @@ export async function setQzoneBlack(
     Cookie: cookieToString(cookieObject),
     'Content-Type': 'application/x-www-form-urlencoded',
   });
-  // Response is callback-wrapped (frameElement.callback style) and may
-  // contain JS-object-literal syntax (unquoted keys) — use the JS-literal
-  // parser that handles both real JSON and non-JSON object literals.
+  // Response is callback-wrapped (frameElement.callback style) and may contain
+  // a small JS-object-literal fragment like `{name:"Ack"}`. Patch the known
+  // unquoted key, then parse via the tolerant JSON/JSONP extractor.
   let data: RawBlackActionResponse;
   try {
     data = parseQzoneJson<RawBlackActionResponse>(text.replace(/\{\s*name\s*:/, '{"name":'));


### PR DESCRIPTION
<!-- 感谢贡献。请填写以下内容，方便评审。 -->

## 关联 Issue
为Qzone新增了空间拉黑/解拉黑的功能

新增端点：`/set_qzone_ban`，字段`user_id`&`enable`，true/1为拉黑、false/0为解除拉黑

示例resp.body: `{"user_id":"2047664746", "enable": true}`

## 变更说明

- `packages/protocol/src/web/qzone.ts`
  - 新增 `setQzoneBlack` 函数，调用 `w.qzone.qq.com/cgi-bin/right/cgi_black_action_new` CGI（h5 proxy），action=1 拉黑、action=2 解除。参考 `reference/php-qzone/qzone.class.php:setQzoneRight`。
    调用的cgi_black_action_new返回示例：
    ```
    <!DOCTYPE html>
    <html>
    <head>
    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
    </head>
    <body>
    <script type="text/javascript">
    var cb;try{document.domain="h5.qzone.qq.com";cb=frameElement.callback;}catch(e){try{document.domain="h5.qzone.qq.com";cb=frameElement.callback;}catch(e){document.domain="h5.qzone.qq.com";cb=frameElement.callback;}}
    frameElement.callback(
    {
        "code":0,
        "subcode":0,
        "message":"",
        "default":0,
        "data":
    {name:"Ack"}}
    );
    </script>
    </body>
    </html>
    ```
     将不符合json规范的{name:"Ack"}替换为了{"name":"Ack"}，以便解析
     注：此处已测试现有新增的parseQzoneCallback函数，并无法解析，故选择更简单的改动方式（此接口返回格式较为固定，已测试多个好友/非好友/self-uin，均暂未发现有特例）

  - 再度修复了`parseQzoneJson`的解析方式，新增了一个先寻找`back(`，向后找最近的`);`截取，再截取`{`到`}`的fallback
    
    由于同时存在js干扰与换行，现有的两种parse方式均失效（直接截取{} / 截取`back({`到`})`）
    且，若直接使用第三种方式，亦存在括号干扰会使parse失效，故在现有基础上再新增fallback

- `packages/core/src/bridge/apis/qzone.ts`
  - 导入 `setQzoneBlack`
  - `QzoneApi` 新增 `setBlack(targetUin, ban)` 方法

- `packages/onebot/src/actions/qzone.ts`
  - 新增 `set_qzone_ban` action，参数 `user_id`（目标 QQ 号）+ `enable`（bool，默认 true 拉黑，false 解除）

- `packages/onebot/tests/qzone-actions.test.ts`
  - 新增 3 个测试：enable=true、enable=false、默认值验证

- `packages/mcp/src/generated/catalog.ts`
  - 自动重新生成，包含新 action 元数据

- `packages/mcp/src/generated/catalog.json`
  - 同上，JSON 格式自动重新生成

## 提交前检查

- [x] 本 PR 聚焦单一目标，未夹带无关改动
- [x] 已通过 `pnpm lint` 与 `pnpm typecheck`
- [x] 已补充/更新相关测试，且 `pnpm test` 通过
- [x] 文件行尾为 LF（未引入 CRLF）
- [x] PR 描述与实际实现一致
- [x] 已通过真机实测
<img width="1285" height="420" alt="图片" src="https://github.com/user-attachments/assets/382c98d5-aadf-4f7b-bea8-9edbe7246b2d" />
<img width="1293" height="389" alt="图片" src="https://github.com/user-attachments/assets/16c404da-7c04-4a6a-be38-93046c5d3215" />

