### PR TITLE
fix(ws): cap send backlog so control frames (pong) are never starved

### DIFF
--- a/packages/onebot/src/network/ws-server-connections.ts
+++ b/packages/onebot/src/network/ws-server-connections.ts
@@ -122,24 +122,41 @@ export class WsServerConnections {
     if (!this.acceptingActions || this.connections.size === 0) return;
     for (const connection of this.connections.values()) {
       if (connection.role !== 'Event' && connection.role !== 'Universal') continue;
-      const json = pickDispatchJson(payload, connection.options);
-      if (json === null) continue;
+      // Backpressure gate first (cheap) before serializing the event: a slow
+      // consumer must not balloon the socket write buffer — control frames
+      // (pong) share the same TCP stream and queue behind the backlog, so an
+      // unbounded backlog starves the peer's heartbeat and the connection
+      // dies anyway. OneBot event push is best-effort, so under overload we
+      // drop frames until the backlog drains below half the ceiling
+      // (hysteresis avoids flapping at the threshold). Log only on the
+      // enter/exit transition to avoid log spam while dropping.
       const backlog = connection.socket.bufferedAmount;
       if (backlog > SEND_BACKPRESSURE_CEILING) {
-        connection.droppingEvents = true;
+        if (!connection.droppingEvents) {
+          connection.droppingEvents = true;
+          this.log.warn(
+            '[%s] send backlog %d bytes, dropping event frames until it drains below %d',
+            this.name,
+            backlog,
+            SEND_BACKPRESSURE_RESUME,
+          );
+        }
       } else if (backlog < SEND_BACKPRESSURE_RESUME) {
-        connection.droppingEvents = false;
+        if (connection.droppingEvents) {
+          connection.droppingEvents = false;
+          this.log.info(
+            '[%s] send backlog drained to %d bytes, resuming event push',
+            this.name,
+            backlog,
+          );
+        }
       }
       if (connection.droppingEvents) {
         this.droppedEvents += 1;
-        this.log.warn(
-          '[%s] send backlog %d bytes, dropping event frame (total dropped: %d)',
-          this.name,
-          backlog,
-          this.droppedEvents,
-        );
         continue;
       }
+      const json = pickDispatchJson(payload, connection.options);
+      if (json === null) continue;
       safeSend(connection.socket, json);
     }
   }

--- a/packages/onebot/src/network/ws-server-connections.ts
+++ b/packages/onebot/src/network/ws-server-connections.ts
@@ -28,6 +28,17 @@ const HEARTBEAT_INTERVAL_MS = 30_000;
 const HEARTBEAT_MAX_MISSED = 2;
 const HEARTBEAT_DEAD_AFTER_S = (HEARTBEAT_INTERVAL_MS * (HEARTBEAT_MAX_MISSED + 1)) / 1000;
 
+// Per-connection send backpressure. OneBot event push is best-effort, so when
+// a slow consumer lets the socket write buffer grow past the ceiling we drop
+// event frames (hysteresis: resume only after the backlog drains below half).
+// An unbounded backlog would otherwise starve control frames — pong shares the
+// same TCP stream and queues behind it, so the peer's heartbeat times out and
+// the connection dies anyway (the "client timed out waiting for pong" failure
+// mode). 256 KiB drains in well under a second on any sane link, far below
+// typical heartbeat timeouts.
+const SEND_BACKPRESSURE_CEILING = 256 * 1024;
+const SEND_BACKPRESSURE_RESUME = SEND_BACKPRESSURE_CEILING / 2;
+
 export type WsServerConnectionConfig = NetworkBase & { path?: string; role?: WsRole };
 
 interface ForwardConnection {
@@ -35,6 +46,7 @@ interface ForwardConnection {
   role: WsRole;
   options: EventReportOptions;
   stopHeartbeat: () => void;
+  droppingEvents: boolean;
 }
 
 interface MetaFrames {
@@ -55,6 +67,7 @@ export class WsServerConnections {
   private acceptingActions = false;
   private readonly inFlightActions = new Set<Promise<void>>();
   private readonly connections = new Map<WebSocket, ForwardConnection>();
+  private droppedEvents = 0;
   private config: WsServerConnectionConfig;
   private options: EventReportOptions;
 
@@ -111,6 +124,22 @@ export class WsServerConnections {
       if (connection.role !== 'Event' && connection.role !== 'Universal') continue;
       const json = pickDispatchJson(payload, connection.options);
       if (json === null) continue;
+      const backlog = connection.socket.bufferedAmount;
+      if (backlog > SEND_BACKPRESSURE_CEILING) {
+        connection.droppingEvents = true;
+      } else if (backlog < SEND_BACKPRESSURE_RESUME) {
+        connection.droppingEvents = false;
+      }
+      if (connection.droppingEvents) {
+        this.droppedEvents += 1;
+        this.log.warn(
+          '[%s] send backlog %d bytes, dropping event frame (total dropped: %d)',
+          this.name,
+          backlog,
+          this.droppedEvents,
+        );
+        continue;
+      }
       safeSend(connection.socket, json);
     }
   }
@@ -157,6 +186,7 @@ export class WsServerConnections {
       role,
       options: this.options,
       stopHeartbeat,
+      droppingEvents: false,
     };
     this.connections.set(socket, connection);
 

--- a/packages/websocket/src/websocket.ts
+++ b/packages/websocket/src/websocket.ts
@@ -188,6 +188,13 @@ export class WebSocket extends EventEmitter {
   get readyState(): number { return this._readyState; }
   get isServer(): boolean { return this._isServer; }
 
+  /** Bytes queued in the underlying socket write buffer (ws-compatible API).
+   *  Lets callers observe backpressure before control frames (pong) get
+   *  starved behind an unbounded event backlog. */
+  get bufferedAmount(): number {
+    return this._socket.writableLength;
+  }
+
   protected _bindSocket(): void {
     const sock = this._socket;
     sock.on('data', (chunk: Buffer) => this._onData(chunk));


### PR DESCRIPTION
## 问题

WS 正向连接（客户端连 SnowLuma 的 ws-server）在客户端消费慢时反复出现 "客户端等待 pong 超时断开"。

根因：pong 与事件推送共享同一条 TCP 流，`socket.write()` 是 FIFO 队列。当事件推送没有背压控制、写缓冲无限膨胀时，收到 ping 后同步写入的 pong 帧会排在积压数据后面，超过对端心跳超时（如 20s）才送达，连接被判定死亡。

之前的思路（缓冲超阈值主动断连）只是把"被动超时断"变成"主动断"，连接照样断，没解决根本问题。

## 方案（只改 SnowLuma 侧）

1. **`packages/websocket/src/websocket.ts`**：给 `WebSocket` 增加 ws 兼容的 `bufferedAmount` getter（返回底层 socket 写缓冲字节数），让上层可以观察背压。

2. **`packages/onebot/src/network/ws-server-connections.ts`**：`onEvent()` 推送事件前检查 `bufferedAmount`：
   - 积压 > 256 KiB → 进入丢弃模式，丢弃事件帧（OneBot 事件推送本就是尽力而为，无确认机制）
   - 积压 < 128 KiB（上限一半）→ 恢复推送（滞回，避免在阈值处抖动）
   - 丢弃时记录 warning 日志与累计计数，便于观察

效果：写缓冲被限制在 ~256 KiB 内，pong 最多排在 256 KiB 数据后面，任何正常链路上都在亚秒级内送达，远低于常见心跳超时（20s/30s），连接不再因 pong 迟到而断。

## 备注

- 事件丢弃是权衡：丢事件比断连好，断连会连带丢更多事件且触发重连风暴。如果担心丢消息，后续可以加"丢弃前合并事件"或按事件类型分级（保留 message 类）的选项。
- 流式 Action 响应（`safeSendAsync`）未加背压，它是请求-响应模式，客户端主动消费，风险低；如需也可加。