### PR TITLE
feat(common): independent file log level via SNOWLUMA_LOG_FILE_LEVEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ WebUI 的“系统设置 → 存储管理”可查看受管数据占用、调整
 | 日志树总量上限 | 1024 MB | `SNOWLUMA_LOG_MAX_TOTAL_MB` |
 | 日志保留天数 | 7 天；`0` 表示关闭按日期清理 | `SNOWLUMA_LOG_RETAIN_DAYS` |
 | 按账号额外写日志 | 关闭 | `SNOWLUMA_LOG_PER_UIN` |
+| 文件日志级别 | debug | `SNOWLUMA_LOG_FILE_LEVEL` |
 
 环境变量优先于 `config/runtime.json`，对应字段会在 WebUI 中显示为锁定。`SNOWLUMA_LOG_MAX_MB` 仅控制单个日志分卷大小，不是日志树总量上限。
 

--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -114,14 +114,32 @@ function resolveMinLevel(): LogLevel {
   return 'info';
 }
 
+const _rawFileLevel = (process.env.SNOWLUMA_LOG_FILE_LEVEL ?? '').toLowerCase();
+
+function resolveFileMinLevel(): LogLevel {
+  if (_rawFileLevel === 'trace') return 'debug';
+  if (_rawFileLevel === 'debug' || _rawFileLevel === 'info' || _rawFileLevel === 'success' ||
+      _rawFileLevel === 'warn' || _rawFileLevel === 'error') {
+    return _rawFileLevel;
+  }
+  return 'debug';
+}
+
 // Mutable — seeded from SNOWLUMA_LOG_LEVEL at module load, but
 // setLogLevel() lets WebUI / SDK callers flip it without a restart.
-// Only governs console + ring buffer + subscribers; the file
-// transport always sees debug-and-up regardless.
+// Only governs console + ring buffer + subscribers;
+// the file transport level is seeded independently from
+// SNOWLUMA_LOG_FILE_LEVEL (default debug)
+// and is not affected by setLogLevel().
 let currentLevel: LogLevel = resolveMinLevel();
+let currentFileLevel: LogLevel = resolveFileMinLevel();
 
 function shouldLog(level: LogLevel): boolean {
   return LEVEL_WEIGHT[level] >= LEVEL_WEIGHT[currentLevel];
+}
+
+function shouldLogToFile(level: LogLevel): boolean {
+  return LEVEL_WEIGHT[level] >= LEVEL_WEIGHT[currentFileLevel];
 }
 
 export const LOG_LEVELS: readonly LogLevel[] = ['trace', 'debug', 'info', 'success', 'warn', 'error'];
@@ -130,11 +148,11 @@ export function getLogLevel(): LogLevel {
   return currentLevel;
 }
 
-/**
- * Change the console / subscriber level at runtime. Invalid input is
- * a no-op (returns false). File transport is unaffected — it always
- * sees every level so post-mortems remain useful.
- */
+
+// Change the console / subscriber level at runtime.
+// Invalid input is a no-op (returns false).
+// Does not affect the file transport log level.
+
 export function setLogLevel(level: string): boolean {
   const lower = String(level).toLowerCase();
   if (!LOG_LEVELS.includes(lower as LogLevel)) return false;
@@ -184,15 +202,15 @@ function render(level: LogLevel, options: LogOptions, args: unknown[], reqId?: n
 }
 
 function emit(level: LogLevel, options: LogOptions, args: unknown[]): void {
-  // Console / subscriber level filter. File output is debug-and-up always;
-  // see log-file-transport.ts.
+  // Console / subscriber level filter.
+  // File output is gated independently by currentFileLevel.
   const passesConsole = shouldLog(level);
 
-  // `trace` never touches disk and is the high-volume full-chain stream. When
-  // it won't reach the console/memory buffer either (level not dialed to
-  // trace), bail BEFORE format/render AND before evaluating any lazy producer
-  // — this is what keeps full-chain tracing ~free at the default level even
-  // with hundreds of groups.
+  // `trace` is the high-volume full-chain diagnostic stream, intentionally
+  // excluded from disk to avoid I/O saturation. When console is not dialed
+  // to trace, the early return below skips format/render/disk entirely.
+  // Set SNOWLUMA_LOG_LEVEL=trace to inspect trace output in console/memory;
+  // trace never reaches disk regardless.
   if (level === 'trace' && !passesConsole) return;
 
   // Lazy trace form: `log.trace(() => ['…', deepRender(x)])`. The producer
@@ -230,11 +248,11 @@ function emit(level: LogLevel, options: LogOptions, args: unknown[]): void {
     stream.write(line.replace(/[\x00-\x08\x0B-\x1A\x1C-\x1F\x7F]/g, '') + '\n');
   }
 
-  // File transport sees debug-and-up for post-mortem value; `trace` is
-  // memory / WebUI only (omitted here to avoid huge on-disk volume). ANSI
-  // stripping happens inside the transport. UIN routes the line to its
-  // per-account sub-file in addition to the shared one.
-  if (level !== 'trace') getFileTransport().write(line, options.uin);
+  // File transport sees levels >= currentFileLevel (SNOWLUMA_LOG_FILE_LEVEL,
+  // default debug). `trace` is memory / WebUI only (omitted here to avoid huge
+  // on-disk volume). ANSI stripping happens inside the transport. UIN routes
+  // the line to its per-account sub-file in addition to the shared one.
+  if (level !== 'trace' && shouldLogToFile(level)) getFileTransport().write(line, options.uin);
 }
 
 /**
@@ -314,3 +332,13 @@ export function createLogger(scope: string): Logger {
 // stamping is a logging concern. Re-exported here so callers import the
 // whole logging surface from one place.
 export { nextRequestId, runWithRequestId, currentRequestId } from './request-context';
+
+// Warn once at module load if SNOWLUMA_LOG_FILE_LEVEL was set to 'trace'
+// (trace is intentionally excluded from disk for I/O reasons — see emit()).
+if (_rawFileLevel === 'trace') {
+  emit('warn', { scope: 'logger' }, [
+    'SNOWLUMA_LOG_FILE_LEVEL=trace is not supported — ' +
+    'trace is never written to disk. File level clamped to debug.',
+  ]);
+}
+

--- a/packages/common/tests/logger.test.ts
+++ b/packages/common/tests/logger.test.ts
@@ -1,11 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// The file transport writes to disk; stub it so the test has no side effects.
-vi.mock('../src/log-file-transport', () => ({
-  getFileTransport: () => ({ write: () => {} }),
+// Capture file transport writes via a spy so tests can assert on what reaches
+// the file. vi.hoisted() runs before vi.mock() so the spy is available inside
+// the factory (which is hoisted by vitest).
+const { fileWriteSpy } = vi.hoisted(() => ({
+  fileWriteSpy: vi.fn(),
 }));
 
-import { createLogger, subscribeLogs, type LogEntry } from '../src/logger';
+vi.mock('../src/log-file-transport', () => ({
+  getFileTransport: () => ({ write: fileWriteSpy, close: async () => {} }),
+}));
+
+import {
+  createLogger,
+  getLogLevel,
+  getRecentLogs,
+  setLogLevel,
+  subscribeLogs,
+  type LogEntry,
+} from '../src/logger';
 
 // Regression for issue #162: a hook-reported garbage UIN (13-digit, timestamp
 // shaped) produced a `[…]` tag wider than the fixed UIN slot, and the colored
@@ -53,5 +66,171 @@ describe('logger UIN slot padding', () => {
     expect(captured).toHaveLength(1);
     expect(captured[0]!.line).toMatch(/INFO\s+\[WebUI\.Export\] download me$/);
     expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('\x1b['));
+  });
+});
+
+// ─── Independent file-level filtering ─────────────────────────────────────
+// The file transport level is set independently from the console level via
+// SNOWLUMA_LOG_FILE_LEVEL (default debug). These tests verify that the
+// correct levels reach or skip the file transport under default settings.
+
+describe('file output gating', () => {
+  beforeEach(() => {
+    fileWriteSpy.mockClear();
+  });
+
+  it('writes debug to file under the default file level', () => {
+    createLogger('Test').debug('breadcrumb');
+    expect(fileWriteSpy).toHaveBeenCalledTimes(1);
+    expect(fileWriteSpy).toHaveBeenCalledWith(
+      expect.stringContaining('breadcrumb'),
+      undefined,
+    );
+  });
+
+  it('writes info to file under the default file level', () => {
+    createLogger('Test').info('item');
+    expect(fileWriteSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes success to file under the default file level', () => {
+    createLogger('Test').success('ok');
+    expect(fileWriteSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes warn to file under the default file level', () => {
+    createLogger('Test').warn('heads-up');
+    expect(fileWriteSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes error to file under the default file level', () => {
+    createLogger('Test').error('problem');
+    expect(fileWriteSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('never writes trace to file regardless of level settings', () => {
+    // trace does not pass the console gate at the default log level (info),
+    // so emit() short-circuits before reaching the file-write decision.
+    // Even if console were set to trace, the hard guard at the end of emit()
+    // would still block the file write — this test just confirms no write
+    // under default conditions.
+    createLogger('Test').trace('full chain');
+    expect(fileWriteSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ─── setLogLevel vs file output ────────────────────────────────────────────
+// setLogLevel() only changes the console / subscriber level. The file output
+// level is independent and should not be affected.
+
+describe('setLogLevel does not affect file output', () => {
+  let savedLevel: ReturnType<typeof getLogLevel>;
+
+  beforeEach(() => {
+    fileWriteSpy.mockClear();
+    savedLevel = getLogLevel();
+  });
+
+  afterEach(() => {
+    setLogLevel(savedLevel);
+  });
+
+  it('still writes debug to file after raising console to warn', () => {
+    setLogLevel('warn');
+    createLogger('Test').debug('breadcrumb');
+    // File level is still debug → debug reaches file even though console
+    // (now at warn) skips it.
+    expect(fileWriteSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('still writes info to file after raising console to error', () => {
+    setLogLevel('error');
+    createLogger('Test').info('item');
+    // File level still debug → info passes shouldLogToFile.
+    expect(fileWriteSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('still writes to file even when console is dialled down to trace', () => {
+    setLogLevel('trace');
+    createLogger('Test').debug('reachable');
+    // Console lets everything through at trace; file still at debug.
+    expect(fileWriteSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── SNOWLUMA_LOG_FILE_LEVEL=trace warning ─────────────────────────────────
+// When the environment variable is set to 'trace' at startup, the logger emits
+// a one-time warning via its own infrastructure (no raw stderr.write). The
+// real file level is clamped to debug regardless.
+
+describe('SNOWLUMA_LOG_FILE_LEVEL=trace warning', () => {
+  const SAVED = process.env.SNOWLUMA_LOG_FILE_LEVEL;
+
+  afterEach(async () => {
+    // Restore the env and reset module cache so the next test gets a clean
+    // logger with the real env value.
+    if (SAVED === undefined) delete process.env.SNOWLUMA_LOG_FILE_LEVEL;
+    else process.env.SNOWLUMA_LOG_FILE_LEVEL = SAVED;
+    vi.resetModules();
+  });
+
+  it('emits a single warn entry at module load with scope logger', async () => {
+    process.env.SNOWLUMA_LOG_FILE_LEVEL = 'trace';
+    vi.resetModules();
+
+    // Dynamic import gives us a fresh logger module that sees the trace env
+    // var during resolveFileMinLevel() — the warning fires inside emit()
+    // at the bottom of the module body.
+    const fresh = await import('../src/logger');
+
+    const warnLogs = fresh
+      .getRecentLogs()
+      .filter((e: { level: string }) => e.level === 'warn');
+
+    // The module-init warning + no other warn entries should be in the ring.
+    expect(warnLogs).toHaveLength(1);
+    expect(warnLogs[0]!.scope).toBe('logger');
+    expect(warnLogs[0]!.message).toContain(
+      'SNOWLUMA_LOG_FILE_LEVEL=trace is not supported',
+    );
+    expect(warnLogs[0]!.message).toContain('clamped to debug');
+
+    fresh.closeLogger();
+  });
+
+  it('emits no warning when the env var is not trace', async () => {
+    delete process.env.SNOWLUMA_LOG_FILE_LEVEL;
+    vi.resetModules();
+
+    const fresh = await import('../src/logger');
+
+    const warnLogs = fresh
+      .getRecentLogs()
+      .filter((e: { level: string }) => e.level === 'warn');
+
+    const traceWarnings = warnLogs.filter(
+      (e: { scope: string }) => e.scope === 'logger',
+    );
+    expect(traceWarnings).toHaveLength(0);
+
+    fresh.closeLogger();
+  });
+
+  it('emits no warning for info', async () => {
+    process.env.SNOWLUMA_LOG_FILE_LEVEL = 'info';
+    vi.resetModules();
+
+    const fresh = await import('../src/logger');
+
+    const warnLogs = fresh
+      .getRecentLogs()
+      .filter((e: { level: string }) => e.level === 'warn');
+
+    const traceWarnings = warnLogs.filter(
+      (e: { scope: string }) => e.scope === 'logger',
+    );
+    expect(traceWarnings).toHaveLength(0);
+
+    fresh.closeLogger();
   });
 });

--- a/packages/onebot/src/api-handler.ts
+++ b/packages/onebot/src/api-handler.ts
@@ -262,8 +262,8 @@ export class ApiHandler {
     params: JsonObject,
     sink?: StreamSink,
   ): Promise<import('./types').ApiResponse> {
-    // Terse breadcrumb to the log file (debug, always persisted): lets the
-    // operator grep "what did the bot get asked to do" in post-mortems.
+    // Terse breadcrumb to the log file (debug, which is written to disk under the default
+    // file level): lets the operator grep "what did the bot get asked to do" in post-mortems.
     this.log.debug('%s params=%s', action, summarizeParams(params));
     // Full request shape, memory-only (trace). Lazy producer → the deep render
     // only runs when trace is live.

--- a/packages/webui/src/components/pages/logs-page.tsx
+++ b/packages/webui/src/components/pages/logs-page.tsx
@@ -510,7 +510,7 @@ export function LogsPage() {
               <div>
                 <div className="mb-2 flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
                   <span className="text-xs font-medium text-foreground">服务端日志级别</span>
-                  <span className="text-xs text-muted-foreground">· 仅影响控制台 / 实时流，文件始终落盘 debug</span>
+                  <span className="text-xs text-muted-foreground">· 仅影响控制台 / 实时流；文件落盘级别由环境变量决定，默认debug</span>
                 </div>
                 <div className="inline-flex flex-wrap gap-1 rounded-lg bg-muted/60 p-1">
                   {LEVELS.map((lv) => {

--- a/packages/webui/src/lib/api/types.ts
+++ b/packages/webui/src/lib/api/types.ts
@@ -249,7 +249,8 @@ export interface ApiClient {
     list(limit?: number): Promise<LogEntry[]>;
     /** Subscribe to the SSE log stream. Returns a disposer. */
     stream(options: LogsStreamOptions): () => void;
-    /** Current console / subscriber level. File output is always debug. */
+    /** Current console / subscriber level. File logging level is set via
+     *  SNOWLUMA_LOG_FILE_LEVEL (default: debug), independent of this method. */
     getLevel(): Promise<{ level: LogLevel; levels: LogLevel[] }>;
     /** Change the console / subscriber level at runtime. No restart needed. */
     setLevel(level: LogLevel): Promise<{ level: LogLevel; levels: LogLevel[] }>;


### PR DESCRIPTION
<!-- 感谢贡献。请填写以下内容，方便评审。 -->

## 关联 Issue

无关联Issue  
提出此PR为解决群中讨论的`[MsgPush.UnknownElement]`占满日志文件的问题
<!-- 例如 Closes #123。若无关联 issue，请说明这个 PR 解决什么问题、为何现在做。 -->

## 变更说明

### 变更
引入独立文件日志级别，将控制台级别与文件级别的控制权分离：

1. **新增 `SNOWLUMA_LOG_FILE_LEVEL` 环境变量**，默认 `debug`。
  文件传输通道现在通过 `shouldLogToFile()` 独立决策是否写入，
  不再跟随控制台级别 `currentLevel`。

2. **trace 自动降级与警告**：若将文件级别设为 `trace`（该级别
  本身永不落盘），模块启动时会通过日志系统自身的 `emit()` 发出
  一次 `[WARN]` 提示，并将文件级别钳位为 `debug`。

3. **同步更新文档与文案**：
    - `README.md` 环境变量表新增 `SNOWLUMA_LOG_FILE_LEVEL` 行
    - WebUI 日志页文案由 "文件始终落盘 debug" 改为
      "文件落盘级别由环境变量决定，默认 debug"
    - `webui/src/lib/api/types.ts` 中 `getLevel()` 的 JSDoc
      明确文件级别独立不受该方法影响
    - `onebot/src/api-handler.ts` 注释补充 "under the default file level"
      限定词

4. **补充单元测试 12 项**：
    - 验证默认文件级别下各 level 的写入/排除行为
    - 验证 `setLogLevel()` 不影响文件输出
    - 验证 `SNOWLUMA_LOG_FILE_LEVEL=trace` 时模块加载警告

## 提交前检查

- [x] 本 PR 聚焦单一目标，未夹带无关改动
- [x] 已通过 `pnpm lint` 与 `pnpm typecheck`
- [x] 已补充/更新相关测试，且 `pnpm test` 通过
- [x] 文件行尾为 LF（未引入 CRLF）
- [x] PR 描述与实际实现一致


---

感觉不说不太好，所以，unit test和commit message是AI写的  
基本上就是改逻辑+同文件内注释，改其他文件的关联文字，加单元测试，三件事，分了三个commit

外加之前提及的editorconfig的事情，发现其实本地设一下git config core.autocrlf=true 似乎也能解决问题……虽然不明白怎么解决的

俺的第一个正经PR贡献给这里了（