### PR TITLE
chore: promote dev → main (5ff12868)

### DIFF
--- a/packages/mcp/src/generated/catalog.json
+++ b/packages/mcp/src/generated/catalog.json
@@ -12553,7 +12553,7 @@
     },
     {
       "category": "扩展",
-      "count": 114
+      "count": 115
     },
     {
       "category": "群相册",

--- a/packages/mcp/src/generated/catalog.ts
+++ b/packages/mcp/src/generated/catalog.ts
@@ -12557,7 +12557,7 @@ export const CATEGORIES: CatalogCategory[] = [
   },
   {
     "category": "扩展",
-    "count": 114
+    "count": 115
   },
   {
     "category": "群相册",


### PR DESCRIPTION
Follow-up for the v1.14.12 release. The generated action catalog was stale, which failed the release preflight.

No version bump. After merge, retag `v1.14.12` to rerun Build and Release.