### PR TITLE
feat(web): 新增获取任意 QQ 号个性装扮接口

### DIFF
--- a/packages/core/src/bridge/apis/web.ts
+++ b/packages/core/src/bridge/apis/web.ts
@@ -2,6 +2,7 @@ import { loadBinarySource } from '@snowluma/protocol/highway/utils';
 import { ForceFetchClientKey, type ClientKeyInfo as NamespaceClientKeyInfo } from '@snowluma/protocol/oidb-services/web/force-fetch-client-key';
 import { GetPskey } from '@snowluma/protocol/oidb-services/web/get-pskey';
 import { getGroupEssenceMsg, getGroupEssenceMsgAll, type GroupEssenceMsgRet } from '@snowluma/protocol/web/group-essence';
+import { getFriendDressWebAPI, type WebFriendDress } from '@snowluma/protocol/web/friend-dress';
 import { getHonorListWebAPI, WebHonorType, type WebHonorItem } from '@snowluma/protocol/web/group-honor';
 import { getDaySignedListWebAPI, type SignedListMember } from '@snowluma/protocol/web/group-signin';
 import {
@@ -416,5 +417,15 @@ export class WebApi {
     const groupCode = groupId.toString();
     const cookieObject = await getCookies(bridge, 'qun.qq.com');
     return await deleteGroupNoticeHttp(cookieObject, groupCode, fid);
+  }
+
+  // ─────────────── friend dress (好友装扮) ───────────────
+
+  /** 查某人正在用的好友装扮（挂件/名片/来电/输入状态等）。走 vip.qq.com 域，
+   *  纯 cookie 鉴权、抓 SSR HTML；解析不出（未登录态/风控/页面改版）返回 null。 */
+  async getFriendDress(targetUin: number): Promise<WebFriendDress | null> {
+    const bridge = asBridge(this.ctx);
+    const cookieObject = await getCookies(bridge, 'vip.qq.com');
+    return getFriendDressWebAPI(cookieObject, targetUin.toString());
   }
 }

--- a/packages/core/src/bridge/apis/web.ts
+++ b/packages/core/src/bridge/apis/web.ts
@@ -422,8 +422,9 @@ export class WebApi {
   // ─────────────── friend dress (好友装扮) ───────────────
 
   /** 查某人正在用的好友装扮（挂件/名片/来电/输入状态等）。走 vip.qq.com 域，
-   *  纯 cookie 鉴权、抓 SSR HTML；解析不出（未登录态/风控/页面改版）返回 null。 */
-  async getFriendDress(targetUin: number): Promise<WebFriendDress | null> {
+   *  纯 cookie 鉴权、抓 SSR HTML。「查到但没装扮」返回空 items；网络/未登录态/
+   *  风控/页面改版/串号数据抛 FriendDressError（kind 区分具体环节）。 */
+  async getFriendDress(targetUin: number): Promise<WebFriendDress> {
     const bridge = asBridge(this.ctx);
     const cookieObject = await getCookies(bridge, 'vip.qq.com');
     return getFriendDressWebAPI(cookieObject, targetUin.toString());

--- a/packages/mcp/src/generated/catalog.json
+++ b/packages/mcp/src/generated/catalog.json
@@ -59,6 +59,43 @@
       "category": "扩展"
     },
     {
+      "name": "_get_friend_dress",
+      "aliases": [],
+      "summary": "获取指定 QQ 号正在使用的个性装扮（挂件/名片/来电/输入状态等）",
+      "returns": "装扮列表；解析不到（未登录态/风控/页面改版）时 items 为空",
+      "readOnly": true,
+      "params": [
+        {
+          "name": "user_id",
+          "type": "uint",
+          "required": true,
+          "role": "user_id",
+          "schema": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "desc": "目标 QQ 号"
+        }
+      ],
+      "invariants": [],
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "目标 QQ 号",
+            "x-role": "user_id"
+          }
+        },
+        "required": [
+          "user_id"
+        ],
+        "additionalProperties": true
+      },
+      "category": "扩展"
+    },
+    {
       "name": "_get_group_notice",
       "aliases": [],
       "summary": "获取群公告",
@@ -10916,7 +10953,7 @@
     },
     {
       "category": "扩展",
-      "count": 109
+      "count": 110
     },
     {
       "category": "群相册",

--- a/packages/mcp/src/generated/catalog.json
+++ b/packages/mcp/src/generated/catalog.json
@@ -62,7 +62,7 @@
       "name": "_get_friend_dress",
       "aliases": [],
       "summary": "获取指定 QQ 号正在使用的个性装扮（挂件/名片/来电/输入状态等）",
-      "returns": "装扮列表；解析不到（未登录态/风控/页面改版）时 items 为空",
+      "returns": "装扮信息；目标未使用任何可查询装扮时 items 为空数组。网络失败、未登录态/风控、页面改版、返回账号与请求不一致时返回失败并附具体原因",
       "readOnly": true,
       "params": [
         {

--- a/packages/mcp/src/generated/catalog.ts
+++ b/packages/mcp/src/generated/catalog.ts
@@ -62,6 +62,43 @@ export const ACTIONS: CatalogAction[] = [
     "category": "扩展"
   },
   {
+    "name": "_get_friend_dress",
+    "aliases": [],
+    "summary": "获取指定 QQ 号正在使用的个性装扮（挂件/名片/来电/输入状态等）",
+    "returns": "装扮列表；解析不到（未登录态/风控/页面改版）时 items 为空",
+    "readOnly": true,
+    "params": [
+      {
+        "name": "user_id",
+        "type": "uint",
+        "required": true,
+        "role": "user_id",
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "desc": "目标 QQ 号"
+      }
+    ],
+    "invariants": [],
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "user_id": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "目标 QQ 号",
+          "x-role": "user_id"
+        }
+      },
+      "required": [
+        "user_id"
+      ],
+      "additionalProperties": true
+    },
+    "category": "扩展"
+  },
+  {
     "name": "_get_group_notice",
     "aliases": [],
     "summary": "获取群公告",
@@ -10920,7 +10957,7 @@ export const CATEGORIES: CatalogCategory[] = [
   },
   {
     "category": "扩展",
-    "count": 109
+    "count": 110
   },
   {
     "category": "群相册",

--- a/packages/mcp/src/generated/catalog.ts
+++ b/packages/mcp/src/generated/catalog.ts
@@ -65,7 +65,7 @@ export const ACTIONS: CatalogAction[] = [
     "name": "_get_friend_dress",
     "aliases": [],
     "summary": "获取指定 QQ 号正在使用的个性装扮（挂件/名片/来电/输入状态等）",
-    "returns": "装扮列表；解析不到（未登录态/风控/页面改版）时 items 为空",
+    "returns": "装扮信息；目标未使用任何可查询装扮时 items 为空数组。网络失败、未登录态/风控、页面改版、返回账号与请求不一致时返回失败并附具体原因",
     "readOnly": true,
     "params": [
       {

--- a/packages/onebot/src/actions/extended.ts
+++ b/packages/onebot/src/actions/extended.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { FriendDressError } from '@snowluma/protocol/web/friend-dress';
 import type { ApiActionContext } from '../api-handler';
 import { asNumber, asString } from '../api-handler';
 import type { ForwardPreviewMeta } from '../modules/message-actions';
@@ -2443,15 +2444,18 @@ export const actions = [
   defineAction({
     name: '_get_friend_dress',
     summary: '获取指定 QQ 号正在使用的个性装扮（挂件/名片/来电/输入状态等）',
-    returns: '装扮列表；解析不到（未登录态/风控/页面改版）时 items 为空',
+    returns: '装扮信息；目标未使用任何可查询装扮时 items 为空数组。网络失败、未登录态/风控、页面改版、返回账号与请求不一致时返回失败并附具体原因',
     readOnly: true,
     params: { user_id: f.userId().describe('目标 QQ 号') },
     run: async (p, ctx) => {
-      const dress = await ctx.bridge.apis.web.getFriendDress(p.user_id);
-      if (!dress) {
-        return failedResponse(RETCODE.ACTION_FAILED, 'failed to get friend dress: 未能解析装扮页');
+      try {
+        return okResponse(await ctx.bridge.apis.web.getFriendDress(p.user_id));
+      } catch (e) {
+        if (e instanceof FriendDressError) {
+          return failedResponse(RETCODE.ACTION_FAILED, `failed to get friend dress (${e.kind}): ${e.message}`);
+        }
+        return failedResponse(RETCODE.ACTION_FAILED, `failed to get friend dress: ${(e as Error).message}`);
       }
-      return okResponse(dress);
     },
   }),
 ];

--- a/packages/onebot/src/actions/extended.ts
+++ b/packages/onebot/src/actions/extended.ts
@@ -2438,6 +2438,22 @@ export const actions = [
       return okResponse({ fileset_id: filesetId });
     },
   }),
+
+  // 好友个性装扮
+  defineAction({
+    name: '_get_friend_dress',
+    summary: '获取指定 QQ 号正在使用的个性装扮（挂件/名片/来电/输入状态等）',
+    returns: '装扮列表；解析不到（未登录态/风控/页面改版）时 items 为空',
+    readOnly: true,
+    params: { user_id: f.userId().describe('目标 QQ 号') },
+    run: async (p, ctx) => {
+      const dress = await ctx.bridge.apis.web.getFriendDress(p.user_id);
+      if (!dress) {
+        return failedResponse(RETCODE.ACTION_FAILED, 'failed to get friend dress: 未能解析装扮页');
+      }
+      return okResponse(dress);
+    },
+  }),
 ];
 
 // 已过滤（机器人/被忽略）的入群请求。

--- a/packages/onebot/tests/action-registry.test.ts
+++ b/packages/onebot/tests/action-registry.test.ts
@@ -90,9 +90,9 @@ describe('compileActionRegistry namespace conflicts', () => {
 });
 
 describe('compiled production Action registry', () => {
-  it('preserves all 179 canonical Action docs', () => {
-    expect(ACTION_REGISTRY.actions).toHaveLength(179);
-    expect(collectActionDocs()).toHaveLength(179);
+  it('preserves all 180 canonical Action docs', () => {
+    expect(ACTION_REGISTRY.actions).toHaveLength(180);
+    expect(collectActionDocs()).toHaveLength(180);
   });
 
   it('resolves every executable name to exactly one canonical doc', () => {

--- a/packages/protocol/src/web/friend-dress.ts
+++ b/packages/protocol/src/web/friend-dress.ts
@@ -1,7 +1,4 @@
-import { createLogger } from '@snowluma/common/logger';
 import { RequestUtil, cookieToString } from './request-util';
-
-const log = createLogger('Bridge.Web');
 
 export interface WebFriendDressItem {
   [key: string]: import('@snowluma/common/json').JsonValue;
@@ -28,6 +25,28 @@ export interface WebFriendDress {
   avatar_url: string;
   /** 对方正在用的装扮（已剔除服务器不回真值的气泡/字体/头像）。 */
   items: WebFriendDressItem[];
+}
+
+/** 装扮查询失败的具体环节 —— 调用方据此给出可区分的错误提示。 */
+export type FriendDressErrorKind =
+  /** HTTP 请求本身失败（网络/非 2xx）。 */
+  | 'network'
+  /** HTML 里抠不到 __INITIAL_ASYNCDATA__（未登录态/风控/页面改版）。 */
+  | 'parse'
+  /** 抠到了 JSON 但结构不符合预期（页面改版）。 */
+  | 'structure'
+  /** 页面返回的 targetUin 与请求的不一致（串号数据，不可信）。 */
+  | 'uin_mismatch';
+
+export class FriendDressError extends Error {
+  constructor(
+    readonly kind: FriendDressErrorKind,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'FriendDressError';
+  }
 }
 
 /** appId → 装扮类别（取自装扮页 business-name / tab 文案）。 */
@@ -97,34 +116,77 @@ function buildDressUrl(targetUin: string): string {
   return `https://zb.vip.qq.com/v2/pages/aioDressPage?${params.toString()}&traceDetail=${TRACE_DETAIL}`;
 }
 
-/** 从 SSR HTML 抠出 window.__INITIAL_ASYNCDATA__ 的 JSON（拿不到返回 null）。 */
-function parseAsyncData(html: string): RawAsyncData | null {
+/** 从 SSR HTML 抠出 window.__INITIAL_ASYNCDATA__ 的 JSON（抠不到/坏 JSON 抛 parse）。 */
+function parseAsyncData(html: string): unknown {
   const m = html.match(/window\.__INITIAL_ASYNCDATA__\s*=\s*(\{[\s\S]*?\});\(function/);
-  if (!m?.[1]) return null;
-  try {
-    return JSON.parse(m[1]) as RawAsyncData;
-  } catch {
-    return null;
+  if (!m?.[1]) {
+    throw new FriendDressError('parse', '装扮页中未找到 __INITIAL_ASYNCDATA__（未登录态/风控/页面改版）');
   }
+  try {
+    return JSON.parse(m[1]) as unknown;
+  } catch (e) {
+    throw new FriendDressError('parse', '__INITIAL_ASYNCDATA__ 不是合法 JSON', { cause: e });
+  }
+}
+
+/** 运行时结构校验：不符合预期的一律抛 structure，绝不带着畸形数据继续。 */
+function validateAsyncData(data: unknown): RawAsyncData & { rawUsingList: RawDressItem[] } {
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    throw new FriendDressError('structure', '__INITIAL_ASYNCDATA__ 顶层不是对象');
+  }
+  const d = data as Record<string, unknown>;
+  if (d['targetUin'] !== undefined && typeof d['targetUin'] !== 'string') {
+    throw new FriendDressError('structure', 'targetUin 不是字符串');
+  }
+  if (d['isSvip'] !== undefined && typeof d['isSvip'] !== 'boolean') {
+    throw new FriendDressError('structure', 'isSvip 不是布尔值');
+  }
+  if (d['avatarImage'] !== undefined && typeof d['avatarImage'] !== 'string') {
+    throw new FriendDressError('structure', 'avatarImage 不是字符串');
+  }
+  if (!Array.isArray(d['rawUsingList'])) {
+    throw new FriendDressError('structure', 'rawUsingList 缺失或不是数组');
+  }
+  d['rawUsingList'].forEach((item: unknown, i: number) => {
+    if (item === null || typeof item !== 'object' || Array.isArray(item)) {
+      throw new FriendDressError('structure', `rawUsingList[${i}] 不是对象`);
+    }
+    const r = item as Record<string, unknown>;
+    if (r['appId'] !== undefined && typeof r['appId'] !== 'number') {
+      throw new FriendDressError('structure', `rawUsingList[${i}].appId 不是数字`);
+    }
+    if (r['itemId'] !== undefined && typeof r['itemId'] !== 'number') {
+      throw new FriendDressError('structure', `rawUsingList[${i}].itemId 不是数字`);
+    }
+    if (r['name'] !== undefined && typeof r['name'] !== 'string') {
+      throw new FriendDressError('structure', `rawUsingList[${i}].name 不是字符串`);
+    }
+    if (r['image'] !== undefined && typeof r['image'] !== 'string') {
+      throw new FriendDressError('structure', `rawUsingList[${i}].image 不是字符串`);
+    }
+  });
+  return data as RawAsyncData & { rawUsingList: RawDressItem[] };
 }
 
 /**
  * 抠出该装扮项的动态预览视频 url（没有则空串）。
  *  - 名片(appId 15)：video 藏在 extraInfo.immersiveMaterial（JSON 字符串）的 videoUrl。
- *  - 来电(appId 17)：无独立字段，按预览图同目录换名 image.jpg → media.mp4。
+ *  - 来电(appId 17)：无独立字段，按预览图同目录换名 (web_)image.jpg → media.mp4
+ *    （funCall/item/{itemId}/media.mp4，已验证可访问）；文件名不匹配时不猜测，返回空串。
  */
 function resolveVideoUrl(r: RawDressItem): string {
   if (r.appId === 15) {
     const raw = r.extraappinfo?.extraInfo?.immersiveMaterial;
-    if (!raw) return '';
+    if (typeof raw !== 'string' || !raw) return '';
     try {
-      return (JSON.parse(raw) as { videoUrl?: string }).videoUrl ?? '';
+      const videoUrl = (JSON.parse(raw) as { videoUrl?: unknown }).videoUrl;
+      return typeof videoUrl === 'string' ? videoUrl : '';
     } catch {
       return '';
     }
   }
-  if (r.appId === 17 && r.image) {
-    return r.image.replace(/\/image\.jpg$/, '/media.mp4');
+  if (r.appId === 17 && r.image && /\/(?:web_)?image\.jpg$/.test(r.image)) {
+    return r.image.replace(/\/(?:web_)?image\.jpg$/, '/media.mp4');
   }
   return '';
 }
@@ -138,19 +200,19 @@ function toItem(r: RawDressItem): WebFriendDressItem {
     name: r.name ?? '',
     preview_url: r.image ?? '',
     video_url: resolveVideoUrl(r),
-    price: r.extrainfo?.price ?? 0,
+    price: typeof r.extrainfo?.price === 'number' ? r.extrainfo.price : 0,
   };
 }
 
 /**
- * 查 targetUin 正在用的好友装扮（挂件/名片/来电/输入状态等）。抠不到
- * __INITIAL_ASYNCDATA__（未登录态/风控/页面改版）时返回 null，让调用方区分
- * 「查到但空」与「压根没解析出来」。
+ * 查 targetUin 正在用的好友装扮（挂件/名片/来电/输入状态等）。「查到但没装扮」
+ * 正常返回空 items；请求/解析/校验的任何一环失败都抛 {@link FriendDressError}，
+ * 带 kind 区分网络、未登录态/风控、页面改版、串号数据。
  */
 export async function getFriendDressWebAPI(
   cookieObject: Record<string, string>,
   targetUin: string,
-): Promise<WebFriendDress | null> {
+): Promise<WebFriendDress> {
   let html: string;
   try {
     html = await RequestUtil.HttpGetText(buildDressUrl(targetUin), 'GET', '', {
@@ -160,13 +222,13 @@ export async function getFriendDressWebAPI(
       'Accept-Language': 'zh-CN,zh;q=0.9',
     });
   } catch (e) {
-    log.warn('getFriendDressWebAPI failed (uin=%s): %s',
-      targetUin, e instanceof Error ? (e.stack ?? e.message) : String(e));
-    return null;
+    throw new FriendDressError('network', `装扮页请求失败: ${e instanceof Error ? e.message : String(e)}`, { cause: e });
   }
 
-  const data = parseAsyncData(html);
-  if (!data?.rawUsingList) return null;
+  const data = validateAsyncData(parseAsyncData(html));
+  if (data.targetUin !== undefined && data.targetUin !== targetUin) {
+    throw new FriendDressError('uin_mismatch', `装扮页返回账号 ${data.targetUin} 与请求账号 ${targetUin} 不一致`);
+  }
 
   return {
     target_uin: data.targetUin ?? targetUin,

--- a/packages/protocol/src/web/friend-dress.ts
+++ b/packages/protocol/src/web/friend-dress.ts
@@ -1,0 +1,179 @@
+import { createLogger } from '@snowluma/common/logger';
+import { RequestUtil, cookieToString } from './request-util';
+
+const log = createLogger('Bridge.Web');
+
+export interface WebFriendDressItem {
+  [key: string]: import('@snowluma/common/json').JsonValue;
+  /** 装扮业务 id（QQ 会员 appId，决定类别）。 */
+  app_id: number;
+  /** 人类可读类别（按 appId 映射，未知则为 appId=<n>）。 */
+  kind: string;
+  /** 装扮 id（默认款为 0）。 */
+  item_id: number;
+  name: string;
+  /** 静态预览图 url。 */
+  preview_url: string;
+  /** 动态预览视频 url（名片/来电才有，否则空串）。 */
+  video_url: string;
+  /** 商城价（非默认款才有，否则 0）。 */
+  price: number;
+}
+
+export interface WebFriendDress {
+  [key: string]: import('@snowluma/common/json').JsonValue;
+  target_uin: string;
+  is_svip: boolean;
+  /** 对方头像图 url（装扮页附带，非"头像装扮"）。 */
+  avatar_url: string;
+  /** 对方正在用的装扮（已剔除服务器不回真值的气泡/字体/头像）。 */
+  items: WebFriendDressItem[];
+}
+
+/** appId → 装扮类别（取自装扮页 business-name / tab 文案）。 */
+const APP_KIND: Record<number, string> = {
+  2: '气泡',
+  4: '挂件',
+  5: '字体',
+  15: '名片',
+  17: '来电',
+  22: '彩色屏保',
+  23: '头像',
+  47: '头像双击动作',
+  352: '输入状态',
+};
+
+/**
+ * 服务器不会回真值的装扮类型：气泡(2)/字体(5)/头像(23)。这几类只按 targetUin 查
+ * 永远回默认款，必须客户端在请求里带对应 id 才知道对方用了啥 —— 拿到也是废数据，剔除。
+ */
+const UNRESOLVABLE_APPS = new Set([2, 5, 23]);
+
+/**
+ * HAR 里的 traceDetail：base64({"appid":"toaio","page_id":"37","item_id":"","item_type":""})。
+ * 与 targetUin 无关，固定值；已是编码后的串，拼接时不可再被二次编码。
+ */
+const TRACE_DETAIL =
+  'base64-eyJhcHBpZCI6InRvYWlvIiwicGFnZV9pZCI6IjM3IiwiaXRlbV9pZCI6IiIsIml0ZW1fdHlwZSI6%0AIiJ9%0A';
+
+/** aio webview 的移动端 UA（照 HAR；桌面 UA 可能返回不同壳）。 */
+const DRESS_UA =
+  'Mozilla/5.0 (Linux; Android 13; 2109119BC Build/TKQ1.221114.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/121.0.6167.71 MQQBrowser/6.2 TBS/047925 Mobile Safari/537.36 V1_AND_SQ_9.2.66_13188_YYB_D QQ/9.2.66.33870 NetType/WIFI WebP/0.3.0 AppId/537339358';
+
+interface RawDressItem {
+  appId?: number;
+  itemId?: number;
+  name?: string;
+  image?: string;
+  extrainfo?: { price?: number };
+  extraappinfo?: { extraInfo?: { immersiveMaterial?: string } };
+}
+
+interface RawAsyncData {
+  targetUin?: string;
+  isSvip?: boolean;
+  avatarImage?: string;
+  rawUsingList?: RawDressItem[];
+}
+
+/** 按 targetUin 拼装扮页 URL（结构照 HAR）。 */
+function buildDressUrl(targetUin: string): string {
+  const inner =
+    `https://zb.vip.qq.com/v2/pages/aioDressPage?fromPage=1&targetUin=${targetUin}` +
+    `&widgetId=0&fontEffectId=0&bgId=custom&chatId=${targetUin}` +
+    `&isGroup=0&traceDetail=${TRACE_DETAIL}`;
+  const params = new URLSearchParams({
+    fromPage: '1',
+    enteranceId: 'aio',
+    url: inner,
+    fontEffectId: '0',
+    chatId: targetUin,
+    widgetId: '0',
+    targetUin,
+    isGroup: '0',
+    bgId: 'custom',
+  });
+  // traceDetail 已是编码后的 base64-... 串，单独拼避免被二次编码。
+  return `https://zb.vip.qq.com/v2/pages/aioDressPage?${params.toString()}&traceDetail=${TRACE_DETAIL}`;
+}
+
+/** 从 SSR HTML 抠出 window.__INITIAL_ASYNCDATA__ 的 JSON（拿不到返回 null）。 */
+function parseAsyncData(html: string): RawAsyncData | null {
+  const m = html.match(/window\.__INITIAL_ASYNCDATA__\s*=\s*(\{[\s\S]*?\});\(function/);
+  if (!m?.[1]) return null;
+  try {
+    return JSON.parse(m[1]) as RawAsyncData;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 抠出该装扮项的动态预览视频 url（没有则空串）。
+ *  - 名片(appId 15)：video 藏在 extraInfo.immersiveMaterial（JSON 字符串）的 videoUrl。
+ *  - 来电(appId 17)：无独立字段，按预览图同目录换名 image.jpg → media.mp4。
+ */
+function resolveVideoUrl(r: RawDressItem): string {
+  if (r.appId === 15) {
+    const raw = r.extraappinfo?.extraInfo?.immersiveMaterial;
+    if (!raw) return '';
+    try {
+      return (JSON.parse(raw) as { videoUrl?: string }).videoUrl ?? '';
+    } catch {
+      return '';
+    }
+  }
+  if (r.appId === 17 && r.image) {
+    return r.image.replace(/\/image\.jpg$/, '/media.mp4');
+  }
+  return '';
+}
+
+function toItem(r: RawDressItem): WebFriendDressItem {
+  const appId = r.appId ?? 0;
+  return {
+    app_id: appId,
+    kind: APP_KIND[appId] ?? `appId=${appId}`,
+    item_id: r.itemId ?? 0,
+    name: r.name ?? '',
+    preview_url: r.image ?? '',
+    video_url: resolveVideoUrl(r),
+    price: r.extrainfo?.price ?? 0,
+  };
+}
+
+/**
+ * 查 targetUin 正在用的好友装扮（挂件/名片/来电/输入状态等）。抠不到
+ * __INITIAL_ASYNCDATA__（未登录态/风控/页面改版）时返回 null，让调用方区分
+ * 「查到但空」与「压根没解析出来」。
+ */
+export async function getFriendDressWebAPI(
+  cookieObject: Record<string, string>,
+  targetUin: string,
+): Promise<WebFriendDress | null> {
+  let html: string;
+  try {
+    html = await RequestUtil.HttpGetText(buildDressUrl(targetUin), 'GET', '', {
+      Cookie: cookieToString(cookieObject),
+      'User-Agent': DRESS_UA,
+      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      'Accept-Language': 'zh-CN,zh;q=0.9',
+    });
+  } catch (e) {
+    log.warn('getFriendDressWebAPI failed (uin=%s): %s',
+      targetUin, e instanceof Error ? (e.stack ?? e.message) : String(e));
+    return null;
+  }
+
+  const data = parseAsyncData(html);
+  if (!data?.rawUsingList) return null;
+
+  return {
+    target_uin: data.targetUin ?? targetUin,
+    is_svip: data.isSvip ?? false,
+    avatar_url: data.avatarImage ?? '',
+    items: data.rawUsingList
+      .filter((r) => !UNRESOLVABLE_APPS.has(r.appId ?? 0))
+      .map(toItem),
+  };
+}

--- a/packages/protocol/tests/web/fixtures/friend-dress-sample.html
+++ b/packages/protocol/tests/web/fixtures/friend-dress-sample.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="HandheldFriendly" content="True" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="viewport"
+        content="width=device-width,initial-scale=1,minimum-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
+    <style type="text/css">
+        .dark {
+            background-color: #000;
+            min-height: 100vh;
+        }
+
+        body {
+            margin: 0px;
+        }
+    </style>
+    <script>
+        window._HTML_BEGIN_TIMESTAMP_ = Date.now();
+        window.inReloadingScriptNumber = 0;
+        window.hasReloadedScriptMap = {};
+        window.addEventListener(
+            "error",
+            function (event) {
+                var element = event.target;
+                var resourceUrl =
+                    element.tagName === "LINK" ? element.href : element.src;
+
+                if (!/^https:\/\/qqvip-web.cdn-go.cn/i.test(resourceUrl)) {
+                    return;
+                }
+
+                var proxiedUrl = resourceUrl.replace(
+                    /^https:\/\/qqvip-web.cdn-go.cn\//,
+                    "https://zb.vip.qq.com/proxy/domain/qqvip-web.cdn-go.cn/"
+                );
+
+                if (window.hasReloadedScriptMap[proxiedUrl]) {
+                    return;
+                }
+
+                switch (element.tagName) {
+                    case "IMG":
+                        element.src = proxiedUrl;
+                        break;
+                    case "LINK":
+                        element.href = proxiedUrl;
+                        break;
+                    case "SCRIPT":
+                        var newScript = document.createElement("script");
+                        newScript.src = proxiedUrl;
+                        newScript.async = element.async;
+                        newScript.defer = element.defer;
+                        newScript.crossOrigin = element.crossOrigin;
+                        if (element.getAttribute("data-vue-meta")) {
+                            newScript.setAttribute(
+                                "data-vue-meta",
+                                element.getAttribute("data-vue-meta")
+                            );
+                        }
+
+                        newScript.onload = function () {
+                            window.inReloadingScriptNumber--;
+
+                            if (window.inReloadingScriptNumber === 0) {
+                                var app =
+                                    window.rieApp.default || window.rieApp;
+                                window.rieVue2Runtime.Vue.default.config.devtools = false;
+                                window.rieVue2Runtime.init(app);
+                            }
+                        };
+                        window.inReloadingScriptNumber++;
+
+                        window.hasReloadedScriptMap[proxiedUrl] =
+                            "reloaded";
+                        element.parentNode.appendChild(newScript);
+                        break;
+                }
+            },
+            true
+        );
+    </script>
+
+<title>好友装扮</title>
+
+<link data-vue-meta="ssr" href="https://qqvip-web.cdn-go.cn/cdn/v1.7.3/legacy-style/gxh.vip.qq.com/storybook/src/css/vip-mall-global/global.css?_bid=5399" rel="stylesheet"><link data-vue-meta="ssr" href="https://qqvip-web.cdn-go.cn/cdn/v1.7.3/legacy-style/gxh.vip.qq.com/vipstyle/component/ui-tag-member-shop.css?_bid=5399" rel="stylesheet">
+<script data-vue-meta="ssr">window.shouldOpenTestEnv = false;</script><script data-vue-meta="ssr" crossOrigin="anonymous" src="https://tam.cdn-go.cn/aegis-sdk/latest/aegis.min.js?_bid=5234"></script><script data-vue-meta="ssr" type="text/javascript" defer>
+            window.QQGXH_ENV = "dev";
+            window.version = "dev";
+            /* eslint-disable */
+if (window.Aegis && !window.__aegis) {
+  var uinMatch = document.cookie.match(/uin=o(\d+)/);
+  var uin;
+  if (uinMatch.length === 2) {
+    uin = parseInt(uinMatch[1], 10);
+  }
+  var samplingReport = Math.random() < 0.1;
+  var appId = '';
+  if (window.location.pathname === '/mall/item-detail') {
+    var appIdRegExArray = window.location.href.match(/appid=(\d+)/i);
+    appId = appIdRegExArray ? appIdRegExArray[1] : '';
+  }
+  var qqversion = '9.3.5' || 'unknown';
+  var aegisConfig = {
+    id: '75w8vtQ8j2WjEb9bWd',
+    reportApiSpeed: samplingReport,
+    reportAssetSpeed: samplingReport,
+    version: window.version,
+    ext1: qqversion,
+    ext2: appId,
+    beforeRequest: function (data) {
+      var logMessage = data.logs.msg || '';
+      if (logMessage.indexOf('tianshu.qq.com') > -1 || logMessage.indexOf('h5.qzone.qq.com/report/action') > -1 || logMessage.indexOf('h.trace.qq.com') > -1 || logMessage.indexOf('report.qqweb.qq.com') > -1) {
+        return false;
+      }
+      if (logMessage.toLowerCase().indexOf('script error.') > -1 || logMessage.toLowerCase().indexOf('network error') > -1 || logMessage.toLowerCase().indexOf('request abort') > -1) {
+        return false;
+      }
+    }
+  };
+  if (uin) {
+    aegisConfig.uin = uin;
+  }
+  window.__aegis = new window.Aegis(aegisConfig);
+  function reportError() {
+    var Vue = window.rieVue2Runtime.Vue.default ? window.rieVue2Runtime.Vue.default : window.rieVue2Runtime.Vue;
+    if (Vue) {
+      Vue.config.errorHandler = function (error) {
+        console.error(error);
+        if (error instanceof Error) {
+          window.__aegis && window.__aegis.error(error);
+        }
+      };
+    }
+  }
+  document.addEventListener('DOMContentLoaded', reportError);
+}
+            </script><script data-vue-meta="ssr" crossOrigin="anonymous" src="https://qqvip-web.cdn-go.cn/mono/latest/vendors/qqmobile/qqapi.wk.js?_bid=5234" defer></script><script data-vue-meta="ssr" crossOrigin="anonymous" defer src="https://qqvip-web.cdn-go.cn/setup/latest/index.js"></script>
+<link rel="preload" href="https://qqvip-web.cdn-go.cn/qqgxh/latest//mall/ac38e282//client/mall/aio-dress/app.0246.css" as="style">
+<link rel="stylesheet" href="https://qqvip-web.cdn-go.cn/qqgxh/latest//mall/ac38e282//client/mall/aio-dress/app.0246.css">
+</head>
+<body>
+    <script data-vue-meta="ssr" type="text/javascript" data-pbody="true">
+                /* eslint-disable */
+(function () {
+  if (location.search.indexOf('bodyColor=transparent') > -1) {
+    document.body.style.backgroundColor = 'transparent';
+  } else {
+    var themeId = 0;
+    var themeRegex = navigator.userAgent.match(/QQTheme\/(\d+)/);
+    if (themeRegex) {
+      try {
+        themeId = parseInt(themeRegex[1], 10);
+      } catch (error) {}
+    }
+    if ([2920, 1102, 1103].indexOf(themeId) > -1) {
+      document.body.style.backgroundColor = '#000';
+    }
+  }
+})();
+                /* eslint-disable */
+// 修复页面元素因为rem错位问题的临时方案, 代码不经过转换，尽量保持兼容性。
+(function () {
+  function getZoomFactor() {
+    var zoomFactor = 1;
+    if (isIOS()) {
+      return zoomFactor;
+    }
+    var declaredHTMLFontSize = document.documentElement.style.fontSize;
+    if (!isSizeValid(declaredHTMLFontSize)) {
+      return zoomFactor;
+    }
+    declaredHTMLFontSize = pixelToNumber(declaredHTMLFontSize);
+    var actualHTMLFontSize = getActualFontSize();
+    if (!isSizeValid(actualHTMLFontSize)) {
+      return zoomFactor;
+    }
+    if (Math.abs(declaredHTMLFontSize - actualHTMLFontSize) < 0.2) {
+      return zoomFactor;
+    }
+    return declaredHTMLFontSize / actualHTMLFontSize;
+  }
+  function isIOS() {
+    return /iPhone|iPad/.test(navigator.userAgent);
+  }
+  ;
+  function pixelToNumber(pixel) {
+    return Number(pixel.replace('px', ''));
+  }
+  function isSizeValid(size) {
+    return /^\d+(\.\d+)?(px)?$/.test(size);
+  }
+  function getActualFontSize() {
+    var toolMan = document.createElement('div');
+    // offsetWidth会返回整数，直接设为1会丢失很大精度
+    toolMan.style.width = '10rem';
+    toolMan.style.position = 'absolute';
+    toolMan.style.left = '-10rem';
+    document.body.appendChild(toolMan);
+    var actualFontSize = toolMan.offsetWidth / 10;
+    toolMan.remove();
+    return actualFontSize;
+  }
+
+  // 设置设备当前应该使用的html font-size
+  function fixRem() {
+    // 设置默认二倍稿的宽高和默认设置html的font-size大小
+    var ALLOWED_MAX_ZOOM_FACTOR = 1.15;
+    var DEFAULT_FONT_SIZE = 100;
+    var DEFAULT_DEVICE_WIDTH = 750;
+    var DEFAULT_DEVICE_HEIGHT = 1334;
+    // 判断宽屏设备的最小高度
+    var MIN_DEVICE_HEIGHT = 610;
+
+    // 获取实际webview展示宽高
+    var html = document.querySelector('html');
+    var clientWidth = DEFAULT_DEVICE_WIDTH;
+    var clientHeight = DEFAULT_DEVICE_HEIGHT;
+    if (isIOS()) {
+      // ios中获取window.innerWidth和window.innerHeight有时候会不准确所以统一使用html.clientWidth
+      clientWidth = html.clientWidth || DEFAULT_DEVICE_WIDTH;
+      clientHeight = html.clientHeight || DEFAULT_DEVICE_HEIGHT;
+    } else {
+      clientWidth = window.innerWidth || html.clientWidth || DEFAULT_DEVICE_WIDTH;
+      clientHeight = window.innerHeight || html.clientHeight || DEFAULT_DEVICE_HEIGHT;
+    }
+
+    // 判断用户是否设置了系统缩放，导致实际设置的html font-size出现偏差，进行纠正
+    var zoomFactor = getZoomFactor();
+    var fixedHTMLFontSize = DEFAULT_FONT_SIZE * (clientWidth / DEFAULT_DEVICE_WIDTH) * zoomFactor;
+
+    /**
+     * 若满足一下条件之一，则视为宽屏设备
+     * 修正后的字体大小大于指定阈值并且高宽比小于1.4
+     * 屏幕高度大于610(避免因拉起输入框而误判)且屏幕高宽比小于1.2(经过对多款主流折叠屏手机分辨率计算得出)
+     */
+
+    const largeScreenList = [fixedHTMLFontSize > DEFAULT_FONT_SIZE * ALLOWED_MAX_ZOOM_FACTOR && clientHeight / clientWidth < 1.4, clientHeight > MIN_DEVICE_HEIGHT && clientHeight / clientWidth < 1.2];
+    if (largeScreenList.some(Boolean)) {
+      // 当为宽屏设备时，考虑用两侧留白的方式恢复成窄屏样式。由于设计侧给出的浮层经常会达到1.5倍屏宽高度，这里取2倍
+      var widthFactor = clientHeight / 2 / DEFAULT_DEVICE_WIDTH;
+      html.style.padding = '0 ' + (clientWidth - DEFAULT_DEVICE_WIDTH * widthFactor) / 2 + 'px';
+      fixedHTMLFontSize = DEFAULT_FONT_SIZE * widthFactor;
+    } else {
+      html.style.padding = '';
+    }
+    html.style.fontSize = fixedHTMLFontSize + 'px';
+  }
+  ;
+  window.addEventListener('load', fixRem);
+  window.addEventListener('resize', fixRem);
+  fixRem();
+})();
+            </script>
+    <!-- 加载数据上报 vip-tracker -->
+    <script src="https://qqvip-web.cdn-go.cn/vip-tracker/latest/index.js?_bid=5234" crossorigin="anonymous"
+        defer></script>
+    <!--这个注释是rie用来插入内容渲染的！！！不能删！！！！-->
+    <div data-server-rendered="true" class="need-status-bar-height" data-v-66e2fb9e><div vt-appid="DressVip" vt-pageid="3001190" vt-busi="{&quot;op_result&quot;:2}" class="page-wrapper" data-v-094eb20e data-v-66e2fb9e><div vt-mdid="101" vt-expose="1" class="head-container" data-v-7bfa11be data-v-094eb20e><div class="title-box" data-v-7bfa11be><div class="title" data-v-7bfa11be>好友正在用</div><!----></div><div vt-itemid="go_zhuanqu" vt-itemtype="4" class="svip-box" data-v-7bfa11be><img src="https://qqvip-web.cdn-go.cn/qqgxh/latest//mall/ac38e282//client/img/penguin.a3db.png" class="penguin" data-v-7bfa11be><div class="content-box" data-v-7bfa11be><div class="pattern" data-v-7bfa11be></div><div class="background" data-v-7bfa11be></div><div class="text-box" data-v-7bfa11be><span data-v-7bfa11be>他是尊贵的SVIP，免费用7000多款装扮</span><div class="arrow" data-v-7bfa11be></div></div></div></div><div class="item-list" data-v-7bfa11be><div class="item-preview" data-v-0e6539b8 data-v-7bfa11be><div vt-sbmdid="1" vt-expose="1" data-v-0e6539b8><div vt-itemid="2141485" vt-itemtype="3001001" class="image-box" data-v-0e6539b8><div class="cubebox-item" data-v-5b8ee750 data-v-0e6539b8><div class="ui-discount-info ui-hippy" style="display:none;" data-v-5b8ee750><span data-v-5b8ee750></span></div><div accessibilityLabel="在说什么呢装扮图片" class="ui-cube-box-bubble-cube cube-size-square" style="background-image:linear-gradient(46deg, rgba(239, 212, 186, .5) 0%,  rgba(239, 212, 186, .3) 100%);" data-v-0c9be67e data-v-5b8ee750><img src="https://tianquan.gtimg.cn/bubble/item/2141485/newPreview1.png" class="cube-size-square" data-v-0c9be67e><div class="cube-size-square cube-size-square-border" data-v-0c9be67e></div></div></div></div></div><div class="text-box" data-v-0e6539b8><div class="business-name" data-v-0e6539b8>
+            气泡
+        </div><div class="name" data-v-0e6539b8>在说什么呢</div></div><div vt-sbmdid="2" vt-expose="1" class="button-box" data-v-0e6539b8><div vt-itemid="2141485" vt-itemtype="3001001" class="button" data-v-0e6539b8>
+            用同款
+        </div></div></div><div class="item-preview" data-v-0e6539b8 data-v-7bfa11be><div vt-sbmdid="1" vt-expose="1" data-v-0e6539b8><div vt-itemid="201534" vt-itemtype="3001008" class="image-box" data-v-0e6539b8><div class="cubebox-item" data-v-5b8ee750 data-v-0e6539b8><div class="ui-discount-info ui-hippy" style="display:none;" data-v-5b8ee750><span data-v-5b8ee750></span></div><div accessibilityLabel="二次元少女装扮图片" class="ui-cube-box-card-cube cube-size-rectangle" data-v-5b8ee750><img src="https://tianquan.gtimg.cn/card/original/201534/templateThumb.jpg" class="cube-size-rectangle card-custom"><div class="cube-size-rectangle cube-size-rectangle-border"></div></div></div></div></div><div class="text-box" data-v-0e6539b8><div class="business-name" data-v-0e6539b8>
+            名片
+        </div><div class="name" data-v-0e6539b8>二次元少女</div></div><div vt-sbmdid="2" vt-expose="1" class="button-box" data-v-0e6539b8><div vt-itemid="201534" vt-itemtype="3001008" class="button" data-v-0e6539b8>
+            用同款
+        </div></div></div><div class="item-preview" data-v-0e6539b8 data-v-7bfa11be><div vt-sbmdid="1" vt-expose="1" data-v-0e6539b8><div vt-itemid="2000" vt-itemtype="3001112" class="image-box" data-v-0e6539b8><div class="cubebox-item" data-v-5b8ee750 data-v-0e6539b8><div class="ui-discount-info ui-hippy" style="display:none;" data-v-5b8ee750><span data-v-5b8ee750></span></div><div class="ui-cube-box-float-cube cube-size-square" style="background:linear-gradient(46deg, rgba(249, 200, 209, .5) 0%,  rgba(249, 200, 209, .3) 100%);" data-v-204c96fb data-v-5b8ee750><div class="cube-size-square custom-float" style="background-image:url(https://tianquan.gtimg.cn/colorScreen/item/2000/listImg.png);" data-v-204c96fb></div><div class="cube-size-square cube-size-square-border" data-v-204c96fb></div></div></div></div></div><div class="text-box" data-v-0e6539b8><div class="business-name" data-v-0e6539b8>
+            浮屏
+        </div><div class="name" data-v-0e6539b8>花瓣</div></div><div vt-sbmdid="2" vt-expose="1" class="button-box" data-v-0e6539b8><div vt-itemid="2000" vt-itemtype="3001112" class="button" data-v-0e6539b8>
+            用同款
+        </div></div></div><div class="item-preview" data-v-0e6539b8 data-v-7bfa11be><div vt-sbmdid="1" vt-expose="1" data-v-0e6539b8><div vt-itemid="2730" vt-itemtype="3001013" class="image-box" data-v-0e6539b8><div class="cubebox-item" data-v-5b8ee750 data-v-0e6539b8><div class="ui-discount-info ui-hippy" style="display:none;" data-v-5b8ee750><span data-v-5b8ee750></span></div><div class="ui-cube-box-background" data-v-4ee6ef0e data-v-5b8ee750><span class="ic-face" data-v-782808e6 data-v-4ee6ef0e><img src="https://tianquan.gtimg.cn/funcall/funCall/2730/web_image.jpg" data-v-782808e6></span></div></div></div></div><div class="text-box" data-v-0e6539b8><div class="business-name" data-v-0e6539b8>
+            来电
+        </div><div class="name" data-v-0e6539b8>岁月成碑</div></div><div vt-sbmdid="2" vt-expose="1" class="button-box" data-v-0e6539b8><div vt-itemid="2730" vt-itemtype="3001013" class="button" data-v-0e6539b8>
+            用同款
+        </div></div></div><div class="item-preview" data-v-0e6539b8 data-v-7bfa11be><div vt-sbmdid="1" vt-expose="1" data-v-0e6539b8><div vt-itemid="0" vt-itemtype="3001011" class="image-box" data-v-0e6539b8><div class="cubebox-item" data-v-5b8ee750 data-v-0e6539b8><div class="ui-discount-info ui-hippy" style="display:none;" data-v-5b8ee750><span data-v-5b8ee750></span></div><div accessibilityLabel="默认挂件装扮图片" class="ui-cube-box-widget-cube cube-size-square" style="background-image:linear-gradient(46deg, rgba(230, 230, 230, .5) 0%,  rgba(230, 230, 230, .3) 100%);" data-v-e853d2f4 data-v-5b8ee750><img src="https://q.qlogo.cn/g?b=qq&amp;nk=1707889225&amp;s=100&amp;timestamp=1784877299499" class="widget-face cube-size-square" style="border-radius:105px;" data-v-e853d2f4><img src="https://tianquan.gtimg.cn/faceAddon/item/0/new1.png" class="custom-widget cube-size-square square-img" data-v-e853d2f4><div class="cube-size-square cube-size-square-border" data-v-e853d2f4></div></div></div></div></div><div class="text-box" data-v-0e6539b8><div class="business-name" data-v-0e6539b8>
+            挂件
+        </div><div class="name" data-v-0e6539b8>默认挂件</div></div><div vt-sbmdid="2" vt-expose="1" class="button-box" data-v-0e6539b8><div vt-itemid="0" vt-itemtype="3001011" class="button stroke" data-v-0e6539b8>
+            去商城
+        </div></div></div><div class="item-preview" data-v-0e6539b8 data-v-7bfa11be><div vt-sbmdid="1" vt-expose="1" data-v-0e6539b8><div vt-itemid="0" vt-itemtype="3001017" class="image-box" data-v-0e6539b8><div class="cubebox-item" data-v-5b8ee750 data-v-0e6539b8><div class="ui-discount-info ui-hippy" style="display:none;" data-v-5b8ee750><span data-v-5b8ee750></span></div><div class="ui-cube-box-face-cube cube-size-square-small" style="background:linear-gradient(46deg, rgba(192, 234, 242, .5) 0%,  rgba(192, 234, 242, .3) 100%);" data-v-7e24d472 data-v-5b8ee750><img src="https://q.qlogo.cn/g?b=qq&amp;nk=10000&amp;s=100" resizeMode="cover" class="cube-size-square" data-v-7e24d472><div class="cube-size-square cube-size-square-border" data-v-7e24d472></div></div></div></div></div><div class="text-box" data-v-0e6539b8><div class="business-name" data-v-0e6539b8>
+            头像
+        </div><div class="name" data-v-0e6539b8>自定义头像</div></div><div vt-sbmdid="2" vt-expose="1" class="button-box" data-v-0e6539b8><div vt-itemid="0" vt-itemtype="3001017" class="button stroke" data-v-0e6539b8>
+            去商城
+        </div></div></div></div><div vt-itemid="unfold" vt-itemtype="4" class="show-all-box" data-v-7bfa11be><div class="text" data-v-7bfa11be>更多</div><div class="icon" data-v-7bfa11be></div></div></div><!----><!----><div vt-mdid="102" vt-expose="1" class="recommend-container" data-v-094eb20e><div class="title-box" data-v-094eb20e><div class="title" data-v-094eb20e>热门推荐</div><div vt-itemtype="4" vt-itemid="go_mall" class="button-text" data-v-094eb20e>
+                去商城
+            </div></div><div class="recommend-tabs" data-v-b5f95dfc data-v-094eb20e><div vt-itemid="tab" vt-itemtype="3001001" class="tab-item active" data-v-b5f95dfc>
+        气泡
+    </div><div vt-itemid="tab" vt-itemtype="3001021" class="tab-item" data-v-b5f95dfc>
+        字体
+    </div><div vt-itemid="tab" vt-itemtype="3001011" class="tab-item" data-v-b5f95dfc>
+        挂件
+    </div><div vt-itemid="tab" vt-itemtype="3001008" class="tab-item" data-v-b5f95dfc>
+        名片
+    </div><div vt-itemid="tab" vt-itemtype="3001041" class="tab-item" data-v-b5f95dfc>
+        主题
+    </div><div vt-itemid="tab" vt-itemtype="3001004" class="tab-item" data-v-b5f95dfc>
+        背景
+    </div><div vt-itemid="tab" vt-itemtype="3001017" class="tab-item" data-v-b5f95dfc>
+        头像
+    </div><div vt-itemid="tab" vt-itemtype="3001013" class="tab-item" data-v-b5f95dfc>
+        来电
+    </div></div><div class="recommend-list-void" data-v-094eb20e><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAplSURBVHgB7V27dttGEB3ZKlIyXxDkHB9ZrqJ8QagyPn5IXbpQZSpZXTpTXyD5C0R16UQ/T1IZ/gLLnSUXgbukitLLdu4FZ5U1TOK5WIAk7jnrXVI0CezdmZ2dmV2IdOjQoUOHDh06dOiw8FiROcDW1lbw4cOH/srKSoDyzcePHwO8zdLTYuNCS8Qan3/z6dOn0+vXr0fj8fhUWo5WEqIEbKF5H2VDvuz0siBRJOUxCAI/40hahtYQAhJ6GPm7GM0DmYx+GxHKKf72HiOedbS6usr3JNmp/B5UvcvLS0pTD2UDn/9O62nf+6hN5DROCDqwD2l4iGbfvIfOo6oZg6BX2lkX4gBG9fG38P0/JAgKUR49ffp0LA2iMUKSRBgS8N7xs2fPQvGAO3fukJgBmj9bb0co+yBmJA3AOyHTiIAkPIIKOnQlCSWuyRgNDy2piSCdO7imUDzCGyHU7bjpIzbjHwYRuPm9pkbiLNy9e3eQIGYEYvZ9zTFeCMFNkgSS0WuDROQB1NmQxOjLSDypsVoJUcuJo+2BvhWqGohkDqCqbCj/zzGHKi21DaTaCNGbeYkmzc8LtPefP39+KHMISPgDVWM0qTm3bNY1qGohBGRsKBlUUdG1a9c250UqZoEDDNL+UueWCPe3/eLFC+cr/2viGPfu3fvZkIEyBhnfzzsZBO+B98ImSgApecl7FcdwKiG8QIygEduoH2E98UAWEPaEz3XMkydPjsURrosj2GTgImmR/CoLivPz83BtbQ23udLHy6319fXo7OzsjTiAE0I4Z0C//obmVyQDI2YoC44EKf0bN2788e7du7+kIiqrrIQ1tRRk2ID6OsR976J5gXml8nxZiRBdfb+WiXd2DDW1LUsImMUnMvFAREpK6XVKJSuLiz6ZSEbs95ElBe+dfYBmoH660igtIfT5oDriom9RTNsq0HXKa108bpd145eSEP44qngkcAW+7GQQ7AOQsa8vjzRQVhilCFGxDFBGbXCHQFo/sUjDgFSwL0IU49kujMKEMKiDasA2HW3S4TPofMJJfYuxHymIwoTgx460rl1VYbG5i1JpkrTBec/l900D+4ThBbbLTPCFCNGJPLaq6l5vcLEJnXyIMiwz0qZ8X4CKHtuh3kdtYKxHpaRf9NqLSkjMuDV51QbmUNEfxjb1cdlJ0kB1eoAyqjvQxHUIo6H6u4WkJDchGvWLpcNX2FWdk6FM7PtSkyRB1SeTTJPI17zHPiojJUUkhDflRTps2JMkA0VSEFRVVH1s89p9muhl5pJchKj+7bONDgrFI9S+39OXD/VackP9bHE4wHdCRWIuyaVycxGiaZ3EqIlFIDtS5xNmJJ4kbw5/X2FJ/j+Y6FeuHXTOUDxDfVqP2Ya05JLuvCorVleQDmeBmKJghzKNFM29As67mCS4drabynABESPWGFC5oouZvix1r/+ppu63MmegNDWdbgSj4h/6uDCgv83SMJkSYtQVvjCUOURLcr9itWWp/pnIo7Lua/1KOpSCNZjvZ302kxCm8bP2bV0tEpjBr82NrM+mziGaX/Xa9/yhCdnxYk7cbdYxoAoLUY59bj3AGupPmaQPpc4jq2lfgk4JWEPknGRUZMEkZOfRtRVAgvn9XGgykXrP0zxDC9HsTxnN+lAqIbrrSNTcrB1YY7zkb1oJ2c7XPYmtBwP85gbe26ybFPzee+3LIO1zqYRwK5jWtRMC0/AAv7NhUk+hIiOpAUrwCCSETA1Fm2r5AHWtOQGmD7lpNe1zWZN6rL8h1rWOHq6omSGv8XkvecCaGrqpro3a4yTcF8ladxDPRBYhgdaR1ASSgU4Zso2L3fbpmtFgUpy6pHGSws7LvDCbVOXLDa2fIZUQ7mLVZi0SQpe+Rcaer72FNvQ3jfPyQMMMdSLVakwlRFNaalntqtf2KhzcZLIEkxPsjJHbt29nrheKwpL88oTUBSv9tEcvbhvSTyEpQ+NRxpx5UtTN7wqr0gBMLjDbzIuFmtjN8d8uMJK/loKw0jyLwAwY787URiREMia2GeiVTHYoq34CaQBZC0MG69kRQR3Wz7Sg0jSYDTIYtYwphJITiSyZ3KO9jqQ79UKwmTofZ03qbXBd26HQQV4ryE539Z0HMAO5LNYslRVpHUiD0LSaKysoixR7zwpK2IbDCXgYjjajtM9lrUPeszZOxiZhmaYcaScg5Sg5p5AIrrjNnpU2bZOw1nT/pn0uy8qK+A99TNIC0DTFfCK64XKAjqcK458imSQ42zY+dwDvtOW0iLyO2qw5JNIvC6QlICmMKaB5bN1cIHpsB0hghsomd3O16eiOvI7aVAlhlFAtg++kRVCLb8C2ObDMer+tMJHXKO1DqYTwBqGTOaEGbcjemAa9ptZdlw01MgI0L7LOfcxcGBoRqzmKt9DQKCGRGVfKs1KPU1igm3+QDmVh+u5x1gczCTEZE3CPdxJSHn3+Y2WfzEQmITpRspT1JS01dAtgvCbKY3Tkci5iHjnW2unpN1U34cwDQETcZ2bzURZyEUJfEmuqLUedGGrdigWnDeOWcZFpo/60Adt51BWRixA1LUOUXt60+jRgtMRpqS62qrmEXgszUHKP6DRY1lWYd42UOx5inHuo8wSTUqHe20gmgaDXHuLYqSARmi155QNz5JA0mSy5yS10tAY6jh7UPspO1QtOHJnXGrg6ktA6eqRQLKZQxNBygR9UVTW8Yb3QHV+ZkRkIeX8Oz20pFYspfPiMkZJlPBsrL0yuWZkk9cIxdXsuaSozo81gn5hcM7r/pSAKE6KJZTThSh+wssiwtkCPypwbXyrrxNo73q8z/XLeoAcUDKocUFB4DjFQU5U5T07OGpx3qIudZjONndJWaOm8LO4+Mpl+TChYBjfILGiKz1UmZpUlQaVEOd07HknFs0jmHeZgGxcHFFQihC4Va48Ft4gdyJJBT4vYshaUlaKXlQ9Sfvv27cWtW7f+QPMnlP76+rqcnZ0txRZqa73BgfkjyHgrFeHkZGuQ8tfa2trfMklqXgpS7I1GwC9YAP4uDuDs7Pfz8/PTmzdvMrFu4UnhfkhU5mz7HZeZkaXN3lnQZzgd6GafsT5Rp9VZIXlhP0errmdoOSeE0MP5T8zDT+p8Io0vJJ8YpBO4c6doLftDeKFqfUXyf8xjblf0XIHbsRL1CNfioa5FQgwo4peXl0N9egDh9RF0VaFSQRXV52su+rjOmMuHgtlIPhuQ1gmskjbs2ZgK67m8lOqezhc7Ps5G8UIIMeURdJE0+IjTWdBIH60o4wryaph4I8SAeUrQwUf2I05R9pnY3ZQqS0qEvh1HEH3vnfdOiMGUR5wSnGOOx56eP8vEBuaaaVZmo0QYNEaIgbrxzdlYBpFM0o5euZQcXUdsMU85QQLRKBEGjRNioHMMF1y7Mx5Ef4q/vWE2vh6Gw/cukrrdCiubLQDc28J6Q77cK8kzgY/b9Fze1hBiw5CD5n3dCuYk1qLWEtcPj5lJ2Ebzu5WEJKFHDQZKDkc8CeLrXpIs7fRYgqCaKAE8OCxq0mjo0KFDhw4dOnTo0KHDZ/gPeuE7Mm+hz58AAAAASUVORK5CYII=" class="void-img" data-v-094eb20e><div class="void-tips" data-v-094eb20e>
+                数据加载中
+            </div><!----></div></div><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADQAAAA0CAMAAADypuvZAAAAclBMVEUAAAAiIiIRERESEhITExMKCgoMDAz////8/Pz8/Pz+/v709PSJiYnv7+/Gxsb4+Pj8/Pz29vb7+/v8/Pzx8fH6+vrZ2dnu7u62trbd3d36+vr6+vr8/Pz6+vrm5ub19fWqqqr///9NTU3p6eljY2OxsbFeuYADAAAAIXRSTlMABQoGCA0Q8NLi4ZceeBW0sqaikoiDS0UtJXLDwZNqZBh6igpAAAABnklEQVRIx9XSa7OCIBAG4BZQ0LKLealOl4Pm//+LBzjjLLYqfO2dqQ/BM++y0+YrA+NXvGhvx1xqLdWxbuPIvpbaS15eIUjOmqS8rpsbtvhtrxUCYw3JA5bI/q4Xo/bzjCu9kjvMmodezXlGwUsHcgNirnkISfIsXupgzhw+ivCs+wie/MLEiDIG1XyKch0RKfwq3pIL/fvdkx9bjgp4TU3XUVV4VZwdZsyMOiICLhQxtomoXHCvSRLTd11PlGQ+okabXVOFCASjxiKqmMA3MUmMRURJJgBRhgeDvTYiqwY8Ux4Sk5UP1jjk1OCvHNFGsEKTGERSTbbXxKFmghIZg7JEIAKRVDHoZJ+EiO1i0MVNhztPtmF0MtO5JqySOpDsMv4fcBVFCD0TO50fYQdczTbBNeAC0581o1IsQsSSnVo2PztjTBFV6XZxttQNR5BTz2yOyMIYHI50XU4zNTvbg8MRZdmkTVaGkNmmi7csbaqDkuZ+diia1BEOywj4P8NYYswSGJlxCcYK8hqqTJsJcxGErNXZCPOhIly6+cr8AWSCpSyWFyd6AAAAAElFTkSuQmCC" class="up-top" style="display:none;" data-v-094eb20e><!----><!----><!----><div vt-mdid="101" data-v-094eb20e><div vt-itemid="mine" vt-itemtype="4" data-v-094eb20e></div><div vt-itemid="show_set" vt-itemtype="4" data-v-094eb20e></div></div></div></div>
+
+<script src="https://qqvip-web.cdn-go.cn/qqgxh/latest//mall/ac38e282//client/rie.vue2.runtime.b4d6.js" crossorigin="anonymous" defer></script><script src="https://qqvip-web.cdn-go.cn/qqgxh/latest//mall/ac38e282//client/mall/aio-dress/app.74a5.js" crossorigin="anonymous" defer></script>
+<script>window.__INITIAL_ASYNCDATA__={"isHost":false,"targetUin":"10000","rawUsingList":[{"images":[],"appId":2,"itemId":2141485,"name":"在说什么呢","feeType":49,"itemBgColor":"dbcab1","image":"https:\u002F\u002Ftianquan.gtimg.cn\u002Fbubble\u002Fitem\u002F2141485\u002FnewPreview1.png","extrainfo":{"price":300,"sourceId":"1112308884"},"extraappinfo":{"multOperationType":[],"extraInfo":{"extQualDay":"0","showGif":"0","bubbleGroup":"0","immersiveMaterial":"{\"zoomPointX\":57,\"zoomPointY\":56,\"color\":\"0xFF000000\",\"staticTopLeft\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-top-left-v2.png\",\"staticTopRight\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-top-right-v2.png\",\"staticBottomLeft\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-bottom-left-v2.png\",\"staticBottomRight\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-bottom-right-v2.png\",\"staticTopMiddle\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-top-middle-v2.png\",\"staticLeftMiddle\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-left-middle-v2.png\",\"staticBottomMiddle\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-bottom-middle-v2.png\",\"staticRightMiddle\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-right-middle-v2.png\",\"staticAllMiddle\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-all-middle-v2.png\",\"staticAll\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-all.png\"}","isKuikly":"1","bubbleType":"0","platformId":"0","isDiy":"0","isAiContent":"false","diyTextPos":"0","cornType":"0","isWithNotificationIcon":"0","vipLevel":"0","isLinkage":"0","showGifNew":"0"},"validDay":31}},{"images":[],"appId":15,"itemId":201534,"name":"二次元少女","feeType":5,"itemBgColor":"7c96c1","image":"https:\u002F\u002Ftianquan.gtimg.cn\u002Fcard\u002Foriginal\u002F201534\u002FtemplateThumb.jpg","extrainfo":{},"extraappinfo":{"multOperationType":[],"extraInfo":{"defaultColor":"2","isDiy":"0"}}},{"images":[],"appId":22,"itemId":2000,"name":"花瓣","feeType":5,"itemBgColor":"f7c8d0","image":"https:\u002F\u002Ftianquan.gtimg.cn\u002FcolorScreen\u002Fitem\u002F2000\u002FlistImg.png","extrainfo":{},"extraappinfo":{"multOperationType":[],"extraInfo":{}}},{"images":[],"appId":17,"itemId":2730,"name":"岁月成碑","feeType":5,"itemBgColor":"f9e7e5","image":"https:\u002F\u002Ftianquan.gtimg.cn\u002Ffuncall\u002FfunCall\u002F2730\u002Fweb_image.jpg","extrainfo":{},"extraappinfo":{"multOperationType":[],"extraInfo":{}}},{"images":[],"appId":4,"name":"默认挂件","feeType":1,"itemBgColor":"f2f2f2","image":"https:\u002F\u002Ftianquan.gtimg.cn\u002FfaceAddon\u002Fitem\u002F0\u002Fnew1.png","extrainfo":{},"isSetup":1,"extraappinfo":{"multOperationType":[],"extraInfo":{"isDiy":"0"}}},{"images":[],"appId":23,"name":"默认头像","feeType":1,"itemBgColor":"00cafc","image":"https:\u002F\u002Fq1.qlogo.cn\u002Fqhis\u002FFixtureAvatarHashRedactedxxxxxxxxxxxxxxxxxxxx\u002F","extrainfo":{},"isSetup":1,"extraappinfo":{"multOperationType":[],"extraInfo":{}}},{"images":[],"appId":47,"name":"拍了拍","feeType":1,"itemBgColor":"9da1b2","image":"https:\u002F\u002Ftianquan.gtimg.cn\u002Fnudgeeffect\u002Fitem\u002F0\u002Fpreview.png","extrainfo":{},"extraappinfo":{"multOperationType":[],"extraInfo":{}}}],"isSvip":true,"avatarImage":"https:\u002F\u002Fq.qlogo.cn\u002Fg?b=qq&nk=10000&s=100","usingList":[{"item":{"images":[],"appId":2,"itemId":2141485,"name":"在说什么呢","feeType":49,"itemBgColor":"dbcab1","image":"https:\u002F\u002Ftianquan.gtimg.cn\u002Fbubble\u002Fitem\u002F2141485\u002FnewPreview1.png","extrainfo":{"price":300,"sourceId":"1112308884"},"extraappinfo":{"multOperationType":[],"extraInfo":{"extQualDay":"0","showGif":"0","bubbleGroup":"0","immersiveMaterial":"{\"zoomPointX\":57,\"zoomPointY\":56,\"color\":\"0xFF000000\",\"staticTopLeft\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-top-left-v2.png\",\"staticTopRight\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-top-right-v2.png\",\"staticBottomLeft\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-bottom-left-v2.png\",\"staticBottomRight\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-bottom-right-v2.png\",\"staticTopMiddle\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-top-middle-v2.png\",\"staticLeftMiddle\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-left-middle-v2.png\",\"staticBottomMiddle\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-bottom-middle-v2.png\",\"staticRightMiddle\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-right-middle-v2.png\",\"staticAllMiddle\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-all-middle-v2.png\",\"staticAll\":\"https:\u002F\u002Ftianquan.gtimg.cn\u002Fimmersive\u002Fbubble\u002F2141485\u002Fstatic-all.png\"}","isKuikly":"1","bubbleType":"0","platformId":"0","isDiy":"0","isAiContent":"false","diyTextPos":"0","cornType":"0","isWithNotificationIcon":"0","vipLevel":"0","isLinkage":"0","showGifNew":"0"},"validDay":31}},"scene":27,"buttonInfo":{"btnName":"用同款","btnStatus":0,"operationType":0}},{"item":{"images":[],"appId":15,"itemId":201534,"name":"二次元少女","feeType":5,"itemBgColor":"7c96c1","image":"https:\u002F\u002Ftianquan.gtimg.cn\u002Fcard\u002Foriginal\u002F201534\u002FtemplateThumb.jpg","extrainfo":{},"extraappinfo":{"multOperationType":[],"extraInfo":{"defaultColor":"2","isDiy":"0"}}},"scene":27,"buttonInfo":{"btnName":"用同款","btnStatus":0,"operationType":0}},{"item":{"images":[],"appId":22,"itemId":2000,"name":"花瓣","feeType":5,"itemBgColor":"f7c8d0","image":"https:\u002F\u002Ftianquan.gtimg.cn\u002FcolorScreen\u002Fitem\u002F2000\u002FlistImg.png","extrainfo":{},"extraappinfo":{"multOperationType":[],"extraInfo":{}}},"scene":27,"buttonInfo":{"btnName":"用同款","btnStatus":0,"operationType":0}},{"item":{"images":[],"appId":17,"itemId":2730,"name":"岁月成碑","feeType":5,"itemBgColor":"f9e7e5","image":"https:\u002F\u002Ftianquan.gtimg.cn\u002Ffuncall\u002FfunCall\u002F2730\u002Fweb_image.jpg","extrainfo":{},"extraappinfo":{"multOperationType":[],"extraInfo":{}}},"scene":27,"buttonInfo":{"btnName":"用同款","btnStatus":0,"operationType":0}},{"item":{"images":[],"appId":4,"name":"默认挂件","feeType":1,"itemBgColor":"f2f2f2","image":"https:\u002F\u002Ftianquan.gtimg.cn\u002FfaceAddon\u002Fitem\u002F0\u002Fnew1.png","extrainfo":{},"isSetup":1,"extraappinfo":{"multOperationType":[],"extraInfo":{"isDiy":"0"}},"itemId":0},"scene":27,"buttonInfo":{"btnName":"去商城","btnStatus":7,"operationType":4}},{"item":{"images":[],"appId":23,"name":"自定义头像","feeType":1,"itemBgColor":"00cafc","image":"https:\u002F\u002Fq.qlogo.cn\u002Fg?b=qq&nk=10000&s=100","extrainfo":{},"isSetup":1,"extraappinfo":{"multOperationType":[],"extraInfo":{}},"itemId":0},"scene":27,"buttonInfo":{"btnName":"去商城","btnStatus":7,"operationType":4}},{"item":{"images":[],"appId":47,"name":"拍了拍","feeType":1,"itemBgColor":"9da1b2","image":"https:\u002F\u002Ftianquan.gtimg.cn\u002Fnudgeeffect\u002Fitem\u002F0\u002Fpreview.png","extrainfo":{},"extraappinfo":{"multOperationType":[],"extraInfo":{}},"itemId":0},"scene":27,"buttonInfo":{"btnName":"用同款","btnStatus":0,"operationType":0}}],"suitListInfo":{"suits":[],"nextIndex":1,"isEnd":true,"switchState":false},"ipCollectionList":[]};(function(){var s;(s=document.currentScript||document.scripts[document.scripts.length-1]).parentNode.removeChild(s);}());</script>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      var app = window.rieApp.default || window.rieApp;
+      window.rieVue2Runtime.Vue.default.config.devtools = false;
+      window.rieVue2Runtime.init(app);
+    });
+  </script>
+    <script>window._HTML_END_TIMESTAMP_ = Date.now();</script>
+    
+    </body>
+</html>

--- a/packages/protocol/tests/web/friend-dress.test.ts
+++ b/packages/protocol/tests/web/friend-dress.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  FriendDressError,
+  getFriendDressWebAPI,
+} from '@snowluma/protocol/web/friend-dress';
+import { RequestUtil } from '@snowluma/protocol/web/request-util';
+
+// 真实装扮页 SSR HTML（脱敏：uin 改为 10000、头像 hash 已打码）。
+// __INITIAL_ASYNCDATA__ 里 7 项装扮：气泡(2)/名片(15)/彩色屏保(22)/来电(17)/
+// 挂件(4)/头像(23)/头像双击动作(47) —— 其中 2/23 属服务器不回真值的废数据。
+const SAMPLE_HTML = readFileSync(
+  fileURLToPath(new URL('./fixtures/friend-dress-sample.html', import.meta.url)),
+  'utf8',
+);
+
+const cookies = { uin: 'o10001', skey: 'SKEY', p_uin: 'o10001', p_skey: 'PSKEY' };
+
+/** 把任意 asyncData 对象包成最小可解析的 SSR HTML。 */
+const wrapHtml = (data: unknown): string =>
+  `<html><script>window.__INITIAL_ASYNCDATA__=${JSON.stringify(data)};(function(){})()</script></html>`;
+
+const mockHtml = (html: string) =>
+  vi.spyOn(RequestUtil, 'HttpGetText').mockResolvedValue(html as never);
+
+describe('friend-dress / real sample parsing', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('sends cookie + mobile UA to zb.vip.qq.com with the target uin', async () => {
+    const request = mockHtml(SAMPLE_HTML);
+    await getFriendDressWebAPI(cookies, '10000');
+
+    const [url, method, , headers] = request.mock.calls[0]!;
+    expect(url).toContain('https://zb.vip.qq.com/v2/pages/aioDressPage?');
+    expect(url).toContain('targetUin=10000');
+    // traceDetail 是预编码的 base64 串，必须原样出现（不能被二次编码成 base64%2D…）。
+    expect(url).toContain('&traceDetail=base64-');
+    expect(method).toBe('GET');
+    expect(headers).toMatchObject({
+      Cookie: 'uin=o10001; skey=SKEY; p_uin=o10001; p_skey=PSKEY',
+    });
+    expect((headers as Record<string, string>)['User-Agent']).toContain('QQ/');
+  });
+
+  it('parses the real page: svip, avatar, and only resolvable dress items', async () => {
+    mockHtml(SAMPLE_HTML);
+    const dress = await getFriendDressWebAPI(cookies, '10000');
+
+    expect(dress.target_uin).toBe('10000');
+    expect(dress.is_svip).toBe(true);
+    expect(dress.avatar_url).toBe('https://q.qlogo.cn/g?b=qq&nk=10000&s=100');
+
+    // 气泡(2)/头像(23) 是服务器永远回默认款的废数据，必须被剔除。
+    const appIds = dress.items.map((i) => i.app_id);
+    expect(appIds).not.toContain(2);
+    expect(appIds).not.toContain(23);
+    expect(appIds).toEqual([15, 22, 17, 4, 47]);
+  });
+
+  it('maps item fields: kind, itemId default 0, price default 0', async () => {
+    mockHtml(SAMPLE_HTML);
+    const dress = await getFriendDressWebAPI(cookies, '10000');
+
+    const card = dress.items.find((i) => i.app_id === 15)!;
+    expect(card.kind).toBe('名片');
+    expect(card.item_id).toBe(201534);
+    expect(card.name).toBe('二次元少女');
+    expect(card.preview_url).toBe('https://tianquan.gtimg.cn/card/original/201534/templateThumb.jpg');
+    expect(card.price).toBe(0);
+
+    // 默认挂件没有 itemId 字段 → 0。
+    const widget = dress.items.find((i) => i.app_id === 4)!;
+    expect(widget.item_id).toBe(0);
+    expect(widget.kind).toBe('挂件');
+  });
+
+  it('derives the funcall video url from the real web_image.jpg preview', async () => {
+    mockHtml(SAMPLE_HTML);
+    const dress = await getFriendDressWebAPI(cookies, '10000');
+
+    const funcall = dress.items.find((i) => i.app_id === 17)!;
+    expect(funcall.preview_url).toBe('https://tianquan.gtimg.cn/funcall/funCall/2730/web_image.jpg');
+    expect(funcall.video_url).toBe('https://tianquan.gtimg.cn/funcall/funCall/2730/media.mp4');
+  });
+});
+
+describe('friend-dress / synthetic payloads', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const base = { targetUin: '10000', isSvip: false, avatarImage: '', rawUsingList: [] as unknown[] };
+
+  it('an empty rawUsingList is a valid result, not an error', async () => {
+    mockHtml(wrapHtml(base));
+    const dress = await getFriendDressWebAPI(cookies, '10000');
+    expect(dress.items).toEqual([]);
+    expect(dress.is_svip).toBe(false);
+  });
+
+  it('does NOT return the image url as video when a funcall preview has an unexpected name', async () => {
+    mockHtml(wrapHtml({
+      ...base,
+      rawUsingList: [{ appId: 17, itemId: 1, name: 'x', image: 'https://cdn.example/funCall/1/preview.png' }],
+    }));
+    const dress = await getFriendDressWebAPI(cookies, '10000');
+    expect(dress.items[0]!.video_url).toBe('');
+    expect(dress.items[0]!.preview_url).toBe('https://cdn.example/funCall/1/preview.png');
+  });
+
+  it('extracts the card video from immersiveMaterial and survives broken JSON there', async () => {
+    mockHtml(wrapHtml({
+      ...base,
+      rawUsingList: [
+        {
+          appId: 15, itemId: 1, name: 'a', image: 'https://cdn.example/a.jpg',
+          extraappinfo: { extraInfo: { immersiveMaterial: '{"videoUrl":"https://cdn.example/a.mp4"}' } },
+        },
+        {
+          appId: 15, itemId: 2, name: 'b', image: 'https://cdn.example/b.jpg',
+          extraappinfo: { extraInfo: { immersiveMaterial: '{not json' } },
+        },
+      ],
+    }));
+    const dress = await getFriendDressWebAPI(cookies, '10000');
+    expect(dress.items[0]!.video_url).toBe('https://cdn.example/a.mp4');
+    expect(dress.items[1]!.video_url).toBe('');
+  });
+
+  it('labels unknown appIds without dropping them', async () => {
+    mockHtml(wrapHtml({
+      ...base,
+      rawUsingList: [{ appId: 999, itemId: 7, name: 'n', image: '' }],
+    }));
+    const dress = await getFriendDressWebAPI(cookies, '10000');
+    expect(dress.items[0]!.kind).toBe('appId=999');
+  });
+});
+
+describe('friend-dress / error classification', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const expectKind = async (uin: string, kind: string) => {
+    const e = await getFriendDressWebAPI(cookies, uin).catch((err: unknown) => err);
+    expect(e).toBeInstanceOf(FriendDressError);
+    expect((e as FriendDressError).kind).toBe(kind);
+    return e as FriendDressError;
+  };
+
+  it('network: transport failure is not folded into a parse error', async () => {
+    vi.spyOn(RequestUtil, 'HttpGetText').mockRejectedValue(new Error('Unexpected status code: 403'));
+    const e = await expectKind('10000', 'network');
+    expect(e.message).toContain('403');
+  });
+
+  it('parse: html without __INITIAL_ASYNCDATA__ (login-wall / risk-control shell)', async () => {
+    mockHtml('<html><body>请先登录</body></html>');
+    await expectKind('10000', 'parse');
+  });
+
+  it('parse: __INITIAL_ASYNCDATA__ present but not valid JSON', async () => {
+    mockHtml('<script>window.__INITIAL_ASYNCDATA__={oops};(function(){})()</script>');
+    await expectKind('10000', 'parse');
+  });
+
+  it('parse: a top-level array never matches the SSR object shape', async () => {
+    mockHtml(wrapHtml([1, 2]));
+    await expectKind('10000', 'parse');
+  });
+
+  it.each([
+    ['rawUsingList missing', { targetUin: '10000' }],
+    ['rawUsingList not an array', { targetUin: '10000', rawUsingList: 'nope' }],
+    ['item not an object', { targetUin: '10000', rawUsingList: ['nope'] }],
+    ['item appId not a number', { targetUin: '10000', rawUsingList: [{ appId: 'four' }] }],
+    ['targetUin not a string', { targetUin: 10000, rawUsingList: [] }],
+  ])('structure: %s', async (_label, payload) => {
+    mockHtml(wrapHtml(payload));
+    await expectKind('10000', 'structure');
+  });
+
+  it('uin_mismatch: page answers for a different account than requested', async () => {
+    mockHtml(wrapHtml({ targetUin: '20000', rawUsingList: [] }));
+    const e = await expectKind('10000', 'uin_mismatch');
+    expect(e.message).toContain('20000');
+    expect(e.message).toContain('10000');
+  });
+
+  it('tolerates a missing targetUin by echoing the requested uin', async () => {
+    mockHtml(wrapHtml({ rawUsingList: [] }));
+    const dress = await getFriendDressWebAPI(cookies, '10000');
+    expect(dress.target_uin).toBe('10000');
+  });
+});


### PR DESCRIPTION
<!-- 感谢贡献。请填写以下内容，方便评审。 -->

## 关联 Issue
无

## 变更说明


  新增 OneBot 动作 _get_friend_dress，传入任意 user_id 即可查询该 QQ号正在使用的个性装扮（挂件、名片、来电、彩色屏保、头像双击动作、输入状态等）。

  无需是好友 —— 该接口走 zb.vip.qq.com 的 SSR 装扮页、纯 cookie 鉴权，对任意 QQ 号均可查询，不受好友关系限制。

---

  沿用现有 web 方法的三层结构（protocol / core WebApi / onebot action）：

  - protocol 层 — 新增 packages/protocol/src/web/friend-dress.ts：GET aioDressPage 抓取 window.__INITIAL_ASYNCDATA__ 并解析。沿用
  RequestUtil.HttpGetText / cookieToString / createLogger('Bridge.Web') 约定。
    - 剔除服务器只回默认款的气泡/字体/头像（appId 2/5/23），避免返回废数据；
    - 名片/来电补齐动态预览视频 url。
  - core 层 — WebApi 新增 getFriendDress(targetUin)，经 getCookies(bridge, 'vip.qq.com') 取 cookie 后调用 protocol 函数。
  - onebot 层 — extended.ts 新增只读动作 _get_friend_dress，参数 user_id，解析失败时返回 ACTION_FAILED。

  pskey/skey 获取与 bkn 计算复用现有实现（本接口仅需 cookie，不用 bkn）。

## 提交前检查

- [x] 本 PR 聚焦单一目标，未夹带无关改动
- [x] 已通过 `pnpm lint` 与 `pnpm typecheck`
- [x] 已补充/更新相关测试，且 `pnpm test` 通过
- [x] 文件行尾为 LF（未引入 CRLF）
- [x] PR 描述与实际实现一致
