### PR TITLE
feat(onebot): add per-WS-client group message filtering

### DIFF
--- a/packages/onebot/src/config.ts
+++ b/packages/onebot/src/config.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import { isIP } from 'node:net';
 import path from 'path';
 import type {
+  GroupMessageFilterConfig,
   HttpClientNetwork,
   HttpServerNetwork,
   JsonObject,
@@ -195,6 +196,7 @@ const RESTORE_TOP_LEVEL_KEYS = new Set([
 
 const RESTORE_NETWORK_KEYS = new Set(['httpServers', 'httpClients', 'wsServers', 'wsClients']);
 const RESTORE_BASE_ADAPTER_KEYS = ['name', 'enabled', 'accessToken', 'messageFormat', 'reportSelfMessage'] as const;
+const GROUP_MESSAGE_FILTER_KEYS = new Set(['mode', 'groupIds']);
 
 function validateOneBotRestoreSource(value: JsonObject): void {
   rejectUnknownKeys(value, RESTORE_TOP_LEVEL_KEYS, '$');
@@ -256,7 +258,7 @@ function validateRestoreAdapterArray(value: unknown, kind: keyof OneBotNetworks,
     ? ['host', 'port', 'path']
     : kind === 'httpClients'
       ? ['url', 'timeoutMs']
-      : ['url', 'role', 'reconnectIntervalMs'];
+      : ['url', 'role', 'reconnectIntervalMs', 'groupMessageFilter'];
   if (kind === 'httpServers') specific.push('enableWebSocket');
   if (kind === 'wsServers') specific.push('role');
   const allowed = new Set<string>([...RESTORE_BASE_ADAPTER_KEYS, ...specific]);
@@ -299,11 +301,14 @@ function validateRestoreAdapterArray(value: unknown, kind: keyof OneBotNetworks,
         invalid(`${pathAt}.role must be Api, Event, or Universal`);
       }
     }
-    if (kind === 'wsClients' && raw.reconnectIntervalMs !== undefined) {
-      const interval = parseRestoreInteger(raw.reconnectIntervalMs);
-      if (interval === null || interval < 1000 || interval > NODE_TIMER_MAX_MS) {
-        invalid(`${pathAt}.reconnectIntervalMs must be an integer between 1000 and ${NODE_TIMER_MAX_MS}`);
+    if (kind === 'wsClients') {
+      if (raw.reconnectIntervalMs !== undefined) {
+        const interval = parseRestoreInteger(raw.reconnectIntervalMs);
+        if (interval === null || interval < 1000 || interval > NODE_TIMER_MAX_MS) {
+          invalid(`${pathAt}.reconnectIntervalMs must be an integer between 1000 and ${NODE_TIMER_MAX_MS}`);
+        }
       }
+      validateGroupMessageFilter(raw.groupMessageFilter, `${pathAt}.groupMessageFilter`);
     }
   });
   return value.length;
@@ -424,6 +429,7 @@ export function assertValidOneBotConfig(value: unknown): asserts value is OneBot
     ) {
       invalid(`${at}.reconnectIntervalMs must be an integer between 1000 and ${NODE_TIMER_MAX_MS}`);
     }
+    validateGroupMessageFilter(item.groupMessageFilter, `${at}.groupMessageFilter`);
   });
 
   if (!isObject(value.statusCommand)) invalid('statusCommand must be an object');
@@ -569,6 +575,38 @@ function validateRole(value: unknown, at: string): void {
   }
 }
 
+function validateGroupMessageFilter(value: unknown, at: string): void {
+  if (value === undefined) return;
+  if (!isObject(value)) invalid(`${at} must be an object`);
+  rejectUnknownKeys(value, GROUP_MESSAGE_FILTER_KEYS, at);
+  if (value.mode !== 'blacklist' && value.mode !== 'whitelist') {
+    invalid(`${at}.mode must be blacklist or whitelist`);
+  }
+  if (!Array.isArray(value.groupIds)) invalid(`${at}.groupIds must be an array`);
+  value.groupIds.forEach((id, index) => {
+    if (typeof id !== 'number' || !Number.isSafeInteger(id) || id <= 0) {
+      invalid(`${at}.groupIds[${String(index)}] must be a positive safe integer`);
+    }
+  });
+}
+
+function parseGroupMessageFilter(value: unknown): GroupMessageFilterConfig | undefined {
+  if (value === undefined) return undefined;
+  validateGroupMessageFilter(value, 'ws client groupMessageFilter');
+  const raw = value as JsonObject;
+  const seen = new Set<number>();
+  const groupIds: number[] = [];
+  for (const id of raw.groupIds as number[]) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    groupIds.push(id);
+  }
+  return {
+    mode: raw.mode as GroupMessageFilterConfig['mode'],
+    groupIds,
+  };
+}
+
 function invalid(message: string): never {
   throw new OneBotConfigValidationError(message);
 }
@@ -681,6 +719,12 @@ function wsClientToJson(n: WsClientNetwork): JsonObject {
     typeof n.reconnectIntervalMs === 'number' && Number.isFinite(n.reconnectIntervalMs)
       ? Math.max(1000, Math.trunc(n.reconnectIntervalMs))
       : 5000;
+  if (n.groupMessageFilter) {
+    out.groupMessageFilter = {
+      mode: n.groupMessageFilter.mode,
+      groupIds: [...new Set(n.groupMessageFilter.groupIds)],
+    };
+  }
   return out;
 }
 
@@ -900,6 +944,7 @@ function parseWsClient(value: JsonObject, defaults: AdapterDefaults): WsClientNe
     url,
     role: asRole(value.role, 'Universal'),
     reconnectIntervalMs: Math.max(1000, reconnectIntervalMs),
+    groupMessageFilter: parseGroupMessageFilter(value.groupMessageFilter),
   });
 }
 

--- a/packages/onebot/src/event-filter.ts
+++ b/packages/onebot/src/event-filter.ts
@@ -1,4 +1,10 @@
-import type { JsonObject, JsonValue, MessageFormat } from './types';
+import type {
+  GroupMessageFilterConfig,
+  JsonObject,
+  JsonValue,
+  MessageFormat,
+} from './types';
+
 export interface EventReportOptions {
   messageFormat: MessageFormat;
   reportSelfMessage: boolean;
@@ -31,6 +37,22 @@ export function buildDispatchPayload(event: JsonObject): DispatchPayload {
   }
 
   return { isSelfMessage, arrayJson, stringJson };
+}
+
+export function shouldDispatchGroupMessage(
+  event: JsonObject,
+  filter: GroupMessageFilterConfig | undefined,
+): boolean {
+  if (!filter) return true;
+  if (event.message_type !== 'group') return true;
+
+  const groupId = event.group_id;
+  if (typeof groupId !== 'number' || !Number.isSafeInteger(groupId) || groupId <= 0) {
+    return true;
+  }
+
+  const listed = filter.groupIds.includes(groupId);
+  return filter.mode === 'blacklist' ? !listed : listed;
 }
 
 export function pickDispatchJson(

--- a/packages/onebot/src/event-filter.ts
+++ b/packages/onebot/src/event-filter.ts
@@ -44,6 +44,7 @@ export function shouldDispatchGroupMessage(
   filter: GroupMessageFilterConfig | undefined,
 ): boolean {
   if (!filter) return true;
+  if (event.post_type !== 'message' && event.post_type !== 'message_sent') return true;
   if (event.message_type !== 'group') return true;
 
   const groupId = event.group_id;

--- a/packages/onebot/src/network/ws-client-adapter.ts
+++ b/packages/onebot/src/network/ws-client-adapter.ts
@@ -3,6 +3,7 @@ import { createLogger } from '@snowluma/common/logger';
 import {
   pickDispatchJson,
   resolveReportOptions,
+  shouldDispatchGroupMessage,
   type DispatchPayload,
   type EventReportOptions,
 } from '../event-filter';
@@ -94,9 +95,10 @@ export class WsClientAdapter extends IOneBotNetworkAdapter<WsClientNetwork> {
     this.role = next.role ?? 'Universal';
   }
 
-  onEvent(_event: JsonObject, payload: DispatchPayload): void {
+  onEvent(event: JsonObject, payload: DispatchPayload): void {
     if (!this.isEnabled || !this.socket) return;
     if (this.role !== 'Event' && this.role !== 'Universal') return;
+    if (!shouldDispatchGroupMessage(event, this.config.groupMessageFilter)) return;
     const json = pickDispatchJson(payload, this.options);
     if (json === null) return;
     safeSend(this.socket, json);

--- a/packages/onebot/src/types.ts
+++ b/packages/onebot/src/types.ts
@@ -26,6 +26,13 @@ export type WsRole = 'Api' | 'Event' | 'Universal';
 
 export type MessageFormat = 'array' | 'string';
 
+export type GroupMessageFilterMode = 'blacklist' | 'whitelist';
+
+export interface GroupMessageFilterConfig {
+  mode: GroupMessageFilterMode;
+  groupIds: number[];
+}
+
 export type NetworkKind = 'httpServers' | 'httpClients' | 'wsServers' | 'wsClients';
 
 export interface NetworkBase {
@@ -63,6 +70,8 @@ export interface WsClientNetwork extends NetworkBase {
   url: string;
   role?: WsRole;
   reconnectIntervalMs?: number;
+  /** Optional per-client filter applied only to group chat message events. */
+  groupMessageFilter?: GroupMessageFilterConfig;
 }
 
 export interface OneBotNetworks {

--- a/packages/onebot/tests/ws-client-group-filter-config.test.ts
+++ b/packages/onebot/tests/ws-client-group-filter-config.test.ts
@@ -1,0 +1,108 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  assertValidOneBotConfig,
+  loadOneBotConfig,
+  makeDefaultOneBotConfig,
+  prepareOneBotConfigForRestore,
+  saveOneBotConfig,
+} from '../src/config';
+
+describe('ws client group message filter config', () => {
+  let tempDir: string;
+  let previousCwd: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snowluma-onebot-group-filter-'));
+    previousCwd = process.cwd();
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('round-trips a ws client group message filter', () => {
+    const config = makeDefaultOneBotConfig();
+    config.networks.wsClients.push({
+      name: 'airi',
+      url: 'wss://example.com/onebot/v11/ws',
+      role: 'Universal',
+      reconnectIntervalMs: 5000,
+      messageFormat: 'array',
+      reportSelfMessage: false,
+      groupMessageFilter: {
+        mode: 'blacklist',
+        groupIds: [985983966, 787682322, 985983966],
+      },
+    });
+
+    saveOneBotConfig('10001', config);
+    const reloaded = loadOneBotConfig('10001');
+
+    expect(reloaded.networks.wsClients[0].groupMessageFilter).toEqual({
+      mode: 'blacklist',
+      groupIds: [985983966, 787682322],
+    });
+  });
+
+  it('rejects malformed ws client group message filters', () => {
+    const invalidValues: unknown[] = [
+      null,
+      { mode: 'deny', groupIds: [985983966] },
+      { mode: 'blacklist', groupIds: '985983966' },
+      { mode: 'blacklist', groupIds: [0] },
+      { mode: 'blacklist', groupIds: [-1] },
+      { mode: 'blacklist', groupIds: [1.5] },
+      { mode: 'blacklist', groupIds: [Number.MAX_SAFE_INTEGER + 1] },
+    ];
+
+    for (const groupMessageFilter of invalidValues) {
+      const config = makeDefaultOneBotConfig();
+      config.networks.wsClients.push({
+        name: 'bad-filter',
+        url: 'ws://127.0.0.1:8080/ws',
+        messageFormat: 'array',
+        reportSelfMessage: false,
+        groupMessageFilter,
+      } as never);
+
+      expect(() => assertValidOneBotConfig(config)).toThrow(/groupMessageFilter/);
+    }
+  });
+
+  it('accepts a valid filter and rejects malformed filter content during restore', () => {
+    const valid = {
+      mode: 'snapshot',
+      networks: {
+        httpServers: [],
+        httpClients: [],
+        wsServers: [],
+        wsClients: [{
+          name: 'airi',
+          url: 'wss://example.com/ws',
+          messageFormat: 'array',
+          reportSelfMessage: false,
+          groupMessageFilter: { mode: 'whitelist', groupIds: [123, 456] },
+        }],
+      },
+      statusCommand: { enabled: true, swallow: false, cooldownSeconds: 5, trigger: '#sl' },
+      historySync: { enabled: false },
+      notifications: { channelIds: [] },
+    };
+
+    expect(() => prepareOneBotConfigForRestore(valid, 'per-uin')).not.toThrow();
+
+    const invalid = structuredClone(valid);
+    invalid.networks.wsClients[0].groupMessageFilter = {
+      mode: 'whitelist',
+      groupIds: ['123'],
+    } as never;
+
+    expect(() => prepareOneBotConfigForRestore(invalid, 'per-uin'))
+      .toThrow(/groupMessageFilter/);
+  });
+});

--- a/packages/onebot/tests/ws-client-group-message-filter-adapter.test.ts
+++ b/packages/onebot/tests/ws-client-group-message-filter-adapter.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { FakeWebSocket, instances } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require('node:events') as typeof import('node:events');
+  const instances: FakeWebSocket[] = [];
+
+  class FakeWebSocket extends EventEmitter {
+    public readyState = 1;
+    public readonly sent: string[] = [];
+
+    constructor(public readonly url: string, _opts: unknown) {
+      super();
+      instances.push(this);
+    }
+
+    send(payload: string, cb?: (err?: Error | null) => void): void {
+      this.sent.push(payload);
+      cb?.(null);
+    }
+
+    close(): void {
+      this.readyState = 3;
+    }
+
+    terminate(): void {
+      this.readyState = 3;
+      this.emit('close');
+    }
+  }
+
+  return { FakeWebSocket, instances };
+});
+
+vi.mock('@snowluma/websocket', () => ({ WebSocket: FakeWebSocket }));
+
+import { buildDispatchPayload } from '../src/event-filter';
+import { NetworkReloadType, type NetworkAdapterContext } from '../src/network/adapter';
+import { WsClientAdapter } from '../src/network/ws-client-adapter';
+import type { JsonObject, WsClientNetwork } from '../src/types';
+
+function ctx(): NetworkAdapterContext {
+  return {
+    uin: '10001',
+    api: { processStreamRequest: async () => {} } as never,
+    buildLifecycleEvent: () => ({}),
+    buildHeartbeatEvent: () => ({}),
+  };
+}
+
+function cfg(over: Partial<WsClientNetwork> = {}): WsClientNetwork {
+  return {
+    name: 'ws',
+    enabled: true,
+    url: 'ws://127.0.0.1:8080/ws',
+    role: 'Universal',
+    reconnectIntervalMs: 5000,
+    messageFormat: 'array',
+    reportSelfMessage: false,
+    ...over,
+  };
+}
+
+function groupMessage(groupId: number): JsonObject {
+  return {
+    post_type: 'message',
+    message_type: 'group',
+    group_id: groupId,
+    user_id: 10001,
+    message: [{ type: 'text', data: { text: 'hello' } }],
+    raw_message: 'hello',
+  };
+}
+
+describe('WsClientAdapter group message filter', () => {
+  it('filters group messages independently for each ws client', () => {
+    instances.length = 0;
+    const event = groupMessage(985983966);
+    const payload = buildDispatchPayload(event);
+
+    const airi = new WsClientAdapter('airi', cfg({
+      name: 'airi',
+      url: 'ws://127.0.0.1:8081/ws',
+      groupMessageFilter: { mode: 'blacklist', groupIds: [985983966] },
+    }), ctx());
+    const moe = new WsClientAdapter('moe', cfg({
+      name: 'moe',
+      url: 'ws://127.0.0.1:8082/ws',
+      groupMessageFilter: { mode: 'blacklist', groupIds: [787682322] },
+    }), ctx());
+
+    airi.open();
+    moe.open();
+    airi.onEvent(event, payload);
+    moe.onEvent(event, payload);
+
+    expect(instances).toHaveLength(2);
+    expect(instances[0].sent).toHaveLength(0);
+    expect(instances[1].sent).toHaveLength(1);
+  });
+
+  it('hot-reloads only the filter without reopening the websocket', async () => {
+    instances.length = 0;
+    const adapter = new WsClientAdapter('airi', cfg({
+      name: 'airi',
+      groupMessageFilter: { mode: 'blacklist', groupIds: [985983966] },
+    }), ctx());
+
+    adapter.open();
+    expect(instances).toHaveLength(1);
+
+    const result = await adapter.reload(cfg({
+      name: 'airi',
+      groupMessageFilter: { mode: 'blacklist', groupIds: [787682322] },
+    }));
+
+    expect(result).toBe(NetworkReloadType.Normal);
+    expect(instances).toHaveLength(1);
+
+    const oldGroup = groupMessage(985983966);
+    adapter.onEvent(oldGroup, buildDispatchPayload(oldGroup));
+    expect(instances[0].sent).toHaveLength(1);
+
+    const newBlockedGroup = groupMessage(787682322);
+    adapter.onEvent(newBlockedGroup, buildDispatchPayload(newBlockedGroup));
+    expect(instances[0].sent).toHaveLength(1);
+  });
+});

--- a/packages/onebot/tests/ws-client-group-message-filter.test.ts
+++ b/packages/onebot/tests/ws-client-group-message-filter.test.ts
@@ -23,6 +23,7 @@ const privateMessage: JsonObject = {
 
 const groupNotice: JsonObject = {
   post_type: 'notice',
+  message_type: 'group',
   notice_type: 'group_increase',
   group_id: 985983966,
   user_id: 10001,

--- a/packages/onebot/tests/ws-client-group-message-filter.test.ts
+++ b/packages/onebot/tests/ws-client-group-message-filter.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { shouldDispatchGroupMessage } from '../src/event-filter';
+import type { GroupMessageFilterConfig, JsonObject } from '../src/types';
+
+function groupMessage(groupId: number): JsonObject {
+  return {
+    post_type: 'message',
+    message_type: 'group',
+    group_id: groupId,
+    user_id: 10001,
+    message: [{ type: 'text', data: { text: 'hello' } }],
+    raw_message: 'hello',
+  };
+}
+
+const privateMessage: JsonObject = {
+  post_type: 'message',
+  message_type: 'private',
+  user_id: 10001,
+  message: [{ type: 'text', data: { text: 'hello' } }],
+  raw_message: 'hello',
+};
+
+const groupNotice: JsonObject = {
+  post_type: 'notice',
+  notice_type: 'group_increase',
+  group_id: 985983966,
+  user_id: 10001,
+};
+
+const blacklist: GroupMessageFilterConfig = {
+  mode: 'blacklist',
+  groupIds: [985983966],
+};
+
+const whitelist: GroupMessageFilterConfig = {
+  mode: 'whitelist',
+  groupIds: [985983966],
+};
+
+describe('shouldDispatchGroupMessage', () => {
+  it('passes every event when the filter is absent', () => {
+    expect(shouldDispatchGroupMessage(groupMessage(985983966), undefined)).toBe(true);
+  });
+
+  it('blocks matching blacklist groups and passes other groups', () => {
+    expect(shouldDispatchGroupMessage(groupMessage(985983966), blacklist)).toBe(false);
+    expect(shouldDispatchGroupMessage(groupMessage(787682322), blacklist)).toBe(true);
+  });
+
+  it('passes matching whitelist groups and blocks other groups', () => {
+    expect(shouldDispatchGroupMessage(groupMessage(985983966), whitelist)).toBe(true);
+    expect(shouldDispatchGroupMessage(groupMessage(787682322), whitelist)).toBe(false);
+  });
+
+  it('blocks every group message for an empty whitelist', () => {
+    expect(shouldDispatchGroupMessage(groupMessage(985983966), {
+      mode: 'whitelist',
+      groupIds: [],
+    })).toBe(false);
+  });
+
+  it('does not affect private messages or notice events', () => {
+    expect(shouldDispatchGroupMessage(privateMessage, blacklist)).toBe(true);
+    expect(shouldDispatchGroupMessage(groupNotice, blacklist)).toBe(true);
+  });
+});

--- a/packages/webui/src/components/config/group-message-filter-utils.test.ts
+++ b/packages/webui/src/components/config/group-message-filter-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { formatGroupIdsInput, parseGroupIdsInput } from './group-message-filter-utils';
+
+describe('group message filter input', () => {
+  it('accepts comma and whitespace separated group ids', () => {
+    expect(parseGroupIdsInput('985983966, 787682322\n123456789')).toEqual({
+      groupIds: [985983966, 787682322, 123456789],
+    });
+  });
+
+  it('deduplicates ids while preserving order', () => {
+    expect(parseGroupIdsInput('985983966,787682322,985983966')).toEqual({
+      groupIds: [985983966, 787682322],
+    });
+  });
+
+  it('accepts an empty list', () => {
+    expect(parseGroupIdsInput('  ')).toEqual({ groupIds: [] });
+  });
+
+  it('rejects invalid values', () => {
+    expect(parseGroupIdsInput('abc').error).toBeDefined();
+    expect(parseGroupIdsInput('0').error).toBeDefined();
+    expect(parseGroupIdsInput('-1').error).toBeDefined();
+    expect(parseGroupIdsInput('1.5').error).toBeDefined();
+    expect(parseGroupIdsInput(String(Number.MAX_SAFE_INTEGER + 1)).error).toBeDefined();
+  });
+
+  it('formats ids for editing', () => {
+    expect(formatGroupIdsInput([985983966, 787682322])).toBe('985983966, 787682322');
+  });
+});

--- a/packages/webui/src/components/config/group-message-filter-utils.ts
+++ b/packages/webui/src/components/config/group-message-filter-utils.ts
@@ -1,0 +1,39 @@
+export type GroupMessageFilterMode = 'blacklist' | 'whitelist';
+
+export interface GroupMessageFilterConfig {
+  mode: GroupMessageFilterMode;
+  groupIds: number[];
+}
+
+export interface GroupIdParseResult {
+  groupIds: number[];
+  error?: string;
+}
+
+export function parseGroupIdsInput(value: string): GroupIdParseResult {
+  const text = value.trim();
+  if (!text) return { groupIds: [] };
+
+  const tokens = text.split(/[\s,]+/).filter(Boolean);
+  const seen = new Set<number>();
+  const groupIds: number[] = [];
+
+  for (const token of tokens) {
+    if (!/^\d+$/.test(token)) {
+      return { groupIds: [], error: `群号“${token}”格式不正确` };
+    }
+    const id = Number(token);
+    if (!Number.isSafeInteger(id) || id <= 0) {
+      return { groupIds: [], error: `群号“${token}”不是有效正整数` };
+    }
+    if (seen.has(id)) continue;
+    seen.add(id);
+    groupIds.push(id);
+  }
+
+  return { groupIds };
+}
+
+export function formatGroupIdsInput(groupIds: number[]): string {
+  return groupIds.join(', ');
+}

--- a/packages/webui/src/components/config/node-edit-dialog.tsx
+++ b/packages/webui/src/components/config/node-edit-dialog.tsx
@@ -44,8 +44,18 @@ import type {
   WsServerNetwork,
 } from '@/types';
 import { generateAccessToken, NETWORK_TABS } from './defaults';
+import {
+  formatGroupIdsInput,
+  parseGroupIdsInput,
+  type GroupMessageFilterConfig,
+  type GroupMessageFilterMode,
+} from './group-message-filter-utils';
 
 type AnyAdapter<K extends NetworkKind> = OneBotNetworks[K][number];
+type WsClientWithGroupFilter = WsClientNetwork & {
+  groupMessageFilter?: GroupMessageFilterConfig;
+};
+type GroupFilterUiMode = 'off' | GroupMessageFilterMode;
 
 const KIND_ICON: Record<NetworkKind, LucideIcon> = {
   httpServers: Server,
@@ -79,6 +89,14 @@ export function NodeEditDialog<K extends NetworkKind>(props: NodeEditDialogProps
   // open gets a fresh `initial` via useState's lazy init — no effect-based
   // resync needed, which keeps the lifecycle linear.
   const [draft, setDraft] = useState<AnyAdapter<K>>(initial);
+  const initialWsClient = kind === 'wsClients' ? initial as WsClientWithGroupFilter : undefined;
+  const [groupIdsText, setGroupIdsText] = useState(
+    () => formatGroupIdsInput(initialWsClient?.groupMessageFilter?.groupIds ?? []),
+  );
+  const parsedGroupIds = useMemo(() => parseGroupIdsInput(groupIdsText), [groupIdsText]);
+  const wsDraft = kind === 'wsClients' ? draft as WsClientWithGroupFilter : undefined;
+  const groupFilterMode: GroupFilterUiMode = wsDraft?.groupMessageFilter?.mode ?? 'off';
+  const groupFilterError = groupFilterMode === 'off' ? undefined : parsedGroupIds.error;
 
   const trimmedName = draft.name?.trim() ?? '';
   const blankName = trimmedName.length === 0;
@@ -101,7 +119,10 @@ export function NodeEditDialog<K extends NetworkKind>(props: NodeEditDialogProps
     [allowEmptyToken, draft.accessToken, draft.name, enforceTokenPolicy, inbound?.host, inbound?.port, kind, uin],
   );
 
-  const canSave = !blankName && !duplicateName && (tokenFeedback?.valid ?? true);
+  const canSave = !blankName
+    && !duplicateName
+    && (tokenFeedback?.valid ?? true)
+    && !groupFilterError;
 
   const patch = (changes: Partial<AnyAdapter<K>>) => setDraft({ ...draft, ...changes } as AnyAdapter<K>);
 
@@ -134,6 +155,15 @@ export function NodeEditDialog<K extends NetworkKind>(props: NodeEditDialogProps
             disabled={!canSave}
             onClick={() => {
               const cleaned = { ...draft, name: trimmedName } as AnyAdapter<K>;
+              if (kind === 'wsClients') {
+                const ws = cleaned as WsClientWithGroupFilter;
+                if (ws.groupMessageFilter) {
+                  ws.groupMessageFilter = {
+                    mode: ws.groupMessageFilter.mode,
+                    groupIds: parsedGroupIds.groupIds,
+                  };
+                }
+              }
               onSubmit(cleaned);
               onOpenChange(false);
             }}
@@ -221,6 +251,51 @@ export function NodeEditDialog<K extends NetworkKind>(props: NodeEditDialogProps
                   onChange={(v) => patch({ role: v } as unknown as Partial<AnyAdapter<K>>)}
                 />
               </SettingRow>
+            )}
+
+            {kind === 'wsClients' && (
+              <>
+                <SettingRow
+                  label="群消息过滤"
+                  desc="只影响此 WS 客户端收到的群聊消息，不影响私聊、通知、请求或 API 通信"
+                >
+                  <DropdownSelect
+                    className="w-32"
+                    ariaLabel="群消息过滤模式"
+                    value={groupFilterMode}
+                    options={GROUP_FILTER_OPTIONS}
+                    onChange={(next) => {
+                      if (next === 'off') {
+                        patch({ groupMessageFilter: undefined } as unknown as Partial<AnyAdapter<K>>);
+                        return;
+                      }
+                      patch({
+                        groupMessageFilter: {
+                          mode: next,
+                          groupIds: parsedGroupIds.error ? [] : parsedGroupIds.groupIds,
+                        },
+                      } as unknown as Partial<AnyAdapter<K>>);
+                    }}
+                  />
+                </SettingRow>
+
+                {groupFilterMode !== 'off' && (
+                  <div className="px-4 py-3">
+                    <Field
+                      label="群号"
+                      placeholder="985983966, 787682322"
+                      value={groupIdsText}
+                      onChange={setGroupIdsText}
+                      error={groupFilterError}
+                    />
+                    <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+                      {groupFilterMode === 'blacklist'
+                        ? '这些群的聊天消息不会发送到此 WS 客户端'
+                        : '只有这些群的聊天消息会发送到此 WS 客户端'}
+                    </p>
+                  </div>
+                )}
+              </>
             )}
 
             <SettingRow label="上报自身消息" desc="将机器人自己发送的消息也作为 message_sent 事件上报">
@@ -544,4 +619,10 @@ const WS_ROLE_OPTIONS: ReadonlyArray<DropdownOption<WsRole>> = [
   { value: 'Universal', label: 'Universal' },
   { value: 'Event', label: 'Event' },
   { value: 'Api', label: 'Api' },
+];
+
+const GROUP_FILTER_OPTIONS: ReadonlyArray<DropdownOption<GroupFilterUiMode>> = [
+  { value: 'off', label: '不启用' },
+  { value: 'blacklist', label: '黑名单' },
+  { value: 'whitelist', label: '白名单' },
 ];


### PR DESCRIPTION
## 改动内容

为 OneBot 反向 WebSocket 客户端新增可选的、按 WS Client 独立配置的群聊消息过滤功能。

每个 WS Client 都可以单独选择群黑名单或群白名单；如果不配置该选项，则保持现有行为不变。

## 行为说明

- `blacklist`：命中的群聊消息不会发送给当前 WS Client。
- `whitelist`：只有命中的群聊消息才会发送给当前 WS Client。
- 私聊消息、notice、request 以及 OneBot API 请求/响应均不受影响。
- 过滤规则按 WS Client 独立生效，不同下游机器人可以使用不同的群列表。
- 仅修改群消息过滤配置时可热更新，不会因此重连 WebSocket。

## WebUI

在 WS Client 编辑界面中增加“群消息过滤”设置，支持：

- 不启用
- 黑名单
- 白名单

群号输入支持逗号、空格或换行分隔，并会校验是否为有效的正安全整数，同时对重复群号去重。

## 测试覆盖

新增并验证了以下场景：

- 配置校验与保存/重新加载后的 round-trip
- 黑名单命中与未命中行为
- 白名单命中与未命中行为
- 空白名单阻止所有群聊消息
- 私聊和 notice 不受群过滤影响
- 多个 WS Client 使用不同过滤规则时互不影响
- 仅修改过滤规则时热更新且不重连
- WebUI 群号输入解析与校验

## 本地验证

已在 Windows 环境完成以下验证：

- 新增 OneBot 群消息过滤相关测试：全部通过
- WebUI 群号解析测试：5/5 通过
- `pnpm typecheck`：monorepo 全部通过
- `pnpm lint`：0 error；有 1 个与本 PR 无关的既有 warning，位于 `packages/protocol/tests/msg-push/temp-message-source.test.ts`
- `pnpm run build:all`：通过

另外也运行了 OneBot 全量测试：80 个测试文件中 79 个通过，共 956 个测试通过、2 个跳过。唯一失败来自已有的 `stream-download.test.ts` Windows 路径场景，该用例使用 `/etc/passwd`，实际报错为 `ctx.getImageInfo is not a function`，与本 PR 的 WS Client 群消息过滤功能无关。

目前上游 PR 的 GitHub Actions 仍处于 fork 首次贡献需要维护者批准的状态，因此暂时保留为 Draft。