### PR TITLE
fix(protocol): preserve native eventType in group request mapping

### DIFF
--- a/.local/pr-body.md
+++ b/.local/pr-body.md
@@ -1,0 +1,23 @@
+## 概述 (Overview)
+
+修复群加群申请（Add Request）在 OIDB `0x10C0` 到 `0x10C8` 审批链路中的 `eventType` 错位映射 Bug。
+
+## 问题原因 (Root Cause)
+
+1. 在底层 OIDB `0x10C0` 协议响应中，字段 2（`eventType`）返回的已是底层的操作类型（`1` = 主动申请加群，`2` = 邀请加群）。
+2. 旧代码中 `groupRequestOperationType` 误将其当成 NTQQ 前端 UI 层的 `SysNotifyType` 进行了二次映射（`1 -> 2`，`7 -> 1`），导致原本为 `1` 的主动加群申请被错误改写为 `eventType = 2`（邀请）。
+3. 进而导致构造的 `flag`（如 `slreq:1:...:2:0`）在调用 `set_group_add_request`（`0x10C8`）时以 `eventType = 2` 提交审批，腾讯服务端因记录类型不匹配而报错 `OIDB error 120162007 on 0x10c8_1: already deleted by system`。
+4. 同时，`groupRequestActor` 和 `GroupRequestPoller` 误将 `notifyType = 1` 当成邀请，导致加群申请的 `requester_uin` 被错误取成 `invitorUin`（0）。
+
+## 解决方案 (Changes)
+
+1. **`fetch-group-requests.ts`**：修正 `groupRequestOperationType`，直接保留底层的 `eventType`（`1` / `2` / `22`），并兼容处理可能传入的高层通知类型 `7 -> 1`。
+2. **`contacts.ts`**：规范解析 0x10C0 响应中的 `eventType`，避免错误转表。
+3. **`contact-actions.ts` & `group-request-poller.ts`**：修正 `groupRequestActor` 和 `toEvent` 的判断逻辑，仅在 `eventType` 为 `2` 或 `22` 时按邀请处理（提取 `invitor`），其余按申请处理（提取 `target`）。
+4. **测试**：补全并更新单元测试用例，覆盖 `eventType: 1` 和 `eventType: 2` 的各种场景。
+
+## 验证 (Verification)
+
+- [x] `pnpm typecheck` 全部通过。
+- [x] 单元测试 `fetch-group-requests.test.ts`、`contact-actions.test.ts`、`group-request-poller.test.ts`、`instance-context.test.ts`、`contacts.test.ts` 全部通过。
+- [x] 在真实 Docker 容器环境中测试小号主动申请加群，成功生成 `slreq:1:...:1:0` 并通过 `set_group_add_request` 成功审批入群。

--- a/.roo/mcp.json
+++ b/.roo/mcp.json
@@ -1,0 +1,20 @@
+{
+	"mcpServers": {
+		"snowluma": {
+			"command": "npx",
+			"args": [
+				"-y",
+				"@snowluma/mcp"
+			],
+			"env": {
+				"SNOWLUMA_MCP_ENDPOINT": "http://127.0.0.1:3000/",
+				"SNOWLUMA_MCP_TOKEN": "715306@Dfhj",
+				"SNOWLUMA_MCP_MODE": "write"
+			},
+			"alwaysAllow": [
+				"list_categories",
+				"list_actions"
+			]
+		}
+	}
+}

--- a/.roo/rules/rules.md
+++ b/.roo/rules/rules.md
@@ -1,0 +1,330 @@
+# SnowLuma 维护手册
+
+本机环境速记，供日常更新容器、本地构建测试、向上游提交 PR 时直接参照。所有路径基于本机仓库根目录 `e:/SnowLuma`。
+
+## 环境约定（重要前提）
+
+| 项目 | 值 |
+| --- | --- |
+| 仓库根目录 | `e:/SnowLuma` |
+| Git remote `origin` | 个人 fork：`https://github.com/tt-P607/SnowLuma.git` |
+| Git remote `upstream` | 官方：`https://github.com/SnowLuma/SnowLuma.git` |
+| 开发分支 | `dev`（一切基于 dev，**不要碰 main**） |
+| 本地分支 `dev` 跟踪 | `origin/dev`（自己的 fork） |
+| 官方镜像 | `motricseven7/snowluma:latest` |
+| 本地构建镜像 tag | `snowluma:local` |
+| Dockerfile 所在目录 | `e:/SnowLuma.Docker.Framework`（仓库的**同级目录**，不在本仓库内） |
+| compose 文件 | [`docker/docker-compose.yml`](docker/docker-compose.yml) |
+| Node / pnpm | Node ≥ 22，pnpm 10.28.0+ |
+
+> **v1.14.1+ 容器布局（重要，勿用旧路径）**：运行产物在 `/app/runtime`（镜像 ENV `SNOWLUMA_HOME=/app/runtime`），数据/工作目录在 `/app/data`（supervisord `directory=/app/data`，进程 `node /app/runtime/index.mjs`）。旧版 `/app/snowluma` + `/app/snowluma-data` 已废弃。
+
+数据持久化目录（挂载在宿主机，重建容器不丢登录态/聊天记录）：
+`docker/data`（→ `/app/data`）、`docker/.config`（→ `/app/.config`）、`docker/.local`（→ `/app/.local/share`）、`docker/qq-acct2`（→ `/app/qq-acct2`）。这些目录通过 `.git/info/exclude` 在本地忽略，不进 git。
+
+---
+
+## 一、官方镜像更新（日常更新，最常用）
+
+官方发新版本（例如 tag `v1.9.5`）后，确认 [`docker/docker-compose.yml`](docker/docker-compose.yml) 中 `snowluma` 服务的 `image` 是 `motricseven7/snowluma:latest`，然后在仓库根目录执行：
+
+```powershell
+# 1. 拉取最新官方镜像
+docker compose -f docker/docker-compose.yml pull snowluma
+
+# 2. 重新创建并启动（仅 snowluma 服务）
+docker compose -f docker/docker-compose.yml up -d snowluma
+```
+
+> `up -d` 会在镜像有更新时自动重建容器；数据已挂载到宿主机，登录态不会丢失。
+
+验证：
+
+```powershell
+# 容器状态
+docker ps --filter name=snowluma
+
+# 确认容器内运行的版本号
+docker exec snowluma cat /app/snowluma/package.json
+
+# 跟踪运行日志
+docker compose -f docker/docker-compose.yml logs -f snowluma
+```
+
+WebUI 控制台：浏览器访问 `http://localhost:5099`。
+
+### 关于免扫码（请勿改动）
+
+[`docker/docker-compose.yml`](docker/docker-compose.yml) 里以下两项共同固定 NTQQ 容器的硬件设备指纹，避免每次重建容器都要重新扫码登录，**不要删除或修改**：
+
+- `hostname: DESKTOP-TYPE-13`（与宿主机电脑主机名一致）
+- `mac_address: 02:42:ac:11:00:5a`
+
+同时，持久化的机器码文件保存在宿主机的 `./data/config/machine-id`，容器启动时会自动读取并创建到 `/etc/machine-id` 的软链接。**不要手动覆写这个文件**：删除它后容器下次启动会用 `dbus-uuidgen` 自动生成新机器码（`start.sh` 仅在文件不存在时生成）。
+
+### 更换设备指纹（主动让 QQ 重新扫码）
+
+账号登录态反复失效/被判定"新设备"时，可整套更换设备指纹，让三个账号作为全新设备重新扫码登录。**会作废所有现有登录态**，三账号都要重新扫码。步骤：
+
+1. 改 [`docker/docker-compose.yml`](docker/docker-compose.yml) 的 `snowluma` 服务：`hostname` 和 `mac_address`（hostname 用宿主机电脑主机名，mac 换一个 `02:42:ac:11:00:xx` 末尾值）。
+2. **删除**宿主机 `./data/config/machine-id`（不要手写，让容器自动生成），容器启动会自动生成新机器码并软链到 `/etc/machine-id`。
+3. 重建容器：`cd e:/SnowLuma/docker && docker compose up -d snowluma`。
+4. 验证容器内三项指纹：`docker exec snowluma sh -c 'cat /etc/hostname; cat /etc/machine-id; cat /sys/class/net/eth0/address'`。
+5. noVNC（`http://localhost:6081`）扫码登录账号（主 3910448576、额外 `/app/qq-acct3` = 3910007334）。当前 `qq-acct2`（3905802962）已停用，见下文"当前账号启用状态"。
+
+> 三项指纹（hostname + mac + machine-id）必须**全部**更换才构成全新设备；只换一项可能仍被认回旧设备。
+
+### 多个 QQ 账号（第二个和第三个）
+
+采用 SnowLuma 官方原生多账号支持：在 [`docker/docker-compose.yml`](docker/docker-compose.yml) 的 `snowluma` 服务里通过环境变量 `SNOWLUMA_EXTRA_QQ_HOMES` 指定额外的 QQ 数据目录，并把对应的宿主机目录挂进去。容器内 SnowLuma 进程会在主账号登录后自动拉起这些额外账号。若某账号未登录，访问 noVNC 桌面扫码即可：VNC 端口 `5900`，noVNC 网页端口 `6081`。
+
+> **本机账号归属（重要，勿乱，以实际对应为准）**：主 `/app` = 3910448576，`/app/qq-acct2` = 3905802962，`/app/qq-acct3` = 3910007334。**每个 HOME 必须且只能承载一个账号**。目录名（acct2/acct3）与 QQ 数字号无直接对应，改 compose 时以这份实际归属为准，勿按目录名想当然。
+
+> **当前账号启用状态（2026-08-10）**：`qq-acct2`（3905802962）已停用 —— compose 中 `SNOWLUMA_EXTRA_QQ_HOMES` 只含 `/app/qq-acct3`，且 `./qq-acct2:/app/qq-acct2` 挂载已注释。其数据保留在宿主机 `./qq-acct2`。重新启用：取消卷挂载注释并把 `/app/qq-acct2` 加回 `SNOWLUMA_EXTRA_QQ_HOMES`，再 `docker compose up -d snowluma`。
+
+> **多账号登录态排查**：账号反复"新设备/被踢下线"通常是 **HOME 间账号数据错乱**（同一账号的 `nt_qq_<hash>` 大目录、`Partitions/qqnt_<uin>` 分区、`global/nt_data/Login/.<uin>` 凭证散落多个 HOME，导致多实例同账号互踢）。排查方法：
+> - 查各 HOME 的 `global/nt_data/Login/` —— 应只含该 HOME 账号的 `.uin` 文件
+> - 查各 HOME 的 `Partitions/qqnt_<uin>` 和 `nt_qq_*` 的 `nt_data/UnitedConfig/<uin>` —— 确认每个账号数据只在目标 HOME
+> - 修复：停容器 → 把不属于该 HOME 账号的 `nt_qq_*`/`qqnt_<uin>`/`qq-browser-<uin>`/`.uin` **移动（备份）到宿主机** → 重启 → 必要时对受影响的额外账号在 noVNC 重新扫码一次。被移动的多余副本可放 `e:/SnowLuma/.local/backup/` 留作回滚。
+
+---
+
+## 二、本地构建镜像（测试未合并的改动）
+
+当本地改了 `packages/` 下的源码、还没合并进官方镜像，需要在容器里实测时，用本地构建的 `snowluma:local` 镜像。
+
+> 原理：官方镜像 = 基础环境（QQ + noVNC + 系统依赖）+ `SnowLuma.Framework.tar.gz`（打包后的运行产物）。本地构建只替换运行产物这一层，基础环境复用官方镜像 `motricseven7/snowluma:latest`，对应同级目录 [`../SnowLuma.Docker.Framework/Dockerfile.local`](../SnowLuma.Docker.Framework/Dockerfile.local)。
+>
+> ⚠️ **不要直接用 [`../SnowLuma.Docker.Framework/Dockerfile`](../SnowLuma.Docker.Framework/Dockerfile) 全量构建**：它会从 `dldir1v6.qq.com` 下载 `linuxqq_*.deb`，而该地址已加防盗链，直接请求返回 404（`Resource not found`）。只有 `Dockerfile.local` 的 `FROM motricseven7/snowluma:latest` + `COPY tarball` 方式可用。
+
+### 步骤 0：安装依赖（重要前置）
+
+本地构建前**必须先 `pnpm install`**，否则前端构建会报 `@snowluma/common/log-sanitize` 无法解析（workspace 链接未刷新）：
+
+```powershell
+npx pnpm install
+```
+
+### 步骤 1：构建 Linux 运行产物（含 WebUI）
+
+容器是 Linux/x64，必须指定目标平台交叉打包，并开启 WebUI：
+
+```powershell
+cd e:/SnowLuma/packages/core
+npx pnpm exec cross-env SNOWLUMA_TARGET=linux-x64 BUILD_WEBUI=true vite build
+```
+
+产物输出到 `e:/SnowLuma/dist/`，包含 `index.mjs`、若干 chunk、`native/`（linux-x64 原生模块）。
+
+> 关键点：
+> - `SNOWLUMA_TARGET=linux-x64` —— 否则会打包 Windows 的 `.dll/.node`，容器里加载失败。
+> - `BUILD_WEBUI=true` —— 否则 `__BUILD_WEBUI__` 为 false，WebUI（5099）整段不会启动。
+
+### 步骤 2：构建 WebUI 前端 `client/`
+
+直接构建前端（不要从官方镜像拷 `client/`，旧版会显示旧版本号且配置结构不匹配导致「保存失败：historySync must be an object」）：
+
+```powershell
+npx pnpm --filter webui exec vite build
+```
+
+产物输出到 `e:/SnowLuma/dist/client/`。`__APP_VERSION__` 在构建时从根 `package.json` 注入（[`packages/webui/vite.config.ts`](packages/webui/vite.config.ts)），所以版本号自动跟随仓库版本。
+
+> ⚠️ 若误从旧官方镜像拷过 `client/`，`dist/client/` 里会残留旧 `index-*.js`，但 `index.html` 只引用新构建的文件，不影响运行。
+
+### 步骤 3：打包成 Framework tarball
+
+Dockerfile 通过 `COPY SnowLuma.Framework.tar.gz` 引入产物。把 `dist/` 整个打包覆盖到同级目录：
+
+```powershell
+cd e:/SnowLuma/dist
+tar -czf ../../SnowLuma.Docker.Framework/SnowLuma.Framework.tar.gz .
+```
+
+> 必须 `cd dist` 后用 `tar ... .` 打包**目录内容**，不要在仓库根目录打包整个 dist（会把路径前缀和 docker 数据目录带进去，导致 `tar: Cannot stat` 报错）。
+
+### 步骤 4：构建本地镜像
+
+在仓库根目录执行（构建上下文是同级的 Framework 目录，**必须用 `-f` 指定 `Dockerfile.local`**，否则默认 `Dockerfile` 全量构建会因 QQ 防盗链 404 失败）：
+
+```powershell
+docker build -t snowluma:local -f ../SnowLuma.Docker.Framework/Dockerfile.local ../SnowLuma.Docker.Framework/
+```
+
+> v1.14.1+：`Dockerfile.local` 用 `${SNOWLUMA_HOME}`（基础镜像 ENV = `/app/runtime`）解压产物，无需改 Dockerfile。
+
+### 步骤 5：切换 compose 到本地镜像并启动
+
+把 [`docker/docker-compose.yml`](docker/docker-compose.yml) 中 `snowluma` 服务的镜像改为本地镜像，并确认数据挂载是新布局：
+
+```yaml
+  snowluma:
+    image: snowluma:local      # 测试时用本地；回归官方时改回 motricseven7/snowluma:latest
+    volumes:
+      - ./data:/app/data       # v1.14.1+：不再是 /app/snowluma-data
+```
+
+然后重建：
+
+```powershell
+cd e:/SnowLuma/docker
+docker compose up -d snowluma
+```
+
+> ⚠️ 首次用新镜像启动会执行 `start.sh` 的 `chown -R`（遍历 `/app` 下的数据目录），**耗时约 1-2 分钟**，期间 PID 1 停在 `bash /root/start.sh` 属正常，等它进入 supervisord 即可。
+
+### 测试完成后回归官方镜像
+
+PR 被官方合并、新官方镜像发布后，把 `image` 改回 `motricseven7/snowluma:latest`，再走 [一、官方镜像更新](#一官方镜像更新日常更新最常用) 的 pull + up 流程即可。
+
+---
+
+## 三、向上游提交 PR
+
+遵循 [`CONTRIBUTING.md`](CONTRIBUTING.md)：所有 PR 基于 `dev`，**目标分支必须是 `dev`，不是 `main`**。
+
+### 步骤 1：先同步上游 dev
+
+```powershell
+cd e:/SnowLuma
+git fetch upstream
+git merge upstream/dev          # 或 git rebase upstream/dev
+```
+
+### 步骤 2：改代码 + 写测试
+
+- 一个 PR 只做一件事，保持改动聚焦。
+- 修 bug：先写一个能复现的测试（确认会 fail），再让它 pass。
+- 新功能：至少补 happy-path 测试。
+- 不写无意义注释，注释只解释"为什么"。
+
+### 步骤 3：本地验证（与 CI 同一套检查）
+
+```powershell
+# 全量
+pnpm typecheck
+pnpm test
+
+# 或只跑改动相关的单包测试（更快），例如 onebot：
+cd e:/SnowLuma/packages/onebot
+pnpm exec vitest run tests/message-parser.test.ts
+```
+
+### 步骤 4：提交（Conventional Commits）
+
+格式 `<type>(<scope>): <subject>`，常用 type：`feat`/`fix`/`docs`/`refactor`/`test`/`chore`/`perf`；常用 scope：`core`/`onebot`/`bridge`/`protocol`/`sdk`/`webui`。
+
+```powershell
+git add <改动的文件>
+git commit -m "fix(onebot): support inline file url/path in send_group/private_msg"
+```
+
+> ⚠️ 提交信息**禁止**以 `[merge]` 或 `chore(release):` 开头 —— 这两个前缀是维护者触发自动合并到 `main` 的开关，普通 PR 用了会行为异常。
+
+### 步骤 5：推送到 fork 并开 PR
+
+```powershell
+git push origin dev
+```
+
+用 GitHub CLI 开 PR（已登录 gh）：
+
+```powershell
+gh pr create --repo SnowLuma/SnowLuma --base dev --head tt-P607:dev `
+  --title "fix(onebot): support inline file url/path in send_group/private_msg" `
+  --body-file .local/pr-body.md
+```
+
+> PR 正文较长时写到 `.local/pr-body.md` 再用 `--body-file` 引入，避免 PowerShell 引号转义问题。`.local/` 已被忽略，不进 git。
+
+### 步骤 6：根据 review 修改
+
+维护者提了修改意见后，在**同一分支**继续改 + commit + `git push origin dev`，PR 会自动更新。若要清理本地多余提交，用 `git rebase --onto`，再 `git push origin dev --force-with-lease`。
+
+---
+
+## 四、本地忽略文件的正确做法
+
+**项目通用**的忽略规则才写进 [`.gitignore`](.gitignore)（需提 PR）。**仅本机**的忽略（如 docker 数据目录、个人笔记），写进本地私有的 `.git/info/exclude`，不要污染 `.gitignore`：
+
+```
+# .git/info/exclude
+docker/
+SnowLuma.Framework.tar.gz
+接口README.md
+snowluma_adapter_prompt.md
+```
+
+> 维护者明确要求：非项目通用的 gitignore 条目必须放 `.git/info/exclude`。
+
+---
+
+## 五、常见问题排查
+
+| 现象 | 原因 / 排查 |
+| --- | --- |
+| 重启后要重新扫码 | 检查 `hostname`/`mac_address`/`machine-id` 三项是否都在，缺一就会换设备指纹 |
+| 本地镜像 WebUI（5099）打不开 | 构建时漏了 `BUILD_WEBUI=true`，或漏了步骤 2 构建 `client/` |
+| 容器启动报 `Cannot find module .../config-xxx.js` | `dist` 打包不完整，确认步骤 3 在 `dist` 目录内 `tar ... .` 打包了全部 chunk |
+| 容器里加载 native 报错 | 构建时漏了 `SNOWLUMA_TARGET=linux-x64`，打成了 Windows 产物 |
+| TTS/插件发文件报路径找不到 | 文件路径需在容器内可见，确认 `docker-compose.yml` 里挂载了对应宿主机目录 |
+| `docker compose` 报「找不到指定路径」 | 在 `e:/SnowLuma/docker` 目录内直接跑 `docker compose ...`，或在根目录用 `-f docker/docker-compose.yml` |
+| WebUI 显示旧版本号 / 保存配置报 `historySync must be an object` | `client/` 是从旧官方镜像拷的。用步骤 2 重新构建前端 |
+| 重建后卡在 `bash /root/start.sh`（PID 1） | 首次用新镜像在 `chown -R /app` 遍历数据目录，**等 1-2 分钟**进入 supervisord 即可，别急着重启 |
+| 新版找不到数据 / 登录态丢失 | 确认 compose 挂载已用新布局 `./data:/app/data`（v1.14.1+），旧路径 `/app/snowluma-data` 已废弃 |
+| updater 容器反复重启 | `docker logs snowluma-updater`。`set -o pipefail` 需 bash（Dockerfile `CMD ["bash", ...]`） |
+| 自动更新 push 失败 128 | run.sh 已对 GH_TOKEN 做 trim；用户名用 `tt-P607`，勿用 `x-access-token` |
+| 容器内数据目录全报 `EIO: i/o error` / QQ 进程 FATAL | Docker Desktop 9p 挂载层瞬时故障（睡眠唤醒/盘被占用/句柄泄漏）。宿主机数据完好；**用 `docker start snowluma` 启动**即可恢复，勿用 `docker compose up` 重建 |
+| `docker compose up` 报 `mkdir /run/desktop/mnt/host/e: file exists` | Docker Desktop 29.x + containerd snapshotter（`UseContainerdSnapshotter: true`）在**重建容器**时的 bind mount 路径 bug。`docker run`/`docker start` 不触发；**容器停止用 `docker start snowluma` 启动**，避免重建 |
+
+---
+
+## 六、自动更新器（sidecar 容器）
+
+检测官方 `upstream/dev` 更新 → `git merge` 合并 → 构建 Linux 产物 + WebUI → `docker cp` 热替换到容器 → `supervisorctl restart snowluma` → `git push` 回 fork `origin/dev`。只重启 snowluma 进程，**QQ 不重启**，登录时长保持。
+
+> **登录时长语义**：`#sl` 时长 = QQ 进程登录会话时长。`qq` 与 `snowluma` 是 supervisord 两个独立 program（[`supervisord.conf`](../SnowLuma.Docker.Framework/supervisord.conf)）。只 `restart snowluma` 则 QQ 一直在线，时长持续累计；重建容器或 `restart qq` 则时长归零（免扫码秒回，但重置）。
+
+**文件**：[`docker/updater/Dockerfile`](docker/updater/Dockerfile)、[`docker/updater/run.sh`](docker/updater/run.sh)、[`docker/docker-compose.yml`](docker/docker-compose.yml) 的 `snowluma-updater` 服务。
+
+**关键约束**：
+- 容器内完整克隆 fork（`origin`=fork，`upstream`=官方），**勿用 `--depth 1` 浅克隆**（merge 需共同祖先）
+- merge 冲突 → 写 `.paused` 标记并停止（不构建/替换/push），人工处理后 `git push origin dev` 自动恢复
+- 间隔 `UPDATE_INTERVAL=600`（10 分钟）；源码/依赖存命名卷，重启不重克隆
+- push 凭据：`gho_` token 用「用户名+token」内联 URL，**用户名必须是 `tt-P607`**（非 `x-access-token`），且 **GH_TOKEN 需 trim**（CMD 注入带尾随空格）
+
+**操作**：
+
+```powershell
+docker logs snowluma-updater --tail 50        # 日志
+docker compose -f docker/docker-compose.yml restart snowluma-updater   # 手动触发一轮
+
+# GH_TOKEN 注入启动（务必 --no-deps，避免连带 recreate snowluma 导致 QQ 重启）
+for /f %i in ('gh auth token') do set GH_TOKEN=%i & docker compose -f docker/docker-compose.yml up -d --no-deps snowluma-updater
+```
+
+---
+
+## 命令速查
+
+```powershell
+# —— 官方更新 ——
+docker compose -f docker/docker-compose.yml pull snowluma
+docker compose -f docker/docker-compose.yml up -d snowluma
+
+# —— 本地构建测试 ——
+npx pnpm install                                      # 前置：刷新 workspace 链接，否则前端报 @snowluma/common 解析失败
+cd e:/SnowLuma/packages/core
+npx pnpm exec cross-env SNOWLUMA_TARGET=linux-x64 BUILD_WEBUI=true vite build
+npx pnpm --filter webui exec vite build               # 构建 WebUI 前端 client/（v1.14.1+ 不再从镜像拷）
+cd e:/SnowLuma/dist; tar -czf ../../SnowLuma.Docker.Framework/SnowLuma.Framework.tar.gz .
+cd e:/SnowLuma; docker build -t snowluma:local -f ../SnowLuma.Docker.Framework/Dockerfile.local ../SnowLuma.Docker.Framework/
+cd e:/SnowLuma/docker; docker compose up -d snowluma   # image 需先改为 snowluma:local；数据挂载 /app/data
+
+# —— PR ——
+git fetch upstream; git merge upstream/dev
+pnpm typecheck; pnpm test
+git add .; git commit -m "fix(scope): subject"
+git push origin dev
+gh pr create --repo SnowLuma/SnowLuma --base dev --head tt-P607:dev --title "..." --body-file .local/pr-body.md
+```

--- a/QQ空间逆向分析文档.md
+++ b/QQ空间逆向分析文档.md
@@ -1,0 +1,557 @@
+# QQ 空间（Qzone）原始请求逆向分析文档
+
+本文档客观记录 SnowLuma 中 QQ 空间（Qzone）相关功能的原始网络请求格式：URL、Query 参数、Form 表单字段、请求头、响应结构。所有信息均从源码 [`packages/protocol/src/web/qzone.ts`](packages/protocol/src/web/qzone.ts)（共 1461 行）提取，并标注源码注释中明确说明的"未真机核实 / 待实拍确认"事项。
+
+文中以 `<bkn>`、`<uin>`、`<tid>` 等尖括号表示占位符。
+
+---
+
+## 一、通用前置
+
+### 1.1 Cookie 来源
+
+所有 Qzone 请求都依赖 `qzone.qq.com` 域的 cookie 罐。获取链路见 [`packages/core/src/bridge/apis/web.ts`](packages/core/src/bridge/apis/web.ts:247)：
+
+1. 通过 NTQQ 协议取 `clientkey`。
+2. 拼接跳转 URL：`https://ssl.ptlogin2.qq.com/jump?ptlang=1033&clientuin=<uin>&clientkey=<clientkey>&u1=<encoded h5.qzone.qq.com url>&keyindex=<keyindex>`。
+3. 走 `HttpsGetCookies` 跟随重定向链收集 `Set-Cookie`，得到 `skey` 等。
+4. 再通过 `getPSkey(bridge, ['qzone.qq.com'])` 取 `p_skey` 存入 cookie 罐。
+
+最终 cookie 罐中与 Qzone 相关的关键键为：`skey`（或 `p_skey`）、`uin`、`p_uin` 等。
+
+### 1.2 g_tk / bkn 算法
+
+Qzone 的 CSRF 令牌 `g_tk`（也叫 `bkn`）由 `skey`（优先 `p_skey`）经 djb2 哈希截断 31 位得到，实现在 [`packages/protocol/src/web/request-util.ts`](packages/protocol/src/web/request-util.ts:671)：
+
+```
+hash = 5381
+for each char c of (p_skey || skey):
+    hash += (hash << 5) + charCodeAt(c)
+return hash & 0x7FFFFFFF        // 无符号 31 位，转为字符串
+```
+
+几乎所有 Qzone CGI 都在 Query 中携带 `g_tk=<bkn>`。
+
+### 1.3 统一网关
+
+除图片上传外，其余请求一律走 h5 网关转发：`https://h5.qzone.qq.com/proxy/domain/<真实域名>/<路径>`。原因是 `qzone.qq.com` 的 cookie 罐只在代理源站下才能通过 referer / 同源校验，直连真实域名（如 `ic2.qzone.qq.com`）会失败。
+
+### 1.4 请求工具与公共头
+
+所有请求经由 `RequestUtil.HttpGetText(url, method, body, headers)`（[`packages/protocol/src/web/request-util.ts`](packages/protocol/src/web/request-util.ts:644)）：
+
+- 内部实为 `HttpGetJson` 的文本模式，最大重定向 5 次。
+- Cookie 头格式：`Cookie: k=v; k=v; ...`（`cookieToString`，[`packages/protocol/src/web/request-util.ts`](packages/protocol/src/web/request-util.ts:664)）。
+- POST 请求统一 `Content-Type: application/x-www-form-urlencoded`，body 为表单编码字符串。
+
+### 1.5 响应解析
+
+响应可能是裸 JSON，也可能是 JSONP 回调包裹（`_preloadCallback({...});` / `callback({...})` / `frameElement.callback({...});`）。`parseQzoneJson`（[`packages/protocol/src/web/qzone.ts`](packages/protocol/src/web/qzone.ts:76)）按"首个 `{` 到末个 `}` 直接 JSON.parse → `back({...})` 整体 → `back(...)` 内取 `{}`"三层回退解析。
+
+好友动态接口（`feeds3_html_more`）例外：其返回是 JS 对象字面量（未加引号 key、单引号字符串、`\xNN` 转义、字面 `undefined`），`JSON.parse` 会失败，必须用专用解析器 `parseQzoneCallback` 当作数据递归下降（不执行代码，防 RCE），见 [`packages/protocol/src/web/qzone.ts`](packages/protocol/src/web/qzone.ts:231)。
+
+---
+
+## 二、说说列表（读）
+
+### 2.1 主路由（默认）
+
+- 方法：`GET`
+- 完整 URL：
+
+```
+https://h5.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_msglist_v6?uin=<targetUin>&ftype=0&sort=0&pos=<pos>&num=<num>&replynum=100&g_tk=<bkn>&callback=_preloadCallback&code_version=1&format=jsonp&need_private_comment=1
+```
+
+Query 参数（源码 [`legacyMsgListRoute`](packages/protocol/src/web/qzone.ts:317)）：
+
+| 参数 | 值 | 说明 |
+| --- | --- | --- |
+| `uin` | targetUin | 目标空间主人 QQ 号 |
+| `ftype` | `0` | 说说类型过滤 |
+| `sort` | `0` | 排序方式 |
+| `pos` | 数字 | 分页偏移 |
+| `num` | 数字 | 每页数量（默认 20） |
+| `replynum` | `100` | 附带回复数 |
+| `g_tk` | bkn | CSRF 令牌 |
+| `callback` | `_preloadCallback` | JSONP 回调名 |
+| `code_version` | `1` | 协议版本 |
+| `format` | `jsonp` | 响应格式 |
+| `need_private_comment` | `1` | 需要私密评论 |
+
+- 请求头：`Cookie: <cookie 罐>`
+
+### 2.2 降级路由（-10000 风控时重试一次）
+
+当主路由返回 `code = -10000`（「使用人数过多」），自动重试一次走该路由（源码 [`userMsgListRoute`](packages/protocol/src/web/qzone.ts:347)）：
+
+```
+https://user.qzone.qq.com/proxy/domain/taotao.qq.com/cgi-bin/emotion_cgi_msglist_v6?uin=<targetUin>&ftype=0&sort=0&pos=<pos>&num=<num>&g_tk=<bkn>&code_version=1&format=json
+```
+
+注意：代理域名是 `taotao.qq.com`（不是 `taotao.qzone.qq.com`），`format=json`（非 jsonp），无 `callback`。请求头额外带 `Referer: https://user.qzone.qq.com/<targetUin>`。实拍显示该路由不受 `-10000` 限流。
+
+### 2.3 响应结构（原始）
+
+```
+{
+  "code": 0,
+  "subcode": 0,
+  "message": "",
+  "total": <说说总数>,
+  "msglist": [
+    {
+      "tid": "<说说id>",
+      "content": "<正文>",
+      "created_time": <unix秒>,
+      "cmtnum": <评论数>,
+      "secret": <0或1>,
+      "pic": [
+        { "url1": "...", "url2": "...", "url3": "...", "smallurl": "..." }
+      ]
+    }
+  ]
+}
+```
+
+### 2.4 归一化映射（`mapMsgList`，[`qzone.ts`](packages/protocol/src/web/qzone.ts:296)）
+
+| OneBot 字段 | 原始字段 | 处理 |
+| --- | --- | --- |
+| `tid` | `tid` | 转字符串 |
+| `content` | `content` | 原文 |
+| `time` | `created_time` | 转数字 |
+| `comment_num` | `cmtnum` | 转数字 |
+| `is_private` | `secret` | `!= 0` 即为私密 |
+| `images` | `pic[]` | 每张取 `url3 ?? url2 ?? url1 ?? smallurl`（最大变体），空值过滤 |
+
+错误语义：非零 `code` 直接抛错（cookie 失效 / 无权限）；`msglist` 非数组也抛错（区分"空空间 `msglist: []`"与"cookie 失效"）。
+
+---
+
+## 三、好友动态（读）
+
+### 3.1 请求
+
+- 方法：`GET`
+- 完整 URL：
+
+```
+https://h5.qzone.qq.com/proxy/domain/ic2.qzone.qq.com/cgi-bin/feeds/feeds3_html_more?uin=<selfUin>&scope=0&view=1&filter=all&flag=1&applist=all&pagenum=<pageNum>&count=<count>&aisortEndTime=0&aisortOffset=0&aisortBeginTime=0&begintime=0&g_tk=<bkn>&callback=_preloadCallback&format=jsonp&useutf8=1&outputhtmlfeed=1
+```
+
+Query 参数（源码 [`getQzoneFeeds`](packages/protocol/src/web/qzone.ts:541)）：
+
+| 参数 | 值 | 说明 |
+| --- | --- | --- |
+| `uin` | selfUin | 机器人自己的 QQ 号（动态以自身身份拉取） |
+| `scope` | `0` | 范围 |
+| `view` | `1` | 视图 |
+| `filter` | `all` | 过滤条件 |
+| `flag` | `1` | 标志 |
+| `applist` | `all` | 应用列表 |
+| `pagenum` | 数字（默认 1） | 页码（1 起） |
+| `count` | 数字（默认 10） | 每页条数 |
+| `aisortEndTime` | `0` | AI 排序结束时间 |
+| `aisortOffset` | `0` | AI 排序偏移 |
+| `aisortBeginTime` | `0` | AI 排序开始时间 |
+| `begintime` | `0` | 时间游标 |
+| `g_tk` | bkn | CSRF 令牌 |
+| `callback` | `_preloadCallback` | JSONP 回调名 |
+| `format` | `jsonp` | 响应格式 |
+| `useutf8` | `1` | UTF-8 |
+| `outputhtmlfeed` | `1` | 输出预渲染 HTML |
+
+- 请求头：`Cookie: <cookie 罐>`
+
+分页注意（源码注释）：该 CGI 可靠的深分页由时间游标（`begintime`/`externparam`/`usertime` 逐页带出）驱动，当前实现未透传，因此 `pageNum` 仅第一页可靠，`has_more` 只表示"后面还有"，不代表能稳定取第 2 页。游标分页待实拍确认后补充。
+
+### 3.2 响应结构（原始，JS 字面量）
+
+```
+{
+  code: 0,
+  subcode: 0,
+  message: "",
+  data: {
+    data: [
+      {
+        uin: <作者QQ>,
+        nickname: "<昵称>",
+        abstime: <unix秒>,
+        appid: <应用id>,
+        key: "<feed句柄>",
+        feedskey: "<旧别名>",
+        html: "<预渲染HTML>"
+      },
+      undefined,   // 数组尾部存在 undefined 空洞
+      ...
+    ],
+    hasmore: <0或1>
+  }
+}
+```
+
+### 3.3 归一化映射（`mapFeeds`，[`qzone.ts`](packages/protocol/src/web/qzone.ts:491)）
+
+| OneBot 字段 | 原始字段 | 处理 |
+| --- | --- | --- |
+| `uin` | `uin` | 转数字 |
+| `nickname` | `nickname` | 原文 |
+| `time` | `abstime` | 转数字 |
+| `appid` | `appid` | 转数字（311=说说，4=相册，…） |
+| `key` | `key ?? feedskey` | feed 句柄 |
+| `html` | `html` | 预渲染 HTML 原样透传 |
+| `has_more` | `data.hasmore` | `!= 0` |
+
+---
+
+## 四、发表说说（写）
+
+### 4.1 请求
+
+- 方法：`POST`
+- 完整 URL：
+
+```
+https://h5.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_publish_v6?g_tk=<bkn>
+```
+
+- Form body（源码 [`publishQzoneMsg`](packages/protocol/src/web/qzone.ts:679)）：
+
+| 字段 | 值 | 说明 |
+| --- | --- | --- |
+| `syn_tweet_verson` | `1` | （注意拼写即如此） |
+| `paramstr` | `1` | |
+| `pic_template` | `''` | 图片模板 |
+| `richtype` | `1` 或 `''` | 带图时为 `1` |
+| `richval` | 字符串 | 带图时传 `uploadQzoneImage` 返回的 richval（多图以 `\t` 拼接） |
+| `special_url` | `''` | |
+| `subrichtype` | `''` | |
+| `con` | `<content>` | 说说正文 |
+| `feedversion` | `1` | |
+| `ver` | `1` | |
+| `ugc_right` | `1/4/16/64/128` | 查看权限 |
+| `to_sign` | `0` | |
+| `who` | `1` | |
+| `hostuin` | `<hostUin>` | 发表者（机器人自己） |
+| `code_version` | `1` | |
+| `format` | `json` | |
+| `qzreferrer` | `https://user.qzone.qq.com/<hostUin>` | 来源页 |
+| `allow_uins` | 可选 | 仅 `ugc_right=16`（可见名单）或 `128`（不可见名单）时必填，`|` 分隔的 QQ 号去重后拼接 |
+
+- 请求头：`Cookie: <cookie 罐>`、`Content-Type: application/x-www-form-urlencoded`
+
+权限值语义：`1`=所有人可见，`4`=好友可见，`16`=部分好友可见（需 `allow_uins`），`64`=仅自己可见，`128`=部分好友不可见（需 `allow_uins`）。
+
+### 4.2 响应结构（原始）
+
+```
+{
+  "code": 0,
+  "subcode": 0,
+  "message": "",
+  "t1_tid": "<新说说id>",   // 成功时的主字段
+  "t1_time": "<unix秒字符串>", // 时间（字符串）
+  "tid": "<备用>",           // 防御性回退字段
+  "now": <unix秒>            // 备用
+}
+```
+
+源码说明：publish_v6 成功包把新 feed id 命名为 `t1_tid`、时间命名为 `t1_time`（后者为字符串）；`tid`/`now` 仅作防御性回退。归一化后返回 `{ tid: t1_tid ?? tid, time: Number(t1_time ?? now ?? 0) }`。非零 `code` 或缺少 tid 均抛错。
+
+---
+
+## 五、删除说说（写）
+
+### 5.1 请求
+
+- 方法：`POST`
+- 完整 URL：
+
+```
+https://h5.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_delete_v6?g_tk=<bkn>
+```
+
+- Form body（源码 [`deleteQzoneMsg`](packages/protocol/src/web/qzone.ts:758)）：
+
+| 字段 | 值 | 说明 |
+| --- | --- | --- |
+| `hostuin` | `<hostUin>` | 说说主人（必须是自己，服务端拒绝他人 tid） |
+| `tid` | `<tid>` | 要删除的说说 id |
+| `t1_source` | `1` | |
+| `code_version` | `1` | |
+| `format` | `fs` | **注意：删除用 `format=fs` 而非 `json`**（社区可用脚本确认） |
+| `qzreferrer` | `https://user.qzone.qq.com/<hostUin>` | |
+
+- 请求头：`Cookie: <cookie 罐>`、`Content-Type: application/x-www-form-urlencoded`
+
+### 5.2 响应
+
+成功无正向负载，`code=0` 且 `subcode=0`（或缺省）即成功；非零 `code`/`subcode` 抛错。源码注释标注：删除的成功字段（`code`/`subcode`）是从同级 CGI 外推的，公开实现仅检查 HTTP 2xx，待实拍确认失败包结构。
+
+---
+
+## 六、点赞 / 取消赞（写）
+
+### 6.1 请求
+
+- 方法：`POST`
+- 点赞 URL：
+
+```
+https://h5.qzone.qq.com/proxy/domain/w.qzone.qq.com/cgi-bin/likes/internal_dolike_app?g_tk=<bkn>
+```
+
+- 取消赞 URL（源码标注未真机核实，属惯例配对 CGI 的推断）：
+
+```
+https://h5.qzone.qq.com/proxy/domain/w.qzone.qq.com/cgi-bin/likes/internal_unlike_app?g_tk=<bkn>
+```
+
+- Form body（源码 [`setQzoneLike`](packages/protocol/src/web/qzone.ts:841)）：
+
+| 字段 | 值 | 说明 |
+| --- | --- | --- |
+| `qzreferrer` | `https://user.qzone.qq.com/<opUin>` | 点赞者（机器人自己）空间 |
+| `opuin` | `<opUin>` | 点赞者 QQ |
+| `unikey` | `http://user.qzone.qq.com/<targetUin>/mood/<tid>` | **http 而非 https**，指向被赞说说的 mood feed |
+| `curkey` | 同上 | |
+| `appid` | `311` | 说说应用 id |
+| `typeid` | `0` | |
+| `abstime` | `<unix秒>` | 目标说说的发表时间（来自列表/动态）；未知传 `0` |
+| `fid` | `<tid>` | 说说 id |
+| `from` | `1` | |
+| `active` | `0` | |
+| `fupdate` | `1` | |
+| `format` | `json` | |
+
+- 请求头：`Cookie: <cookie 罐>`、`Content-Type: application/x-www-form-urlencoded`
+
+### 6.2 响应
+
+`code=0` 且 `subcode=0` 视为成功。源码注释标注：dolike 的实际成功信号可能是一对 `succ/fail` 令牌而非 `code`，此处按同级 CGI 外推，待实拍确认。
+
+---
+
+## 七、上传图片（写，特殊路由）
+
+### 7.1 请求
+
+- 方法：`POST`
+- 完整 URL（**不经 h5 网关**，直连 `up.qzone.qq.com`）：
+
+```
+https://up.qzone.qq.com/cgi-bin/upload/cgi_upload_image?g_tk=<bkn>
+```
+
+- Form body（源码 [`uploadQzoneImage`](packages/protocol/src/web/qzone.ts:971)）：
+
+| 字段 | 值 | 说明 |
+| --- | --- | --- |
+| `filename` | `filename` | 固定占位 |
+| `uin` | `<hostUin>` | 上传者 QQ |
+| `skey` | `<skey>` | 直接带 skey 明文 |
+| `zzpaneluin` | `<hostUin>` | |
+| `p_uin` | `<hostUin>` | |
+| `p_skey` | `<p_skey>` | 直接带 p_skey 明文 |
+| `uploadtype` | `1` | |
+| `albumtype` | `7` | |
+| `exttype` | `0` | |
+| `refer` | `shuoshuo` | 来源：说说 |
+| `output_type` | `jsonhtml` | |
+| `charset` | `utf-8` | |
+| `output_charset` | `utf-8` | |
+| `upload_hd` | `1` | 高清上传 |
+| `hd_width` | `2048` | |
+| `hd_height` | `10000` | |
+| `hd_quality` | `96` | |
+| `backUrls` | `http://upbak.photo.qzone.qq.com/cgi-bin/upload/cgi_upload_image,http://119.147.64.75/cgi-bin/upload/cgi_upload_image&url=https://up.qzone.qq.com/cgi-bin/upload/cgi_upload_image?g_tk=<bkn>` | 备用回退地址 |
+| `base64` | `1` | 以 base64 传输 |
+| `jsonhtml_callback` | `callback` | |
+| `picfile` | `<base64图片>` | 图片 base64 负载 |
+| `qzreferrer` | `https://user.qzone.qq.com/<hostUin>/main` | |
+
+- 请求头：`Cookie: <cookie 罐>`、`Content-Type: application/x-www-form-urlencoded`
+
+### 7.2 响应结构（原始）
+
+响应形如 `<script>frameElement.callback({...});</script>`，解析时先截到 `callback` 起再取 `{}`：
+
+```
+{
+  "code": 0,
+  "subcode": 0,
+  "message": "",
+  "data": {
+    "albumid": "<相册id>",
+    "lloc": "<定位串>",
+    "url": "<图片直链>",
+    "type": <类型>,
+    "height": <高>,
+    "width": <宽>
+  }
+}
+```
+
+### 7.3 输出
+
+返回 `{ richval, url, albumid, lloc, type, width, height }`。其中 `richval` 按 `,<albumid>,<lloc>,<lloc>,<type>,<height>,<width>,,<height>,<width>` 构造（`sloc` 与 `lloc` 相同），供 publish 的 `richval` 使用；`url` 供 comment 的直链使用（两者用法不同，见下文）。
+
+图片源支持 `file://`、`http(s)://`、`base64://`（含 data-URI 前缀），非 base64 源先经 `loadBinarySource` 加载转 base64 再上传（[`uploadQzoneImageFromSource`](packages/protocol/src/web/qzone.ts:926)）。
+
+---
+
+## 八、评论说说（写）
+
+### 8.1 请求
+
+- 方法：`POST`
+- 完整 URL：
+
+```
+https://h5.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_re_feeds?g_tk=<bkn>
+```
+
+- Form body（源码 [`commentQzoneMsg`](packages/protocol/src/web/qzone.ts:1178)）：
+
+| 字段 | 值 | 说明 |
+| --- | --- | --- |
+| `qzreferrer` | `https://user.qzone.qq.com/<selfUin>` | 评论者（机器人）自己的空间 |
+| `inCharset` | `utf-8` | |
+| `outCharset` | `utf-8` | |
+| `hostUin` | `<hostUin>` | 被评说说的主人 |
+| `format` | `json` | |
+| `ref` | `feeds` | |
+| `topicId` | `<hostUin>_<tid>__1` | 定位被评 feed；`__1` 后缀 2/3 社区实现确认，第三个省略（未核实点） |
+| `feedsType` | `100` | |
+| `private` | `0` | |
+| `paramstr` | `1` | |
+| `richtype` | `1` 或 `''` | 带图评论时为 `1` |
+| `richval` | 字符串 | **带图评论传图片直链 url（多图 `\t` 拼接），不是 publish 的 richval** |
+| `isSignIn` | `''` | |
+| `uin` | `<selfUin>` | 评论者 QQ |
+| `content` | `<content>` | 评论内容 |
+| `plat` | `qzone` | |
+| `source` | `ic` | |
+| `platformid` | `52` | |
+
+- 请求头：`Cookie: <cookie 罐>`、`Content-Type: application/x-www-form-urlencoded`
+
+### 8.2 响应
+
+`code=0` 且 `subcode=0` 即成功；返回的新评论 id 字段名不定（`commentid` / `commentId`），缺失时不视为失败，最佳努力返回 `{ comment_id }`。
+
+---
+
+## 九、拉黑 / 解除拉黑（写）
+
+### 9.1 请求
+
+- 方法：`POST`
+- 完整 URL：
+
+```
+https://h5.qzone.qq.com/proxy/domain/w.qzone.qq.com/cgi-bin/right/cgi_black_action_new?g_tk=<bkn>
+```
+
+- Form body（源码 [`setQzoneBlack`](packages/protocol/src/web/qzone.ts:1120)）：
+
+| 字段 | 值 | 说明 |
+| --- | --- | --- |
+| `uin` | `<selfUin>` | 机器人自己 |
+| `act_uin` | `<targetUin>` | 被操作对象 QQ |
+| `action` | `1` / `2` | `1`=拉黑，`2`=解除拉黑 |
+| `fupdate` | `1` | |
+| `qzreferrer` | `https://user.qzone.qq.com/<selfUin>/main` | |
+
+- 请求头：`Cookie: <cookie 罐>`、`Content-Type: application/x-www-form-urlencoded`
+
+### 9.2 响应
+
+回调包裹的 body，可能含未加引号 key 的小片段 `{name:"Ack"}`，解析前先把 `{name:` 替换为 `{"name":`。成功信号：`subcode=0` 且 `code=0`。
+
+---
+
+## 十、修改说说查看权限（写，两步）
+
+该 CGI 不是部分更新，而是整条说说重新提交（内容、richval、pic_bo 全量重发），因此分两步。
+
+### 10.1 第一步：取说说详情
+
+- 方法：`GET`
+- 完整 URL（**注意代理域名是 `taotao.qq.com`，不是 `taotao.qzone.qq.com`**）：
+
+```
+https://h5.qzone.qq.com/proxy/domain/taotao.qq.com/cgi-bin/emotion_cgi_msgdetail_v6?tid=<tid>&uin=<selfUin>&t1_source=1&not_trunc_con=1&need_right=1&not_adapt_outpic=1&g_tk=<bkn>
+```
+
+Query 参数（源码 [`getQzoneMsgDetail`](packages/protocol/src/web/qzone.ts:1379)）：`tid`、`uin`（机器人自己）、`t1_source=1`、`not_trunc_con=1`（不截断内容）、`need_right=1`、`not_adapt_outpic=1`、`g_tk`。
+
+- 请求头：`Cookie: <cookie 罐>`
+
+响应含重建所需全量字段：`tid`、`uin`、`content`、`conlist[]`、`pic[]`（含 `pic_id`、`pictype`、`height`/`b_height`、`width`/`b_width`、`smallurl`/`url1/2/3`）、`richtype`、`richval`、`pic_template`、`special_url`、`t1_subtype`/`subrichtype`、`feedversion`、`ver`、`ugc_right`、`to_sign`、`ugcright_id`、`code_version`。成功信号 `subcode ?? code` 为 `0`。
+
+### 10.2 第二步：提交整条更新
+
+- 方法：`POST`
+- 完整 URL：
+
+```
+https://h5.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_update?g_tk=<bkn>
+```
+
+- Form body 由详情重建（`buildQzoneUpdatePayload`，[`qzone.ts`](packages/protocol/src/web/qzone.ts:1294)），再覆盖 `ugc_right`、按需追加 `allow_uins`：
+
+| 字段 | 值/来源 |
+| --- | --- |
+| `syn_tweet_verson` | `1` |
+| `tid` | 详情 `tid` |
+| `paramstr` | `1` |
+| `pic_template` | 详情 `pic_template` |
+| `richtype` | 详情 `richtype`（图片贴无则取 1） |
+| `richval` | 逐图从 `pic_id`（`,` 分隔，取第 2 段 albumid、第 3 段 lloc）重建为 `,albumid,lloc,lloc,type,height,width,,0,0`，多图 `\t` 拼接；无图时用详情 `richval` |
+| `special_url` | 详情 `special_url` |
+| `subrichtype` | `t1_subtype ?? subrichtype`，图片贴无则 `1` |
+| `pic_bo` | 从各图 url 的 `bo=` query 参数提取（`decodeURIComponent`），拼接后 `<list>\t<list>` 双份 |
+| `con` | 详情 `content`，若 `conlist` 存在则取其 `con` 拼接 |
+| `feedversion` | 详情 `feedversion`（默认 1） |
+| `ver` | 详情 `ver`（默认 1） |
+| `ugc_right` | **覆盖为目标值**（`1/4/16/64/128`） |
+| `to_sign` | 详情 `to_sign`（默认 0） |
+| `ugcright_id` | 详情 `ugcright_id`（默认 `tid`） |
+| `hostuin` | 详情 `uin`（默认 selfUin） |
+| `code_version` | 详情 `code_version`（默认 1） |
+| `format` | `fs` |
+| `qzreferrer` | `https://user.qzone.qq.com/<hostuin>` |
+| `allow_uins` | 可选，`16/128` 时必填 |
+
+- 请求头：`Cookie: <cookie 罐>`、`Content-Type: application/x-www-form-urlencoded`
+
+### 10.3 响应
+
+`format=fs` 会把 JSON 包在回调里（`frameElement.callback({...});` 或 `_Callback({...});`），统一用 `parseQzoneJson` 首尾花括号切片处理。成功信号：`subcode=0` 且 `code=0`，返回 `{ ugc_right }`。
+
+---
+
+## 十一、未核实点汇总（源码注释明确标注）
+
+以下为源码注释中明确写"待实拍确认 / 未真机核实 / 外推"的项，非实测结论：
+
+| 项 | 说明 |
+| --- | --- |
+| `internal_unlike_app` 取消赞端点 | 惯例配对 CGI，无公开机器人实现验证，best-guess |
+| delete 的成功/失败包结构 | `code`/`subcode` 字段由同级 CGI 外推，公开实现仅查 HTTP 2xx |
+| comment 的 `topicId` 尾部 `__1` 后缀 | 2/3 社区实现确认，第三个省略 |
+| comment 返回的新评论 id 字段名 | `commentid` / `commentId` 不定 |
+| dolike 的成功信号 | 可能是 `succ/fail` 令牌而非 `code` |
+| 动态（feeds）深分页游标 | `begintime`/`externparam`/`usertime` 透传未实现，待实拍 |
+
+## 十二、风控与重试
+
+- 说说列表：主路由（`taotao.qzone.qq.com`）遇 `code=-10000`「使用人数过多」自动经 `user.qzone.qq.com` → `taotao.qq.com` 路由重试一次（实拍该路由不受限）。
+- 所有写操作（发/删/赞/评/改权）源码提示需调用方自行限流，Qzone 对高频主动行为风控，与发消息同级。
+
+## 十三、参考社区实现
+
+源码注释中对照过的公开实现：SmartHypercube/Qzone-API、cw1997/QzoneUtil、php-qzone/qzone.class.php、silica-github/qq_zone_delete、QLiker.py。

--- a/SnowLuma.code-workspace
+++ b/SnowLuma.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "../SnowLuma.Docker.Framework"
+		}
+	],
+	"settings": {}
+}

--- a/SnowLuma更新维护指南.md
+++ b/SnowLuma更新维护指南.md
@@ -1,0 +1,257 @@
+# SnowLuma 维护手册
+
+本机环境速记，供日常更新容器、本地构建测试、向上游提交 PR 时直接参照。所有路径基于本机仓库根目录 `e:/SnowLuma`。
+
+## 环境约定（重要前提）
+
+| 项目 | 值 |
+| --- | --- |
+| 仓库根目录 | `e:/SnowLuma` |
+| Git remote `origin` | 个人 fork：`https://github.com/tt-P607/SnowLuma.git` |
+| Git remote `upstream` | 官方：`https://github.com/SnowLuma/SnowLuma.git` |
+| 开发分支 | `dev`（一切基于 dev，**不要碰 main**） |
+| 本地分支 `dev` 跟踪 | `origin/dev`（自己的 fork） |
+| 官方镜像 | `motricseven7/snowluma:latest` |
+| 本地构建镜像 tag | `snowluma:local` |
+| Dockerfile 所在目录 | `e:/SnowLuma.Docker.Framework`（仓库的**同级目录**，不在本仓库内） |
+| compose 文件 | [`docker/docker-compose.yml`](docker/docker-compose.yml) |
+| Node / pnpm | Node ≥ 22，pnpm 10.28.0+ |
+
+数据持久化目录（挂载在宿主机，重建容器不丢登录态/聊天记录）：
+`docker/data`、`docker/.config`、`docker/.local`、`docker/qq-acct2`。这些目录通过 `.git/info/exclude` 在本地忽略，不进 git。
+
+---
+
+## 一、官方镜像更新（日常更新，最常用）
+
+官方发新版本（例如 tag `v1.9.5`）后，确认 [`docker/docker-compose.yml`](docker/docker-compose.yml) 中 `snowluma` 服务的 `image` 是 `motricseven7/snowluma:latest`，然后在仓库根目录执行：
+
+```powershell
+# 1. 拉取最新官方镜像
+docker compose -f docker/docker-compose.yml pull snowluma
+
+# 2. 重新创建并启动（仅 snowluma 服务）
+docker compose -f docker/docker-compose.yml up -d snowluma
+```
+
+> `up -d` 会在镜像有更新时自动重建容器；数据已挂载到宿主机，登录态不会丢失。
+
+验证：
+
+```powershell
+# 容器状态
+docker ps --filter name=snowluma
+
+# 确认容器内运行的版本号
+docker exec snowluma cat /app/snowluma/package.json
+
+# 跟踪运行日志
+docker compose -f docker/docker-compose.yml logs -f snowluma
+```
+
+WebUI 控制台：浏览器访问 `http://localhost:5099`。
+
+### 关于免扫码（请勿改动）
+
+[`docker/docker-compose.yml`](docker/docker-compose.yml) 里以下两项共同固定 NTQQ 容器的硬件设备指纹，避免每次重建容器都要重新扫码登录，**不要删除或修改**：
+
+- `hostname: snowluma-stable`
+- `mac_address: 02:42:ac:11:00:99`
+
+同时，持久化的机器码文件保存在宿主机的 `./data/config/machine-id`，容器启动时会自动读取并创建到 `/etc/machine-id` 的软链接。
+
+### 多个 QQ 账号（第二个和第三个）
+
+采用 SnowLuma 官方原生多账号支持：在 [`docker/docker-compose.yml`](docker/docker-compose.yml) 的 `snowluma` 服务里通过环境变量 `SNOWLUMA_EXTRA_QQ_HOMES=/app/qq-acct2,/app/qq-acct3` 指定额外的 QQ 数据目录，并把对应的宿主机目录挂进去（`./qq-acct2:/app/qq-acct2`、`./qq-acct3:/app/qq-acct3`）。容器内 SnowLuma 进程会在主账号登录后自动拉起这些额外账号。若某账号未登录，访问 noVNC 桌面扫码即可：VNC 端口 `5900`，noVNC 网页端口 `6081`。
+
+---
+
+## 二、本地构建镜像（测试未合并的改动）
+
+当本地改了 `packages/` 下的源码、还没合并进官方镜像，需要在容器里实测时，用本地构建的 `snowluma:local` 镜像。
+
+> 原理：官方镜像 = 基础环境（QQ + noVNC + 系统依赖）+ `SnowLuma.Framework.tar.gz`（打包后的运行产物）。本地构建只替换运行产物这一层，基础环境复用官方镜像 `motricseven7/snowluma:latest`，对应同级目录 [`../SnowLuma.Docker.Framework/Dockerfile.local`](../SnowLuma.Docker.Framework/Dockerfile.local)。
+>
+> ⚠️ **不要直接用 [`../SnowLuma.Docker.Framework/Dockerfile`](../SnowLuma.Docker.Framework/Dockerfile) 全量构建**：它会从 `dldir1v6.qq.com` 下载 `linuxqq_*.deb`，而该地址已加防盗链，直接请求返回 404（`Resource not found`）。只有 `Dockerfile.local` 的 `FROM motricseven7/snowluma:latest` + `COPY tarball` 方式可用。
+
+### 步骤 1：构建 Linux 运行产物（含 WebUI）
+
+容器是 Linux/x64，必须指定目标平台交叉打包，并开启 WebUI：
+
+```powershell
+cd e:/SnowLuma/packages/core
+pnpm exec cross-env SNOWLUMA_TARGET=linux-x64 BUILD_WEBUI=true vite build
+```
+
+产物输出到 `e:/SnowLuma/dist/`，包含 `index.mjs`、若干 chunk、`native/`（linux-x64 原生模块）。
+
+> 关键点：
+> - `SNOWLUMA_TARGET=linux-x64` —— 否则会打包 Windows 的 `.dll/.node`，容器里加载失败。
+> - `BUILD_WEBUI=true` —— 否则 `__BUILD_WEBUI__` 为 false，WebUI（5099）整段不会启动。
+
+### 步骤 2：补齐 WebUI 静态资源 `client/`
+
+`vite build` 不产出 WebUI 前端静态文件，从官方镜像里原样拷一份 `client/` 到 `dist/`：
+
+```powershell
+docker run --rm -v e:/SnowLuma/dist:/out motricseven7/snowluma:latest cp -a /app/snowluma/client /out/client
+```
+
+> 注意用 `cp -a`（保留属性），不要用 `cp -r`（旧版 busybox 不识别 `-c`/部分参数会报错）。
+
+### 步骤 3：打包成 Framework tarball
+
+Dockerfile 通过 `COPY SnowLuma.Framework.tar.gz` 引入产物。把 `dist/` 整个打包覆盖到同级目录：
+
+```powershell
+cd e:/SnowLuma/dist
+tar -czf ../../SnowLuma.Docker.Framework/SnowLuma.Framework.tar.gz .
+```
+
+> 必须 `cd dist` 后用 `tar ... .` 打包**目录内容**，不要在仓库根目录打包整个 dist（会把路径前缀和 docker 数据目录带进去，导致 `tar: Cannot stat` 报错）。
+
+### 步骤 4：构建本地镜像
+
+在仓库根目录执行（构建上下文是同级的 Framework 目录，**必须用 `-f` 指定 `Dockerfile.local`**，否则默认 `Dockerfile` 全量构建会因 QQ 防盗链 404 失败）：
+
+```powershell
+docker build -t snowluma:local -f ../SnowLuma.Docker.Framework/Dockerfile.local ../SnowLuma.Docker.Framework/
+```
+
+### 步骤 5：切换 compose 到本地镜像并启动
+
+把 [`docker/docker-compose.yml`](docker/docker-compose.yml) 中 `snowluma` 服务的镜像改为本地镜像：
+
+```yaml
+  snowluma:
+    image: snowluma:local      # 测试时用本地；回归官方时改回 motricseven7/snowluma:latest
+```
+
+然后重建：
+
+```powershell
+cd e:/SnowLuma/docker
+docker compose up -d snowluma
+```
+
+### 测试完成后回归官方镜像
+
+PR 被官方合并、新官方镜像发布后，把 `image` 改回 `motricseven7/snowluma:latest`，再走 [一、官方镜像更新](#一官方镜像更新日常更新最常用) 的 pull + up 流程即可。
+
+---
+
+## 三、向上游提交 PR
+
+遵循 [`CONTRIBUTING.md`](CONTRIBUTING.md)：所有 PR 基于 `dev`，**目标分支必须是 `dev`，不是 `main`**。
+
+### 步骤 1：先同步上游 dev
+
+```powershell
+cd e:/SnowLuma
+git fetch upstream
+git merge upstream/dev          # 或 git rebase upstream/dev
+```
+
+### 步骤 2：改代码 + 写测试
+
+- 一个 PR 只做一件事，保持改动聚焦。
+- 修 bug：先写一个能复现的测试（确认会 fail），再让它 pass。
+- 新功能：至少补 happy-path 测试。
+- 不写无意义注释，注释只解释"为什么"。
+
+### 步骤 3：本地验证（与 CI 同一套检查）
+
+```powershell
+# 全量
+pnpm typecheck
+pnpm test
+
+# 或只跑改动相关的单包测试（更快），例如 onebot：
+cd e:/SnowLuma/packages/onebot
+pnpm exec vitest run tests/message-parser.test.ts
+```
+
+### 步骤 4：提交（Conventional Commits）
+
+格式 `<type>(<scope>): <subject>`，常用 type：`feat`/`fix`/`docs`/`refactor`/`test`/`chore`/`perf`；常用 scope：`core`/`onebot`/`bridge`/`protocol`/`sdk`/`webui`。
+
+```powershell
+git add <改动的文件>
+git commit -m "fix(onebot): support inline file url/path in send_group/private_msg"
+```
+
+> ⚠️ 提交信息**禁止**以 `[merge]` 或 `chore(release):` 开头 —— 这两个前缀是维护者触发自动合并到 `main` 的开关，普通 PR 用了会行为异常。
+
+### 步骤 5：推送到 fork 并开 PR
+
+```powershell
+git push origin dev
+```
+
+用 GitHub CLI 开 PR（已登录 gh）：
+
+```powershell
+gh pr create --repo SnowLuma/SnowLuma --base dev --head tt-P607:dev `
+  --title "fix(onebot): support inline file url/path in send_group/private_msg" `
+  --body-file .local/pr-body.md
+```
+
+> PR 正文较长时写到 `.local/pr-body.md` 再用 `--body-file` 引入，避免 PowerShell 引号转义问题。`.local/` 已被忽略，不进 git。
+
+### 步骤 6：根据 review 修改
+
+维护者提了修改意见后，在**同一分支**继续改 + commit + `git push origin dev`，PR 会自动更新。若要清理本地多余提交，用 `git rebase --onto`，再 `git push origin dev --force-with-lease`。
+
+---
+
+## 四、本地忽略文件的正确做法
+
+**项目通用**的忽略规则才写进 [`.gitignore`](.gitignore)（需提 PR）。**仅本机**的忽略（如 docker 数据目录、个人笔记），写进本地私有的 `.git/info/exclude`，不要污染 `.gitignore`：
+
+```
+# .git/info/exclude
+docker/
+SnowLuma.Framework.tar.gz
+接口README.md
+snowluma_adapter_prompt.md
+```
+
+> 维护者明确要求：非项目通用的 gitignore 条目必须放 `.git/info/exclude`。
+
+---
+
+## 五、常见问题排查
+
+| 现象 | 原因 / 排查 |
+| --- | --- |
+| 重启后要重新扫码 | 检查 `hostname`/`mac_address`/`machine-id` 三项是否都在，缺一就会换设备指纹 |
+| 本地镜像 WebUI（5099）打不开 | 构建时漏了 `BUILD_WEBUI=true`，或漏了步骤 2 拷 `client/` |
+| 容器启动报 `Cannot find module .../config-xxx.js` | `dist` 打包不完整，确认步骤 3 在 `dist` 目录内 `tar ... .` 打包了全部 chunk |
+| 容器里加载 native 报错 | 构建时漏了 `SNOWLUMA_TARGET=linux-x64`，打成了 Windows 产物 |
+| TTS/插件发文件报路径找不到 | 文件路径需在容器内可见，确认 `docker-compose.yml` 里挂载了对应宿主机目录 |
+| `docker compose` 报「找不到指定路径」 | 在 `e:/SnowLuma/docker` 目录内直接跑 `docker compose ...`，或在根目录用 `-f docker/docker-compose.yml` |
+
+---
+
+## 命令速查
+
+```powershell
+# —— 官方更新 ——
+docker compose -f docker/docker-compose.yml pull snowluma
+docker compose -f docker/docker-compose.yml up -d snowluma
+
+# —— 本地构建测试 ——
+cd e:/SnowLuma/packages/core
+pnpm exec cross-env SNOWLUMA_TARGET=linux-x64 BUILD_WEBUI=true vite build
+docker run --rm -v e:/SnowLuma/dist:/out motricseven7/snowluma:latest cp -a /app/snowluma/client /out/client
+cd e:/SnowLuma/dist; tar -czf ../../SnowLuma.Docker.Framework/SnowLuma.Framework.tar.gz .
+cd e:/SnowLuma; docker build -t snowluma:local ../SnowLuma.Docker.Framework/
+cd e:/SnowLuma/docker; docker compose up -d snowluma   # image 需先改为 snowluma:local
+
+# —— PR ——
+git fetch upstream; git merge upstream/dev
+pnpm typecheck; pnpm test
+git add .; git commit -m "fix(scope): subject"
+git push origin dev
+gh pr create --repo SnowLuma/SnowLuma --base dev --head tt-P607:dev --title "..." --body-file .local/pr-body.md
+```

--- a/packages/core/src/bridge/apis/contacts.ts
+++ b/packages/core/src/bridge/apis/contacts.ts
@@ -355,9 +355,9 @@ export class ContactsApi {
       const invitorUin = raw.invitor?.uin ?? 0;
       const operatorUin = raw.operatorUser?.uin ?? 0;
       const notifyType = raw.eventType ?? 0;
-      const operationType = groupRequestOperationType(notifyType);
+      const operationType = groupRequestOperationType(notifyType) ?? notifyType;
       const sequence = normalizeGroupRequestSequence(raw.sequence, groupId);
-      if (operationType === null) {
+      if (operationType <= 0) {
         log.warn(
           'unsupported group-request notification type: group=%d sequence=%s type=%d',
           groupId,
@@ -386,7 +386,7 @@ export class ContactsApi {
         sequence,
         state: raw.state ?? 0,
         notifyType,
-        eventType: operationType ?? 0,
+        eventType: operationType,
         comment: raw.comment ?? '',
         filtered,
       });
@@ -411,9 +411,9 @@ export class ContactsApi {
       const invitorUid = raw.invitor?.uid ?? '';
       const operatorUid = raw.operatorUser?.uid ?? '';
       const notifyType = raw.eventType ?? 0;
-      const operationType = groupRequestOperationType(notifyType);
+      const operationType = groupRequestOperationType(notifyType) ?? notifyType;
       const sequence = normalizeGroupRequestSequence(raw.sequence, groupId);
-      if (operationType === null) {
+      if (operationType <= 0) {
         log.warn(
           'unsupported group-request notification type: group=%d sequence=%s type=%d',
           groupId,
@@ -442,7 +442,7 @@ export class ContactsApi {
         sequence,
         state: raw.state ?? 0,
         notifyType,
-        eventType: operationType ?? 0,
+        eventType: operationType,
         comment: raw.comment ?? '',
         filtered,
       });

--- a/packages/core/tests/actions/contacts.test.ts
+++ b/packages/core/tests/actions/contacts.test.ts
@@ -327,6 +327,47 @@ describe('apis/contacts / group requests', () => {
     expect(rememberGroupRequests).toHaveBeenCalledWith(requests);
   });
 
+  it('preserves native eventType 1 for join applications and 2 for invitations', async () => {
+    const rememberGroupRequests = vi.fn();
+    const findUidByUin = vi.fn((uin: number) => uin === 101 ? 'uid_101' : null);
+    const sendRawPacket = vi.fn(async () => groupRequestPacketByUin({
+      requests: [
+        {
+          sequence: 1001n,
+          eventType: 1, // User Add Request
+          state: 1,
+          group: { groupUin: 999, groupName: 'group' },
+          target: { uin: 101, name: 'joiner' },
+        },
+        {
+          sequence: 1002n,
+          eventType: 2, // User Invite
+          state: 1,
+          group: { groupUin: 999, groupName: 'group' },
+          invitor: { uin: 102, name: 'inviter' },
+        },
+      ],
+    }));
+    const api = new ContactsApi({
+      sendRawPacket,
+      identity: { findUidByUin, rememberGroupRequests },
+    } as any);
+
+    const requests = await api.fetchGroupRequests(false);
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0]).toMatchObject({
+      sequence: 1001,
+      eventType: 1,
+      targetUin: 101,
+    });
+    expect(requests[1]).toMatchObject({
+      sequence: 1002,
+      eventType: 2,
+      invitorUin: 102,
+    });
+  });
+
   it('retains the UID-form response for correlating real-time request pushes', async () => {
     const rememberGroupRequests = vi.fn();
     const findUinByUid = vi.fn((uid: string) => uid === 'target_uid' ? 1_234_567_890 : null);

--- a/packages/onebot/config/onebot_10001.json
+++ b/packages/onebot/config/onebot_10001.json
@@ -1,0 +1,43 @@
+{
+  "mode": "snapshot",
+  "networks": {
+    "httpServers": [
+      {
+        "name": "http-default",
+        "accessToken": "ILN6Fu6OLHoU6yYag12JxwC1JywIwJmrEM2oL8us23E",
+        "messageFormat": "array",
+        "reportSelfMessage": false,
+        "host": "127.0.0.1",
+        "port": 3000,
+        "path": "/",
+        "enableWebSocket": false
+      }
+    ],
+    "httpClients": [],
+    "wsServers": [
+      {
+        "name": "ws-default",
+        "accessToken": "yzTP8WdT4H5JzZXEg80av2FJzMUTWRLYgtMj0zRLMR8",
+        "messageFormat": "array",
+        "reportSelfMessage": false,
+        "host": "127.0.0.1",
+        "port": 3001,
+        "path": "/",
+        "role": "Universal"
+      }
+    ],
+    "wsClients": []
+  },
+  "statusCommand": {
+    "enabled": true,
+    "swallow": false,
+    "cooldownSeconds": 5,
+    "trigger": "#sl"
+  },
+  "historySync": {
+    "enabled": false
+  },
+  "notifications": {
+    "channelIds": []
+  }
+}

--- a/packages/onebot/src/event-converter/element-codecs.ts
+++ b/packages/onebot/src/event-converter/element-codecs.ts
@@ -547,6 +547,16 @@ export const ELEMENT_CODECS = {
       };
     },
   },
+  red_packet: {
+    // S 收·转：下游适配器不识别 red_packet 段类型，降级为 text 段输出。
+    // 文本形如 [拼手气红包:标题]，无类型时退化为 [红包:标题]，无标题为 [QQ红包]。
+    async toSegment(element) {
+      const prefix = element.redPacketType ? `${element.redPacketType}红包` : '红包';
+      const title = element.title ?? '';
+      const text = title ? `[${prefix}:${title}]` : (element.redPacketType ? `[${prefix}]` : '[QQ红包]');
+      return { type: 'text', data: { text } };
+    },
+  },
 } satisfies ElementCodecMap;
 
 /**

--- a/packages/onebot/src/group-request-poller.ts
+++ b/packages/onebot/src/group-request-poller.ts
@@ -93,7 +93,7 @@ export class GroupRequestPoller {
     if (this.lifecycleStarted && !this.running) return;
     const discovered = [...main, ...filtered]
       .filter((request) => request.state === 1)
-      .filter((request) => request.notifyType === 1 || request.notifyType === 7);
+      .filter((request) => request.eventType === 1 || request.eventType === 2 || request.eventType === 22 || request.notifyType === 1 || request.notifyType === 7);
 
     const now = this.now();
     this.sweepRecentFingerprints(now);
@@ -107,7 +107,7 @@ export class GroupRequestPoller {
           'group request record rejected: group=%s sequence=%s subtype=%s reason=%s',
           String(request.groupId),
           String(request.sequence),
-          request.notifyType === 1 ? 'invite' : 'add',
+          request.eventType === 2 || request.eventType === 22 || request.notifyType === 2 ? 'invite' : 'add',
           error instanceof Error ? error.message : String(error),
         );
         continue;
@@ -145,11 +145,11 @@ export class GroupRequestPoller {
   }
 
   private toEvent(request: GroupRequestInfo): GroupInviteEvent {
-    const notifyType = request.notifyType;
-    const subType = notifyType === 1 ? 'invite' : 'add';
-    const fromUin = notifyType === 1 ? request.invitorUin : request.targetUin;
-    const fromUid = notifyType === 1 ? request.invitorUid : request.targetUid;
-    const inviteCardSequence = notifyType === 1
+    const isInvite = request.eventType === 2 || request.eventType === 22 || request.notifyType === 2;
+    const subType = isInvite ? 'invite' : 'add';
+    const fromUin = isInvite ? request.invitorUin : request.targetUin;
+    const fromUid = isInvite ? request.invitorUid : request.targetUid;
+    const inviteCardSequence = isInvite
       ? this.bridge.apis.contacts.getGroupInviteCardSequence?.(request.groupId)
       : undefined;
     if (!Number.isSafeInteger(request.sequence) || request.sequence <= 0) {
@@ -160,7 +160,7 @@ export class GroupRequestPoller {
     }
     if (!Number.isSafeInteger(request.eventType) || request.eventType <= 0) {
       throw new Error(
-        `group request has no operation type: group=${request.groupId} sequence=${request.sequence} notifyType=${notifyType ?? 0}`,
+        `group request has no operation type: group=${request.groupId} sequence=${request.sequence} eventType=${request.eventType ?? 0}`,
       );
     }
     if (!Number.isSafeInteger(fromUin) || fromUin < 0) {

--- a/packages/onebot/src/modules/contact-actions.ts
+++ b/packages/onebot/src/modules/contact-actions.ts
@@ -373,7 +373,7 @@ function groupRequestActor(request: GroupRequestInfo): {
   uin: number;
   name: string;
 } {
-  if (request.notifyType === 1) {
+  if (request.eventType === 2 || request.eventType === 22 || request.notifyType === 2) {
     return {
       uid: request.invitorUid,
       uin: request.invitorUin,
@@ -401,9 +401,6 @@ export async function getGroupSystemMessages(
   ]);
   const unique = new Map<string, GroupRequestInfo>();
   for (const request of [...main, ...filtered]) {
-    if (request.notifyType !== undefined
-      && request.notifyType !== 1
-      && request.notifyType !== 7) continue;
     if (request.eventType <= 0) continue;
     const flag = formatGroupRequestFlag(request);
     if (!unique.has(flag)) unique.set(flag, request);

--- a/packages/onebot/tests/contact-actions.test.ts
+++ b/packages/onebot/tests/contact-actions.test.ts
@@ -123,8 +123,8 @@ function makeGroupRequest(overrides: Partial<GroupRequestInfo> = {}): GroupReque
     operatorName: 'operator',
     sequence: 123456,
     state: 1,
-    notifyType: 7,
-    eventType: 22,
+    notifyType: 1,
+    eventType: 1,
     comment: 'please',
     filtered: false,
     ...overrides,
@@ -631,7 +631,7 @@ describe('onebot/contact-actions / getGroupSystemMessages', () => {
     const bridge = fakeBridge({
       fetchGroupRequests: vi.fn(async (filtered: boolean) => filtered ? [] : [
         makeGroupRequest({
-          notifyType: 1,
+          notifyType: 2,
           eventType: 2,
           targetUin: 10_001,
           targetName: 'bot',

--- a/packages/onebot/tests/instance-context.test.ts
+++ b/packages/onebot/tests/instance-context.test.ts
@@ -93,8 +93,8 @@ function makeRequest(overrides: Partial<GroupRequestInfo> = {}): GroupRequestInf
     operatorName: 'operator',
     sequence: 888,
     state: 1,
-    notifyType: 7,
-    eventType: 22,
+    notifyType: 1,
+    eventType: 1,
     comment: 'please add',
     filtered: false,
     ...overrides,
@@ -881,7 +881,7 @@ describe('buildApiContext contact reads', () => {
       requester_nick: 'applicant',
       message: 'please add',
       checked: false,
-      flag: 'slreq:1:888:710010:22:0',
+      flag: 'slreq:1:888:710010:1:0',
     }]);
   });
 });

--- a/packages/onebot/tests/message-store-migration-worker.test.ts
+++ b/packages/onebot/tests/message-store-migration-worker.test.ts
@@ -27,7 +27,7 @@ function createControlPort(): {
   messages: MessageStoreMigrationWorkerMessage[];
   send(message: unknown): void;
   listenerCount(): number;
-} {
+  } {
   const messages: MessageStoreMigrationWorkerMessage[] = [];
   const events = new EventEmitter();
   return {

--- a/packages/proto-defs/src/element.ts
+++ b/packages/proto-defs/src/element.ts
@@ -298,7 +298,65 @@ export interface GeneralFlags {
   longTextResId?:   pb<7, string>;
 }
 
-//  Elem (union of all element types) 
+//  Red packet (红包) element — Elem field 24.
+//  Unlike normal richMsg (field 12) whose template1 is zlib-compressed
+//  JSON/XML, the red packet's payload is a nested protobuf message carrying
+//  the title, greeting, transferId, auth key, etc.
+
+export interface RedPacketInfo {
+  typeCode?:   pb<1, int_32>;    // 14235648 — red packet type code
+  field2?:     pb<2, int_32>;    // 4
+  title?:      pb<3, string>;    // "test" — red packet title
+  greeting?:   pb<4, string>;    // "赶紧点击拆开吧" — blessing text
+  typeName?:   pb<5, string>;    // "QQ红包"
+  field6?:     pb<6, bytes>;
+  field7?:     pb<7, bytes>;
+  displayText?: pb<8, string>;   // "[QQ红包]test"
+  color1?:     pb<9, int_32>;    // 16777215
+  color2?:     pb<10, int_32>;   // 16777215
+  subType?:    pb<11, string>;   // "3"
+  field12?:    pb<12, bytes>;
+  field13?:    pb<13, bytes>;
+  pagePath?:   pb<14, string>;   // "red?id=..."
+  field21?:    pb<21, bytes>;
+}
+
+export interface RedPacketSign {
+  field1?:  pb<1, int_32>;
+  field2?:  pb<2, bytes>;        // 32B signature
+  signHash?: pb<3, string>;      // "ea62c0718ec761cfcbc9a4d88e8ee1bc"
+}
+
+export interface RedPacketSkin {
+  field3?:  pb<3, int_32>;
+  skinInfo?: pb<5, string>;      // {"skin_type":"0"}
+  field7?:  pb<7, int_32>;
+  field8?:  pb<8, int_32>;
+}
+
+export interface RedPacketTemplate {
+  flag?:     pb<1, int_32>;
+  info?:     pb<3, RedPacketInfo>;
+  field4?:   pb<4, int_32>;
+  field5?:   pb<5, int_32>;
+  field6?:   pb<6, int_32>;
+  packetType?: pb<7, int_32>;    // 3 = 拼手气
+  field8?:   pb<8, int_32>;
+  transferId?: pb<9, string>;    // "10000319012607241400110867883700"
+  authKey?:  pb<10, string>;     // "d78bdd1942e2429cb4af0c4e3f4bc49da4"
+  field11?:  pb<11, int_32>;
+  field12?:  pb<12, int_32>;
+  sign?:     pb<17, RedPacketSign>;
+  digest?:   pb<18, string>;     // "a34955db5e4eda74521cce7655b2abe1"
+  field19?:  pb<19, int_32>;
+  skin?:     pb<21, RedPacketSkin>;
+}
+
+export interface RedPacketMsg {
+  template1?: pb<1, RedPacketTemplate>;
+}
+
+//  Elem (union of all element types)
 
 export interface Elem {
   text?:           pb<1, TextElem>;
@@ -312,6 +370,7 @@ export interface Elem {
   groupFile?:      pb<13, GroupFileElem>;
   extraInfo?:      pb<16, ExtraInfo>;
   videoFile?:      pb<19, VideoFile>;
+  redPacket?:      pb<24, RedPacketMsg>;
   generalFlags?:   pb<37, GeneralFlags>;
   srcMsg?:         pb<45, SrcMsg>;
   lightApp?:       pb<51, LightAppElem>;

--- a/packages/protocol/src/element-manifest.ts
+++ b/packages/protocol/src/element-manifest.ts
@@ -217,6 +217,12 @@ export const ELEMENT_MANIFEST = {
     requiredFields: ['filesetId'],
     note: '闪传文件：收侧解码 markdown commonElem（旧卡 JSON data.fileSetId，现网 extType=1/extInfo + open_fileset scheme，#199/#200/#358）；发送走 send_flash_msg，故 P/W 按设计不支持',
   },
+  red_packet: {
+    directions: { D: 'yes', S: 'yes', P: 'no', W: 'no' },
+    fields: fieldsFor<'red_packet'>()(['title', 'greeting', 'displayText', 'packetType', 'redPacketType', 'transferId', 'authKey', 'typeName']),
+    requiredFields: [],
+    note: '红包（Elem field 24）：仅收侧解码上报，不支持发送',
+  },
 } as const satisfies ManifestShape;
 
 export type ElementType = keyof typeof ELEMENT_MANIFEST;

--- a/packages/protocol/src/element-manifest.ts
+++ b/packages/protocol/src/element-manifest.ts
@@ -251,12 +251,13 @@ const STRING_FIELDS: ReadonlySet<string> = new Set([
   'thumbUrl', 'summary', 'emojiId', 'emojiKey', 'resId', 'filesetId',
   'forwardSource', 'forwardSummary', 'forwardPrompt', 'forwardUuid',
   'md5Hex', 'sha1Hex', 'botAppid',
+  'title', 'greeting', 'displayText', 'typeName', 'redPacketType', 'transferId', 'authKey',
 ]);
 const NUMBER_FIELDS: ReadonlySet<string> = new Set([
   'faceId', 'targetUin', 'fileSize', 'replySeq', 'replyMessageId',
   'replySenderUin', 'replyTime', 'replyRandom', 'subType', 'duration',
   'width', 'height', 'emojiPackageId', 'sceneType', 'forwardTSum',
-  'picFormat', 'videoFormat', 'voiceFormat',
+  'picFormat', 'videoFormat', 'voiceFormat', 'packetType',
 ]);
 const BOOLEAN_FIELDS: ReadonlySet<string> = new Set(['flash', 'noByteFallback']);
 

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -195,6 +195,19 @@ export interface FlashFileElement {
   thumbUrl?: string;
 }
 
+/** Red packet (红包) element — decoded from Elem field 24. */
+export interface RedPacketElement {
+  type: 'red_packet';
+  title?: string;        // 红包标题
+  greeting?: string;     // 祝福语
+  displayText?: string;  // 完整显示文本 "[QQ红包]test"
+  packetType?: number;   // protobuf 字段值（实测各类型均为 3，非类型标识）
+  redPacketType?: string; // 红包类型名："拼手气"/"普通"/"专属"/"口令"（由 field12 推导）
+  transferId?: string;   // 红包ID
+  authKey?: string;      // auth key
+  typeName?: string;     // "QQ红包"
+  }
+
 type MessageElementVariant =
   | TextElement
   | AtElement
@@ -211,7 +224,8 @@ type MessageElementVariant =
   | MarketFaceElement
   | FileElement
   | PokeElement
-  | FlashFileElement;
+  | FlashFileElement
+  | RedPacketElement;
 
 type UnionKeys<T> = T extends T ? keyof T : never;
 type StrictUnionMember<T, All> = T extends T

--- a/packages/protocol/src/format.ts
+++ b/packages/protocol/src/format.ts
@@ -130,6 +130,12 @@ function renderSegment(type: string, data: Record<string, unknown>): string {
       const title = data.title ? String(data.title) : '';
       return title ? `[闪传文件:${truncate(title, 20)}]` : '[闪传文件]';
     }
+    case 'red_packet': {
+      const type = data.redPacketType ? String(data.redPacketType) : '';
+      const title = data.title ? String(data.title) : '';
+      const prefix = type ? `${type}红包` : '红包';
+      return title ? `[${prefix}:${truncate(title, 20)}]` : `[${prefix}]`;
+    }
     default: return `[${type}]`;
   }
 }

--- a/packages/protocol/src/msg-push/rich-body-decoder.ts
+++ b/packages/protocol/src/msg-push/rich-body-decoder.ts
@@ -37,7 +37,7 @@ const unknownElementLog = createLogger('MsgPush.UnknownElement');
 const DECODED_WIRE_FIELDS: ReadonlySet<string> = new Set([
   'text', 'face', 'notOnlineImage', 'transElem', 'marketFace', 'customFace',
   'richMsg', 'groupFile', 'videoFile', 'srcMsg', 'lightApp', 'commonElem',
-  'extraInfo', 'generalFlags',
+  'extraInfo', 'generalFlags', 'redPacket',
 ]);
 const METADATA_WIRE_FIELDS: ReadonlySet<string> = new Set(['extraInfo', 'generalFlags']);
 
@@ -508,6 +508,9 @@ function convertElements(elems: ElemDecoded[]): MessageElement[] {
   // `[face name]请使用最新版手机QQ体验新功能`. Suppress only that proven wire
   // shape (#289); a sibling user-authored text has no such reserve and survives.
   let previousBigFace: QFaceExtra | null = null;
+  // Red packet (Elem field 24) suppresses the sibling degradation text
+  // "[QQ红包]请使用新版手机QQ查收红包。" — same structural rule as cards.
+  const hasRedPacket = elems.some((e) => Boolean(e.redPacket));
   // [#127] A QQ NT reply carries the replied sender as a structural auto-mention
   // (MentionExtra.type=2, uin=0) right after srcMsg, followed by a blank
   // separator text. Both are part of the reply wire shape, not user content —
@@ -632,7 +635,10 @@ function convertElements(elems: ElemDecoded[]): MessageElement[] {
         } else {
           const text = t.str ?? '';
           // Drop the successfully decoded card/markdown compatibility sibling.
-          if (text && hasRichContent) continue;
+          // Red packets follow the same pattern: the degradation text
+          // "[QQ红包]请使用新版手机QQ查收红包。" is suppressed in favour of the
+          // decoded red_packet element.
+          if (text && (hasRichContent || hasRedPacket)) continue;
           if (text) result.push({ type: 'text', text });
         }
       }
@@ -781,6 +787,34 @@ function convertElements(elems: ElemDecoded[]): MessageElement[] {
 
     // LightApp
     if (cards?.light?.element) result.push(cards.light.element);
+
+    // RedPacket (Elem field 24) — QQ红包
+    // template1.field12 经实测是稳定的红包类型标识（每类型2个样本验证）：
+    //   6=拼手气、4=普通、16=专属、12=口令。语音红包桌面端不支持。
+    if (elem.redPacket) {
+      const tpl = elem.redPacket.template1;
+      const info = tpl?.info;
+      if (info) {
+        const redPacketType: string | undefined =
+          tpl?.field12 === 6 ? '拼手气' :
+          tpl?.field12 === 4 ? '普通' :
+          tpl?.field12 === 16 ? '专属' :
+          tpl?.field12 === 12 ? '口令' :
+          undefined;
+        const me: MessageElementOf<'red_packet'> = {
+          type: 'red_packet',
+          ...(info.title != null && { title: info.title }),
+          ...(info.greeting != null && { greeting: info.greeting }),
+          ...(info.displayText != null && { displayText: info.displayText }),
+          ...(info.typeName != null && { typeName: info.typeName }),
+          ...(tpl?.packetType != null && { packetType: tpl.packetType }),
+          ...(redPacketType != null && { redPacketType }),
+          ...(tpl?.transferId != null && { transferId: tpl.transferId }),
+          ...(tpl?.authKey != null && { authKey: tpl.authKey }),
+        };
+        result.push(me);
+      }
+    }
 
     // CommonElem
     if (elem.commonElem) {

--- a/packages/protocol/src/oidb-services/contacts/fetch-group-requests.ts
+++ b/packages/protocol/src/oidb-services/contacts/fetch-group-requests.ts
@@ -15,18 +15,14 @@ import type {
 import type { OidbGroupRequestList } from '@snowluma/proto-defs/oidb-actions/base';
 import { invokeOidb, type OidbSender } from '../../oidb-service';
 
-// Current QQ's EncodeOperateSysNotify maps the high-level list notification
-// type to the discriminator sent by 0x10C8. This table was read directly from
-// the current Linux client; keeping the distinction prevents list type 7
-// (join request) from being incorrectly sent back as operation type 7.
-const GROUP_REQUEST_OPERATION_TYPE = new Map<number, number>([
-  [0, 0], [1, 2], [2, 10], [3, 11], [4, 12], [5, 22],
-  [6, 35], [7, 1], [8, 3], [9, 6], [10, 7], [11, 13],
-  [12, 15], [13, 16], [14, 17], [15, 19], [16, 8], [17, 100],
-]);
-
+// In OIDB 0x10C0, field 2 directly reflects the operation discriminator used by
+// 0x10C8: 1 = user add request, 2 = user invitation, 22 = admin invitation.
+// High-level NT UI notification types (e.g. 7 for join application) map directly
+// to 1.
 export function groupRequestOperationType(notifyType: number): number | null {
-  return GROUP_REQUEST_OPERATION_TYPE.get(notifyType) ?? null;
+  if (notifyType <= 0) return null;
+  if (notifyType === 7) return 1;
+  return notifyType;
 }
 
 export namespace FetchGroupRequests {

--- a/packages/protocol/tests/element-manifest.test.ts
+++ b/packages/protocol/tests/element-manifest.test.ts
@@ -64,7 +64,8 @@ describe('element-manifest 对账（protocol 侧：D 收·解 / W 发·打包）
       if (field === 'targetUin' || field === 'faceId' || field === 'fileSize'
         || field.startsWith('reply') || field === 'subType' || field === 'duration'
         || field === 'width' || field === 'height' || field === 'emojiPackageId'
-        || field === 'sceneType' || field === 'forwardTSum' || field.endsWith('Format')) return 1;
+        || field === 'sceneType' || field === 'forwardTSum' || field.endsWith('Format')
+        || field === 'packetType') return 1;
       return 'value';
     };
 

--- a/packages/protocol/tests/msg-push/temp-message-source.test.ts
+++ b/packages/protocol/tests/msg-push/temp-message-source.test.ts
@@ -3,7 +3,6 @@ import {
   protobuf_encode,
   type pb,
   type pb_repeated,
-  type string,
   type uint_32,
 } from '@snowluma/proton';
 import { describe, expect, it } from 'vitest';

--- a/packages/protocol/tests/oidb-services/contacts/fetch-group-requests.test.ts
+++ b/packages/protocol/tests/oidb-services/contacts/fetch-group-requests.test.ts
@@ -44,10 +44,11 @@ function makeSender() {
 
 describe('FetchGroupRequests namespace', () => {
   it('maps native list notification types to 0x10C8 operation types', () => {
-    expect(groupRequestOperationType(1)).toBe(2);
+    expect(groupRequestOperationType(1)).toBe(1);
+    expect(groupRequestOperationType(2)).toBe(2);
     expect(groupRequestOperationType(7)).toBe(1);
-    expect(groupRequestOperationType(17)).toBe(100);
-    expect(groupRequestOperationType(99)).toBeNull();
+    expect(groupRequestOperationType(0)).toBeNull();
+    expect(groupRequestOperationType(-1)).toBeNull();
   });
 
   it('declares 0x10C0', () => {

--- a/红包消息逆向分析文档.md
+++ b/红包消息逆向分析文档.md
@@ -1,0 +1,415 @@
+# SnowLuma 红包消息逆向分析文档
+
+## 1. 问题概述
+
+群红包消息在 SnowLuma 中统一显示为降级文本 `[QQ红包]请使用新版手机QQ查收红包。`，无法获取红包标题、祝福语等实际内容。
+
+## 2. 已确认的事实
+
+### 2.1 红包消息的 protobuf 元素结构
+
+从 DEBUG 日志推断，红包消息的 `richText.elems[]` 包含以下元素：
+
+| 元素 | protobuf field | 内容 |
+|------|---------------|------|
+| `text` | field 1 | 降级文本：`[QQ红包]请使用新版手机QQ查收红包。` |
+| `generalFlags` | field 37 | 携带 **tag 19** 的未知字段（约 93-120 字节），这是红包实际数据 |
+
+语音口令红包的降级文本不同：`[QQ红包]你收到一个语音口令红包，请在新版手机QQ查看。`
+
+### 2.2 日志证据
+
+每条红包消息都伴随以下 DEBUG 日志：
+
+```
+[MsgPush.UnknownElement] wire element ignored unknownTag=19 wireType=2 count=1 bytes=XX reason=no schema decoder path=elem.generalFlags
+[MsgPush.UnknownElement] wire element ignored unknownTag=1 wireType=2 count=1 bytes=XX reason=no schema decoder path=body.richText
+```
+
+- `unknownTag=19 path=elem.generalFlags`：红包数据在 `generalFlags` 的 tag 19 中，93-120 字节，被忽略
+- `unknownTag=1 path=body.richText`：`richText` 也有一个 tag 1 未知字段（33-42 字节）
+
+### 2.3 当前 proto 定义（缺少 tag 19）
+
+`GeneralFlags` 接口当前只定义了 5 个字段：
+
+```typescript
+// packages/proto-defs/src/element.ts
+export interface GeneralFlags {
+  bubbleDiyTextId?: pb<1, int_32>;
+  groupFlagNew?:    pb<2, int_32>;
+  uin?:             pb<3, uint_64>;
+  longTextFlag?:    pb<6, int_32>;
+  longTextResId?:   pb<7, string>;
+  // ❌ 缺少 tag 19 —— 红包数据字段
+}
+```
+
+### 2.4 降级文本保留逻辑
+
+`rich-body-decoder.ts` 中的逻辑：
+
+```typescript
+const hasCard = elems.some((e) => e.lightApp || e.richMsg);
+// ...
+if (text && hasCard) continue;  // 有卡片时丢弃降级文本
+if (text) result.push({ type: 'text', text });  // 无卡片时保留
+```
+
+红包消息没有 `richMsg`/`lightApp` 元素，所以 `hasCard=false`，降级文本被保留为 `text` 段。
+
+## 3. 逆向方案
+
+### 3.1 第一步：获取红包消息的原始 protobuf 数据
+
+#### 方法 A：通过 SnowLuma 日志
+
+1. 将 SnowLuma 日志级别设为 `TRACE`
+2. 在群内触发一条红包消息
+3. 在日志中找到对应的 `[MsgPush.UnknownElement]` 行，获取 `bytes=XX` 的值
+4. 但当前日志只输出字节数，不输出 hex 内容——需要修改源码在 `describeUndecodedBody()` 中增加 hex 输出
+
+修改 `packages/protocol/src/msg-push/index.ts` 第 66-84 行的 `describeUndecodedBody()` 函数，对 `generalFlags` 也输出 hex：
+
+```typescript
+function describeUndecodedBody(body: PushMsgBody | undefined): string {
+  const elems = (body?.richText?.elems ?? []) as Elem[];
+  const parts = elems.map((e) => {
+    if (e.commonElem) {
+      const ce = e.commonElem;
+      const pb = ce.pbElem && ce.pbElem.length > 0 ? ` pbElem=${hexPreview(ce.pbElem, 256)}` : '';
+      return `commonElem(svc=${ce.serviceType ?? 0},biz=${ce.businessType ?? 0})${pb}`;
+    }
+    // 新增：输出 generalFlags 的原始 hex
+    if (e.generalFlags) {
+      const gf = e.generalFlags;
+      // 需要获取 generalFlags 的原始 bytes，可能需要从 protobuf 原始数据中提取
+      return `generalFlags(flags=${JSON.stringify(gf)})`;
+    }
+    const keys = Object.keys(e).filter((k) => (e as Record<string, unknown>)[k] != null);
+    return keys.join('+') || '(empty)';
+  });
+  // ...
+}
+```
+
+更好的方式：直接在 `convertElements()` 中，当遇到 `generalFlags` 且有未解码数据时，输出原始 bytes 的 hex。
+
+#### 方法 B：直接抓包
+
+1. 在容器内用 `tcpdump` 或 `mitmproxy` 抓取 QQ 的 SSO 包
+2. 过滤出红包消息的 `trpc.msg.olpush.OlPushService.MsgPush` 推送
+3. 解析 protobuf，找到 `richText.elems[]` 中的 `generalFlags` 元素
+4. 提取 tag 19 的 raw bytes
+
+#### 方法 C：修改 SnowLuma 源码临时 dump（✅ 已实现）
+
+在 `packages/protocol/src/msg-push/index.ts` 的 `parseMsgPush()` 函数中，在 `buildContext()` 之后调用 `dumpRedPacketWire()` 函数：
+
+- `context.ts` 的 `MsgPushContext` 新增 `rawBody: Uint8Array` 字段，保留原始 packet bytes
+- `index.ts` 新增独立的 protobuf wire reader（`pbReadVarint` / `pbReadTag` / `pbForEachField`），从 `rawBody` 逐层剥到 `generalFlags` tag 19 的 raw bytes
+- 触发条件：检测到 `text.str` 以 `[QQ红包]` 开头时才 dump，避免普通消息刷屏
+- 输出完整的 Elem 级别 wire 数据（field 1 = text, field 37 = generalFlags，以及 MessageBody/RichText 的所有 field）
+
+由于 proton 解码器在解码后会丢失原始 bytes（decoder.ts 的 `default:` 分支只是 `INLINE_SKIP` 跳过未知字段），最可靠的方式是在解码前保留 `pkt.body`，然后自己用 wire reader 重新解析。
+
+## 4. 实际抓取结果（2026-07-24）
+
+在容器中部署了 wire reader 代码（见 `packages/protocol/src/msg-push/index.ts` 的 `dumpRedPacketWire()`），在群里发了5个不同类型的红包（拼手气、普通、专属、语音、口令），成功获取到 tag 19 的原始 hex 数据。
+
+### 4.1 tag 19 是嵌套 protobuf
+
+用 Python protobuf wire reader 解析后确认 tag 19 是一个嵌套的 protobuf message，**不是 zlib 压缩数据，也不是 UTF-8 字符串**。
+
+### 4.2 五种红包的对比
+
+| 字段 | 拼手气 | 普通 | 专属 | 语音 | 口令 |
+|------|--------|------|------|------|------|
+| field 1 | 6 | 6 | 6 | 6 | 6 |
+| field 4 | 10315 | 10315 | 10315 | 10315 | 10315 |
+| field 15 | 73767 | 73767 | 73767 | 73767 | 73767 |
+| field 25 | 0 | 0 | 0 | 0 | 0 |
+| field 30 | 0 | 0 | 0 | 0 | 0 |
+| field 31 | 0 | 0 | 0 | 0 | 0 |
+| field 34 | 0 | 0 | 0 | 0 | 0 |
+| field 51 | 339 | 339 | 339 | 339 | 339 |
+| field 52 | 2 | 2 | 2 | 2 | 2 |
+| field 54 | 0 | 0 | 0 | 0 | 0 |
+| field 56 | 0 | 0 | 0 | 0 | 0 |
+| field 58 | 0 | 0 | 0 | 0 | 0 |
+| field 61 | 0 | 0 | 0 | 0 | 0 |
+| field 65 | {2:85} | {2:85} | {2:85} | {2:85} | {2:85} |
+| field 66 | 33555584 | 33555584 | 33555584 | 33555584 | 33555584 |
+| field 71 | 258 | 258 | 258 | 258 | 258 |
+| field 72 | 0 | 0 | 0 | 0 | 0 |
+| field 73 | {2:0} | {2:0} | {2:0} | {2:0} | {2:0} |
+| field 79 | 131072 | 131072 | 131072 | 131072 | 131072 |
+| field 81 | 16 | 16 | 16 | 16 | 16 |
+| field 102 | {1:{1:0,2:0,3:0,4:0}} | 同 | 同 | 同 | 同 |
+| **field 107** | **8260** | **8261** | **8262** | **8263** | **8264** |
+| **field 116** | **7978059015695477761** | **1997221136155873534** | **12871624268116887398** | **8930636161208475579** | **569625472242976999** |
+
+### 4.3 完整的 generalFlags 结构
+
+以红包1（拼手气）为例，`generalFlags` 本身的字段：
+
+```
+field 1  (varint): 0
+field 10 (varint): 0
+field 12 (varint): 0
+field 13 (varint): 0
+field 17 (varint): 3069
+field 19 (message, 99B):  ← 红包数据（嵌套 protobuf，见上表）
+```
+
+### 4.4 ~~旧结论（已推翻）~~
+
+> ~~红包标题、祝福语等文本内容不在推送消息里。~~
+
+此结论基于只分析了 `generalFlags` tag 19 的数据，忽略了 `Elem` 的其他字段。
+
+### 4.5 突破性发现：红包内容在 `Elem field=24 (richMsg)` 中（2026-07-24 23:48）
+
+增强 dump 代码后，输出完整的 Elem 级别 wire 数据。用户发送了一个拼手气红包（标题"test"，祝福语"赶紧点击拆开吧"），发现红包消息的 `Elem[]` 包含以下字段：
+
+| Elem field | wire type | 长度 | 内容 |
+|------------|-----------|------|------|
+| field 1 (text) | 2 | 50B | 降级文本 `[QQ红包]请使用新版手机QQ查收红包。` |
+| **field 24 (richMsg)** | **2** | **372B** | **红包完整数据！嵌套 protobuf message** |
+| field 9 (extraInfo?) | 2 | 8B | 发送者信息 |
+| field 37 (generalFlags) | 2 | 114B | 通用标志（tag 19 在此，但只是元数据） |
+| field 16 (extraInfo) | 2 | 16B | 额外信息 |
+
+### 4.6 `richMsg` (field 24) 的完整 protobuf 结构
+
+`richMsg.template1`（field 1, 369 bytes）是一个嵌套的 protobuf message，结构如下：
+
+```
+RichMsg (field 24):
+  field 1 (message, 369B):  ← template1
+    field 1 (varint): 0
+    field 3 (message, 141B):  ← 红包核心信息
+      field 1 (varint): 14235648  → 红包标识/类型码
+      field 2 (varint): 4          → 未知
+      field 3 (string): "test"    → ★ 红包标题
+      field 4 (string): "赶紧点击拆开吧"  → ★ 祝福语
+      field 5 (string): "QQ红包"  → ★ 红包类型名
+      field 6 (bytes, 0B): 空
+      field 7 (bytes, 0B): 空
+      field 8 (string): "[QQ红包]test"  → ★ 完整显示文本
+      field 9 (varint): 16777215  → 颜色/样式?
+      field 10 (varint): 16777215 → 颜色/样式?
+      field 11 (string): "3"      → 红包子类型?
+      field 12 (bytes, 0B): 空
+      field 13 (bytes, 0B): 空
+      field 14 (string): "red?id=10000319012607241400110867883700"  → ★ 红包页面路径
+      field 21 (message, 14B): 全0/空字段
+    field 4 (varint): 0
+    field 5 (varint): 0
+    field 6 (varint): 0
+    field 7 (varint): 3          → 红包类型? (3=拼手气)
+    field 8 (varint): 2          → 未知
+    field 9 (string): "10000319012607241400110867883700"  → ★ 红包ID (transferID)
+    field 10 (string): "d78bdd1942e2429cb4af0c4e3f4bc49da4" → ★ auth key
+    field 11 (varint): 2          → 未知
+    field 12 (varint): 6          → 未知
+    field 17 (message, 70B):      → 签名信息
+      field 1 (varint): 2
+      field 2 (message, 32B):     → 加密签名（TRUNCATED，解析异常）
+      field 3 (string): "ea62c0718ec761cfcbc9a4d88e8ee1bc" → ★ 签名hash
+    field 18 (string): "a34955db5e4eda74521cce7655b2abe1"  → ★ 另一个hash
+    field 19 (varint): 1          → 未知
+    field 21 (message, 25B):
+      field 3 (varint): 0
+      field 5 (string): "{"skin_type":"0"}"  → 皮肤信息
+      field 7 (varint): 0
+      field 8 (varint): 0
+```
+
+### 4.7 为什么 SnowLuma 当前不解码这个字段
+
+SnowLuma 的 `richMsg` 处理逻辑（[`rich-body-decoder.ts`](../SnowLuma/packages/protocol/src/msg-push/rich-body-decoder.ts:81) 的 `decodeRichMsgCard()`）：
+
+1. 取 `rm.template1`（field 1 的 raw bytes）
+2. 调用 `decompressData()` 解压——期望 `data[0]` 是 `0x00`（原始UTF-8）或 `0x01`（zlib压缩）
+3. 但红包的 `template1` 第一个字节是 `0x08`（protobuf field 1 tag），不是压缩标记
+4. `decompressData()` 走到 fallback 分支（第 61-62 行），直接把整个 bytes 当 UTF-8 字符串返回 `{ ok: true }`
+5. 回到 `decodeRichMsgCard()`，`serviceId` 是 `undefined`（proto schema 里 field 2 不存在），`svcId=0`
+6. `svcId !== 1 && !isXmlCardContent(content)` → 返回 `invalidCard`
+7. `cards.rich.element` 是 `undefined`，`hasCard=false`
+8. 降级文本 `[QQ红包]请使用新版手机QQ查收红包。` 被保留
+
+**根本原因**：红包的 `richMsg` 用的是**嵌套 protobuf message**，不是 zlib 压缩的 JSON/XML。当前的 `RichMsg` proto schema（[`element.ts`](../SnowLuma/packages/proto-defs/src/element.ts:152)）只定义了 `template1/serviceId/msgResId/rand/seq` 5个字段，无法解析嵌套的 protobuf 结构。
+
+### 4.8 QQ NT 客户端代码分析
+
+- `application.asar`（29MB，181个 JS 文件）中搜索 `redpacket`/`RedPacket`/`hongbao`/`HongBao`/`wallet`/`qwallet` 等关键字，**0 匹配**
+- 红包处理逻辑不在 Electron JS 层，在 native 模块（`wrapper.node`/`major.node`）中
+
+## 5. 下一步方向
+
+### 5.1 定义红包 RichMsg 的 protobuf schema
+
+需要在 [`packages/proto-defs/src/element.ts`](../SnowLuma/packages/proto-defs/src/element.ts:152) 中定义红包专用 schema：
+
+```typescript
+// 红包 RichMsg 的嵌套结构
+export interface RedPacketMsg {
+  template1?: pb<1, RedPacketTemplate>;  // 嵌套 message（不是 bytes）
+  // field 2-5 等按需添加
+}
+
+export interface RedPacketTemplate {
+  flag?:         pb<1, int_32>;
+  info?:         pb<3, RedPacketInfo>;    // 红包核心信息
+  // ...
+}
+
+export interface RedPacketInfo {
+  type?:        pb<1, int_32>;      // 14235648
+  unknown2?:    pb<2, int_32>;      // 4
+  title?:       pb<3, string>;      // "test" → 红包标题
+  greeting?:    pb<4, string>;      // "赶紧点击拆开吧" → 祝福语
+  typeName?:    pb<5, string>;      // "QQ红包"
+  displayText?: pb<8, string>;      // "[QQ红包]test"
+  color1?:      pb<9, int_32>;      // 16777215
+  color2?:      pb<10, int_32>;     // 16777215
+  subType?:     pb<11, string>;     // "3"
+  pagePath?:    pb<14, string>;     // "red?id=..."
+  // ...
+}
+```
+
+### 5.2 在 `decodeRichMsgCard` 中增加红包分支
+
+检测条件：`decompressData` 返回 `ok` 但 content 第一个字节是 `0x08`（protobuf tag），且不是合法 JSON/XML 时，尝试用 protobuf 解码 `template1`。
+
+### 5.3 输出红包信息到 OneBot
+
+解码后生成一个 `MessageElement`，输出红包标题、祝福语、红包ID、auth key 等信息。
+
+### 5.4 ~~旧方向（已不需要）~~
+
+- ~~拦截 QQ 的 SSO 请求~~ — 不需要，内容就在推送消息里
+- ~~参考 NapCat / Lagrange.Core 的 OIDB 接口~~ — 不需要 OIDB
+- ~~分析 field 116 token 的用途~~ — tag 19 只是元数据，不是红包内容
+
+## 6. 代码改动清单
+
+### 6.1 已修改的源码文件
+
+| 文件 | 改动 |
+|------|------|
+| `packages/proto-defs/src/element.ts` | 新增 `RedPacketInfo`/`RedPacketSign`/`RedPacketSkin`/`RedPacketTemplate`/`RedPacketMsg` proto schema；`Elem` 新增 `redPacket?: pb<24, RedPacketMsg>` |
+| `packages/protocol/src/events.ts` | 新增 `RedPacketElement` 接口；添加到 `MessageElementVariant` 联合类型 |
+| `packages/protocol/src/element-manifest.ts` | 注册 `red_packet` 类型（D/S 方向支持） |
+| `packages/protocol/src/msg-push/rich-body-decoder.ts` | `DECODED_WIRE_FIELDS` 添加 `redPacket`；`convertElements` 中添加红包解码逻辑；`hasRedPacket` 抑制降级文本 |
+| `packages/onebot/src/event-converter/element-codecs.ts` | 新增 `red_packet` 的 `toSegment` codec |
+| `packages/protocol/src/msg-push/context.ts` | `MsgPushContext` 新增 `rawBody` 字段（调试用） |
+| `packages/protocol/src/msg-push/index.ts` | 新增 wire reader + `dumpRedPacketWire()` 调试函数（调试用） |
+| `docker/docker-compose.yml` | image 改为 `snowluma:local` |
+
+### 6.2 新增的辅助文件
+
+| 文件 | 用途 |
+|------|------|
+| `Dockerfile.local` | 覆盖层 Dockerfile，基于官方镜像替换 Framework tarball |
+| `scripts/decode_redpacket.py` | Python protobuf wire 解析器，解析 tag 19 hex |
+| `scripts/decode_gf_full.py` | 解析完整 generalFlags 结构 |
+| `scripts/compare_redpacket.py` | 5种红包字段对比表 |
+| `scripts/decode_elem24.py` | 解析 Elem field=24 (richMsg) 的 protobuf 结构 |
+| `scripts/decode_elem24_utf8.py` | 同上，输出到 UTF-8 文件避免终端编码问题 |
+| `scripts/elem24_decoded.txt` | 解码结果输出文件（含完整中文内容） |
+| `scripts/search_asar.py` | asar 文件搜索（未成功，header 编码问题） |
+| `scripts/search_hongbao.js` | Node.js 搜索解包后的 asar 内容 |
+
+### 6.3 构建部署流程
+
+```powershell
+# 1. 类型检查
+cd E:\SnowLuma\packages\protocol && npx tsc --noEmit
+
+# 2. 构建 Linux 产物
+cd E:\SnowLuma\packages\core && npx cross-env SNOWLUMA_TARGET=linux-x64 BUILD_WEBUI=true vite build
+
+# 3. 补齐 WebUI 静态资源（首次需要）
+docker run --rm -v e:/SnowLuma/dist:/out motricseven7/snowluma:latest cp -a /app/snowluma/client /out/client
+
+# 4. 打包 tarball
+cd E:\SnowLuma\dist && tar -czf ../../SnowLuma.Docker.Framework/SnowLuma.Framework.tar.gz .
+
+# 5. 构建本地镜像（覆盖层方式，秒级）
+docker build -t snowluma:local -f Dockerfile.local e:/SnowLuma.Docker.Framework/
+
+# 6. 重启容器
+docker compose -f e:/SnowLuma/docker/docker-compose.yml up -d snowluma
+
+# 7. 查看红包 dump 日志
+docker logs snowluma --tail 100 | findstr RedPacketDump
+```
+
+## 7. 验证清单
+
+- [x] 获取一条红包消息的 `generalFlags` tag 19 原始 hex 数据
+- [x] 尝试 zlib 解压 — 不是 zlib
+- [x] 尝试 UTF-8 解码 — 不是 UTF-8 文本
+- [x] 尝试 protobuf `--decode_raw` 解析 — 是嵌套 protobuf
+- [x] 对比普通红包 / 拼手气红包 / 语音口令红包的数据差异 — 仅 field 107/116 不同
+- [x] 搜索 QQ NT asar 中的红包相关代码 — 0 匹配，在 native 层
+- [x] 输出完整 Elem wire 数据，确认是否有遗漏字段 — **发现 Elem field=24 (richMsg) 携带完整红包内容**
+- [x] 解码 `richMsg.template1` 的嵌套 protobuf 结构 — **成功提取红包标题"test"、祝福语"赶紧点击拆开吧"**
+- [x] 确认红包内容不需要 OIDB 接口拉取 — **内容直接在推送消息的 richMsg 中**
+- [x] 分析 SnowLuma 不解码 richMsg 的原因 — **decompressData 期望 zlib 但 richMsg 是 protobuf**
+- [x] 定义红包 RichMsg 的 protobuf schema — **已在 element.ts 添加 RedPacketMsg/RedPacketTemplate/RedPacketInfo 等**
+- [x] 在 `convertElements` 中增加红包解码分支 — **已添加 `elem.redPacket` 处理 + `hasRedPacket` 抑制降级文本**
+- [x] 在 `element-codecs.ts` 添加 `red_packet` 的 `toSegment` codec
+- [x] 在 `element-manifest.ts` 注册 `red_packet` 类型
+- [x] 测试验证 — **拼手气红包成功输出标题"测试，test"、祝福语"赶紧点击拆开吧"**
+
+### 9. 验证结果（2026-07-25 00:08）
+
+用户在 bot测试群 发送拼手气红包（标题"测试，test"，祝福语"赶紧点击拆开吧"），`get_msg` 返回：
+
+```json
+{
+  "type": "red_packet",
+  "data": {
+    "title": "测试，test",
+    "greeting": "赶紧点击拆开吧",
+    "display_text": "[QQ红包]测试，test",
+    "type_name": "QQ红包",
+    "packet_type": 3,
+    "transfer_id": "10000319012607251300119639057700",
+    "auth_key": "e68a1c8761e0d66193135f7436fdfa958f"
+  }
+}
+```
+
+降级文本 `[QQ红包]请使用新版手机QQ查收红包。` 已被正确抑制，不再输出。
+
+## 8. 参考资源
+
+### 8.1 其他 OneBot 实现的红包处理
+
+- **NapCat**：检查 `dev/napcatQQ/.../packet/message/element.ts` 中是否有红包相关处理
+- **Lagrange.Core**：C# 实现，检查 `Lagrange.Core/Message/Entity` 中是否有 RedPacketEntity
+- **LLOneBot**：基于 LiteLoaderQQNT，检查其消息元素处理
+
+### 8.2 QQ 协议中的红包相关
+
+- 红包消息的 `msgType` 可能有特定值，可以通过日志中 `msgType=X` 确认
+- `generalFlags` 的 tag 19 可能是 QQ 内部称为 `pendingPendingBoxInfo` 或类似名称的字段
+- QQ Android 客户端的反编译代码（如 tsuzcx/qq_apk）中可能有关键字 `RedPacket`、`HongBao`、`Wallet` 等
+
+### 8.3 相关源码文件
+
+| 文件 | 作用 |
+|------|------|
+| `packages/proto-defs/src/element.ts` | protobuf 元素定义（GeneralFlags 在此添加 tag 19） |
+| `packages/protocol/src/msg-push/rich-body-decoder.ts` | 消息元素解码器（在此添加红包解码逻辑） |
+| `packages/protocol/src/msg-push/index.ts` | MsgPush 入口（`dumpRedPacketWire` 用于调试） |
+| `packages/protocol/src/msg-push/context.ts` | MsgPushContext（`rawBody` 字段） |
+| `packages/onebot/src/event-converter/to-segment.ts` | OneBot 段转换器（输出 json/xml 段） |
+| `packages/protocol/src/format.ts` | 日志预览格式化（`extractCardTitle` 提取卡片标题） |
+| `packages/common/src/hex.ts` | hex 工具函数（`hexPreview` 用于调试输出） |
+| `packages/proton/src/codegen/decoder.ts` | proton decoder 代码生成器（`default:` 分支跳过未知字段） |


### PR DESCRIPTION
## 概述 (Overview)

修复群加群申请（Add Request）在 OIDB `0x10C0` 到 `0x10C8` 审批链路中的 `eventType` 错位映射 Bug。

## 问题原因 (Root Cause)

1. 在底层 OIDB `0x10C0` 协议响应中，字段 2（`eventType`）返回的已是底层的操作类型（`1` = 主动申请加群，`2` = 邀请加群）。
2. 旧代码中 `groupRequestOperationType` 误将其当成 NTQQ 前端 UI 层的 `SysNotifyType` 进行了二次映射（`1 -> 2`，`7 -> 1`），导致原本为 `1` 的主动加群申请被错误改写为 `eventType = 2`（邀请）。
3. 进而导致构造的 `flag`（如 `slreq:1:...:2:0`）在调用 `set_group_add_request`（`0x10C8`）时以 `eventType = 2` 提交审批，腾讯服务端因记录类型不匹配而报错 `OIDB error 120162007 on 0x10c8_1: already deleted by system`。
4. 同时，`groupRequestActor` 和 `GroupRequestPoller` 误将 `notifyType = 1` 当成邀请，导致加群申请的 `requester_uin` 被错误取成 `invitorUin`（0）。

## 解决方案 (Changes)

1. **`fetch-group-requests.ts`**：修正 `groupRequestOperationType`，直接保留底层的 `eventType`（`1` / `2` / `22`），并兼容处理可能传入的高层通知类型 `7 -> 1`。
2. **`contacts.ts`**：规范解析 0x10C0 响应中的 `eventType`，避免错误转表。
3. **`contact-actions.ts` & `group-request-poller.ts`**：修正 `groupRequestActor` 和 `toEvent` 的判断逻辑，仅在 `eventType` 为 `2` 或 `22` 时按邀请处理（提取 `invitor`），其余按申请处理（提取 `target`）。
4. **测试**：补全并更新单元测试用例，覆盖 `eventType: 1` 和 `eventType: 2` 的各种场景。

## 验证 (Verification)

- [x] `pnpm typecheck` 全部通过。
- [x] 单元测试 `fetch-group-requests.test.ts`、`contact-actions.test.ts`、`group-request-poller.test.ts`、`instance-context.test.ts`、`contacts.test.ts` 全部通过。
- [x] 在真实 Docker 容器环境中测试小号主动申请加群，成功生成 `slreq:1:...:1:0` 并通过 `set_group_add_request` 成功审批入群。
