### PR TITLE
fix(protocol): 修复collection的proto定义错误

### DIFF
--- a/packages/proto-defs/src/collection.ts
+++ b/packages/proto-defs/src/collection.ts
@@ -140,25 +140,24 @@ export interface CollectionLocationSummary {
 }
 
 export interface CollectionLinkSummary {
-  title?: pb<1, string>;
-  description?: pb<2, string>;
-  url?: pb<3, string>;
-  picList?: pb_repeated<4, CollectionPictureInfo>;
-  contentType?: pb<5, uint_32>;
-  originalUri?: pb<6, string>;
-  publisher?: pb<7, string>;
-  version?: pb<8, uint_32>;
+  url?: pb<1, string>;
+  title?: pb<2, string>;
+  publisher?: pb<3, string>;
+  brief?: pb<4, string>;
+  picList?: pb_repeated<5, CollectionPictureInfo>;
+  contentType?: pb<6, uint_32>;
+  field7?: pb<7, string>;
 }
 
 export interface CollectionSummary {
   textSummary?: pb<1, CollectionTextSummary>;
-  richMediaSummary?: pb<2, CollectionRichMediaSummary>;
+  linkSummary?: pb<2, CollectionLinkSummary>;
   gallerySummary?: pb<3, CollectionGallerySummary>;
   audioSummary?: pb<4, CollectionAudioSummary>;
   videoSummary?: pb<5, CollectionVideoSummary>;
   fileSummary?: pb<6, CollectionFileSummary>;
   locationSummary?: pb<7, CollectionLocationSummary>;
-  linkSummary?: pb<8, CollectionLinkSummary>;
+  richMediaSummary?: pb<8, CollectionRichMediaSummary>;
 }
 
 export interface CollectionItem {

--- a/packages/protocol/tests/web/collection.test.ts
+++ b/packages/protocol/tests/web/collection.test.ts
@@ -58,8 +58,36 @@ interface CollectionTextSummaryOracle {
   truncated?: pb<2, bool>;
 }
 
+interface CollectionPictureInfoOracle {
+  url?: pb<1, string>;
+  width?: pb<6, uint_32>;
+  height?: pb<7, uint_32>;
+}
+
+interface CollectionLinkSummaryOracle {
+  url?: pb<1, string>;
+  title?: pb<2, string>;
+  publisher?: pb<3, string>;
+  brief?: pb<4, string>;
+  picList?: pb_repeated<5, CollectionPictureInfoOracle>;
+  contentType?: pb<6, uint_32>;
+}
+
+interface CollectionRichMediaSummaryOracle {
+  title?: pb<1, string>;
+  subTitle?: pb<2, string>;
+  brief?: pb<3, string>;
+  picList?: pb_repeated<4, CollectionPictureInfoOracle>;
+  contentType?: pb<5, uint_32>;
+  originalUri?: pb<6, string>;
+  publisher?: pb<7, string>;
+  richMediaVersion?: pb<8, uint_32>;
+}
+
 interface CollectionSummaryOracle {
   textSummary?: pb<1, CollectionTextSummaryOracle>;
+  linkSummary?: pb<2, CollectionLinkSummaryOracle>;
+  richMediaSummary?: pb<8, CollectionRichMediaSummaryOracle>;
 }
 
 interface CollectionItemOracle {
@@ -256,6 +284,84 @@ describe('getCollectionList', () => {
       },
     });
     expect(transport).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps a type 2 link summary whose brief is a string without throwing', async () => {
+    // Regression: the old proto declared CollectionLinkSummary.picList at field 4,
+    // but the server puts the `brief` string there. Decoding a string as a message
+    // reads its first byte (0x43 = 'C') as a start-group tag and throws
+    // "protobuf unterminated group". The link summary now maps field 4 as brief.
+    const linkSummary: CollectionLinkSummaryOracle = {
+      url: 'https://example.invalid/article',
+      title: 'Example Article',
+      publisher: 'Example Publisher',
+      brief: 'Candy summary text that starts with a group-start byte',
+      picList: [{ url: 'https://example.invalid/cover.jpg', width: 1280, height: 720 }],
+      contentType: 1,
+    };
+
+    const result = await getCollectionList({
+      uin: '10001',
+      pskey: 'ticket-value',
+      transport: async () => successResponse([{
+        cid: 'cid-link',
+        type: 2,
+        author: { numId: 1n },
+        modifyTime: 1_200n,
+        summary: { linkSummary },
+      }], 1),
+    });
+
+    const item = result.collectionSearchList.collectionItemList[0];
+    expect(item.type).toBe(2);
+    expect(item.summary.linkSummary).toMatchObject({
+      url: 'https://example.invalid/article',
+      title: 'Example Article',
+      publisher: 'Example Publisher',
+      brief: 'Candy summary text that starts with a group-start byte',
+      picList: [{ url: 'https://example.invalid/cover.jpg', field6: 1280, field7: 720 }],
+      contentType: 1,
+    });
+    expect(item.summary.richMediaSummary).toBeNull();
+  });
+
+  it('maps a type 8 rich media summary at field 8', async () => {
+    const richMediaSummary: CollectionRichMediaSummaryOracle = {
+      title: 'Rich Media Title',
+      subTitle: 'Rich Media Subtitle',
+      brief: 'Rich media brief',
+      picList: [{ url: 'https://example.invalid/rich.jpg', width: 800, height: 600 }],
+      contentType: 2,
+      originalUri: 'https://example.invalid/original',
+      publisher: 'Rich Publisher',
+      richMediaVersion: 3,
+    };
+
+    const result = await getCollectionList({
+      uin: '10001',
+      pskey: 'ticket-value',
+      transport: async () => successResponse([{
+        cid: 'cid-rich',
+        type: 8,
+        author: { numId: 2n },
+        modifyTime: 1_300n,
+        summary: { richMediaSummary },
+      }], 1),
+    });
+
+    const item = result.collectionSearchList.collectionItemList[0];
+    expect(item.type).toBe(8);
+    expect(item.summary.richMediaSummary).toMatchObject({
+      title: 'Rich Media Title',
+      subTitle: 'Rich Media Subtitle',
+      brief: 'Rich media brief',
+      picList: [{ url: 'https://example.invalid/rich.jpg', field6: 800, field7: 600 }],
+      contentType: 2,
+      originalUri: 'https://example.invalid/original',
+      publisher: 'Rich Publisher',
+      richMediaVersion: 3,
+    });
+    expect(item.summary.linkSummary).toBeNull();
   });
 
   it('filters categories while following a strictly decreasing cursor', async () => {


### PR DESCRIPTION
<!-- 感谢贡献。请填写以下内容，方便评审。 -->

## 关联 Issue

无

获取收藏列表protobuf解码崩溃，日志如下：
```plaintext
09:32:48 WARN  [1707889225] [Bridge.Action] get_collection_list failed: protobuf unterminated group
Error: protobuf unterminated group
    at __skipUnknownField$98 (file:///C:/Users/17078/Documents/GitHub/SnowLuma/dist/index.mjs:48155:9)
    at protobuf_decode_CollectionPictureInfo (file:///C:/Users/17078/Documents/GitHub/SnowLuma/dist/index.mjs:48550:14)
    at protobuf_decode_CollectionRichMediaSummary (file:///C:/Users/17078/Documents/GitHub/SnowLuma/dist/index.mjs:48650:14)
    at protobuf_decode_CollectionSummary (file:///C:/Users/17078/Documents/GitHub/SnowLuma/dist/index.mjs:49513:11)
    at protobuf_decode_CollectionItem (file:///C:/Users/17078/Documents/GitHub/SnowLuma/dist/index.mjs:49749:12)
    at protobuf_decode_GetCollectionListResponse (file:///C:/Users/17078/Documents/GitHub/SnowLuma/dist/index.mjs:49884:14)
    at protobuf_decode_CollectionResponseOperation (file:///C:/Users/17078/Documents/GitHub/SnowLuma/dist/index.mjs:49964:11)
    at protobuf_decode_CollectionResponseBody (file:///C:/Users/17078/Documents/GitHub/SnowLuma/dist/index.mjs:50028:11)
    at decodeEnvelope (file:///C:/Users/17078/Documents/GitHub/SnowLuma/dist/index.mjs:50760:9)
    at getCollectionList (file:///C:/Users/17078/Documents/GitHub/SnowLuma/dist/index.mjs:50958:20)
```

<!-- 例如 Closes #123。若无关联 issue，请说明这个 PR 解决什么问题、为何现在做。 -->

## 变更说明

  `get_collection_list` 解码收藏列表时抛 `protobuf unterminated group`,崩在`CollectionPictureInfo`。

  根因:type=2(链接类收藏)的 proto 定义和服务端真实返回字段错位。真实布局里`picList`(图片,message)在 field 5
  而定义写成field 4
  
  field 4实际是个字符串。解码器把字符串当 message 递归解,首字节  0x43 被读成 group 起始标签,找不到配对结束标签 → 报错。

  顺带发现第二个 bug:`CollectionSummary` 把 field 2 和 field 8 的 `link/richMedia` 命名反了(真实规律是 field 号 == 收藏 type,type2=link 在 field2、type8=richMedia 在 field8)。

 - proto-defs/src/collection.ts
    - 重写 CollectionLinkSummary 字段:按实测改为
  url(1)/title(2)/publisher(3)/brief(4)/picList(5)/contentType(6)。
    - CollectionSummary 的 field 2↔8

  - web/collection.ts 的 mapItem 无需改(linkSummary 走通用透传)。

  验证:用真机 dump(50 条收藏)确认整个响应不再 throw;proto-defs/protocol

## 提交前检查

- [x] 本 PR 聚焦单一目标，未夹带无关改动
- [x] 已通过 `pnpm lint` 与 `pnpm typecheck`
- [x] 已补充/更新相关测试，且 `pnpm test` 通过
- [x] 文件行尾为 LF（未引入 CRLF）
- [x] PR 描述与实际实现一致
