### PR TITLE
feat(profile, onebot): 添加企点账号标志的获取与透传

### DIFF
--- a/packages/core/tests/bridge-member-identity.test.ts
+++ b/packages/core/tests/bridge-member-identity.test.ts
@@ -47,6 +47,9 @@ function emptyProfile(uin: number, uid: string) {
     sign: '',
     avatar: '',
     level: 0,
+    qidianMasterFlag: 0,
+    qidianCrewFlag: 0,
+    qidianCrewFlag2: 0,
   };
 }
 

--- a/packages/core/tests/identity-service.test.ts
+++ b/packages/core/tests/identity-service.test.ts
@@ -757,6 +757,9 @@ describe('IdentityService', () => {
       sign: '',
       avatar: '',
       level: 0,
+      qidianMasterFlag: 0,
+      qidianCrewFlag: 0,
+      qidianCrewFlag2: 0,
     };
     const request = {
       groupId: GROUP_ID,
@@ -911,7 +914,10 @@ describe('IdentityService', () => {
 
 describe('IdentityService.resolveUid', () => {
   function makeProfile(uin: number, uid: string): UserProfileInfo {
-    return { uin, uid, nickname: '', remark: '', qid: '', sex: 'unknown', age: 0, sign: '', avatar: '', level: 0 };
+    return {
+      uin, uid, nickname: '', remark: '', qid: '', sex: 'unknown', age: 0, sign: '', avatar: '', level: 0,
+      qidianMasterFlag: 0, qidianCrewFlag: 0, qidianCrewFlag2: 0,
+    };
   }
 
   it('returns the cached uid without invoking the fetcher', async () => {
@@ -976,7 +982,10 @@ describe('IdentityService.resolveUid', () => {
 
 describe('IdentityService inbound UID→UIN', () => {
   function makeProfile(uin: number, uid: string): UserProfileInfo {
-    return { uin, uid, nickname: '', remark: '', qid: '', sex: 'unknown', age: 0, sign: '', avatar: '', level: 0 };
+    return {
+      uin, uid, nickname: '', remark: '', qid: '', sex: 'unknown', age: 0, sign: '', avatar: '', level: 0,
+      qidianMasterFlag: 0, qidianCrewFlag: 0, qidianCrewFlag2: 0,
+    };
   }
 
   it('findUinByUid treats a numeric uid as that uin without consulting maps', () => {

--- a/packages/onebot/src/manager.ts
+++ b/packages/onebot/src/manager.ts
@@ -525,6 +525,7 @@ async function warmUpBridgeState(
           uin: f.uin, uid: f.uid,
           nickname: f.nickname || uin,
           remark: '', qid: '', sex: 'unknown', age: 0, sign: '', avatar: '', level: 0,
+          qidianMasterFlag: 0, qidianCrewFlag: 0, qidianCrewFlag2: 0,
         });
         bridge.identity.nickname = f.nickname || uin;
         log.debug('self info: UIN=%s uid=%s nickname=%s', uin, f.uid, f.nickname ?? '');

--- a/packages/onebot/src/modules/contact-actions.ts
+++ b/packages/onebot/src/modules/contact-actions.ts
@@ -296,6 +296,9 @@ function formatStrangerInfo(p: UserProfileInfo): JsonObject {
     batteryStatus: p.batteryStatus ?? 0,
     customStatus: p.customStatus ?? null,
     customStatusDescInfo: p.customStatusDesc ?? '',
+    qidian_master_flag: p.qidianMasterFlag,
+    qidian_crew_flag: p.qidianCrewFlag,
+    qidian_crew_flag_2: p.qidianCrewFlag2,
   };
 }
 

--- a/packages/onebot/tests/contact-actions.test.ts
+++ b/packages/onebot/tests/contact-actions.test.ts
@@ -104,7 +104,8 @@ function makeProfile(
   remark = '',
 ): UserProfileInfo {
   return {
-    uin, uid: `u_${uin}`, nickname, remark, qid: '', sex, age, sign, avatar: '',
+    uin, uid: `u_${uin}`, nickname, remark, qid: '', sex, age, sign, avatar: '', level: 0,
+    qidianMasterFlag: 0, qidianCrewFlag: 0, qidianCrewFlag2: 0,
   };
 }
 
@@ -544,6 +545,24 @@ describe('onebot/contact-actions / getStrangerInfo', () => {
       age: 25,
       remark: 'Teammate',
       long_nick: 'Stay curious',
+    });
+  });
+
+  it('passes through the qidian (企点) flags from the profile', async () => {
+    const bridge = fakeBridge({
+      fetchUserProfile: vi.fn(async () => ({
+        ...makeProfile(55555, 'QidianWorker', 'male'),
+        qidianMasterFlag: 0,
+        qidianCrewFlag: 1,
+        qidianCrewFlag2: 0,
+      })),
+    });
+    const out = await getStrangerInfo(bridge, 55555);
+    expect(out).toMatchObject({
+      user_id: 55555,
+      qidian_master_flag: 0,
+      qidian_crew_flag: 1,
+      qidian_crew_flag_2: 0,
     });
   });
 

--- a/packages/protocol/src/oidb-services/contacts/fetch-user-profile-by-uid.ts
+++ b/packages/protocol/src/oidb-services/contacts/fetch-user-profile-by-uid.ts
@@ -28,6 +28,8 @@ import { invokeOidb, type OidbSender } from '../../oidb-service';
 const REQUESTED_KEYS = [
   20002, 27394, 20009, 20031, 101, 103, 102, 20020, 20003, 20026,
   105, 27372, 27406, 20037,
+  // 企点标志（QQ 企点 / 企业版 QQ 账号）：员工号实测为 1，普通账号为 0
+  40410, 42031,
 ];
 
 export namespace FetchUserProfileByUid {
@@ -55,6 +57,7 @@ export namespace FetchUserProfileByUid {
       uin: body.body.uin ?? 0,
       uid: body.body.uid ?? '',
       nickname: '', remark: '', qid: '', sex: 'unknown', age: 0, sign: '', avatar: '', level: 0,
+      qidianMasterFlag: 0, qidianCrewFlag: 0, qidianCrewFlag2: 0,
     };
 
     if (body.body.properties) {
@@ -85,6 +88,9 @@ export namespace FetchUserProfileByUid {
       info.age = numMap.get(20037) ?? 0;
       info.level = numMap.get(105) ?? 0;
       applyOnlineStatus(info, bytesMap, numMap);
+      // 企点标志：40410 / 42031，服务器仅在返回时才出现（普通账号缺省 → 0）
+      info.qidianMasterFlag = numMap.get(42031) ?? 0;
+      info.qidianCrewFlag = numMap.get(40410) ?? 0;
     }
 
     return info;

--- a/packages/protocol/src/oidb-services/contacts/fetch-user-profile.ts
+++ b/packages/protocol/src/oidb-services/contacts/fetch-user-profile.ts
@@ -55,6 +55,8 @@ export function applyOnlineStatus(
 const REQUESTED_KEYS = [
   20002, 27394, 20009, 20031, 101, 103, 102, 20020, 20003, 20026,
   105, 27372, 27406, 20037,
+  // 企点标志（QQ 企点 / 企业版 QQ 账号）：员工号实测为 1，普通账号为 0
+  40410, 42031,
 ];
 
 export namespace FetchUserProfile {
@@ -86,6 +88,7 @@ export namespace FetchUserProfile {
       uin: body.body.uin ?? requestedUin,
       uid: body.body.uid ?? '',
       nickname: '', remark: '', qid: '', sex: 'unknown', age: 0, sign: '', avatar: '', level: 0,
+      qidianMasterFlag: 0, qidianCrewFlag: 0, qidianCrewFlag2: 0,
     };
 
     if (body.body.properties) {
@@ -116,6 +119,9 @@ export namespace FetchUserProfile {
       info.age = numMap.get(20037) ?? 0;
       info.level = numMap.get(105) ?? 0;
       applyOnlineStatus(info, bytesMap, numMap);
+      // 企点标志：40410 / 42031，服务器仅在返回时才出现（普通账号缺省 → 0）
+      info.qidianMasterFlag = numMap.get(42031) ?? 0;
+      info.qidianCrewFlag = numMap.get(40410) ?? 0;
     }
 
     return info;

--- a/packages/protocol/src/qq-info.ts
+++ b/packages/protocol/src/qq-info.ts
@@ -17,6 +17,16 @@ export interface UserProfileInfo {
   batteryStatus?: number;
   customStatus?: { faceId: number; wording: string } | null;
   customStatusDesc?: string;
+  /**
+   * 企点标志（QQ 企点 / 企业版 QQ 账号），0/1。
+   * 数据来源为 OIDB 0xFE1_2 number-property key 40410 / 42031：
+   * 真实企点员工号上实测均为 1，普通账号均为 0（见 issue #404 讨论）。
+   * 与 NapCat `simpleInfo.relationFlags` 的 qidianMasterFlag / qidianCrewFlag
+   * 对应；qidianCrewFlag2 未发现独立 key，恒为 0。
+   */
+  qidianMasterFlag: number;
+  qidianCrewFlag: number;
+  qidianCrewFlag2: number;
 }
 
 export interface FriendInfo {

--- a/packages/protocol/tests/oidb-services/contacts/fetch-user-profile.test.ts
+++ b/packages/protocol/tests/oidb-services/contacts/fetch-user-profile.test.ts
@@ -44,6 +44,43 @@ describe('FetchUserProfile namespace', () => {
       expect(keys).toContain(101);   // avatar
       expect(keys).toContain(102);   // sign
       expect(keys).toContain(103);   // remark
+      expect(keys).toContain(40410); // qidian crew flag (企点员工标志)
+      expect(keys).toContain(42031); // qidian master flag (企点主号标志)
+    });
+
+    it('decodes qidian flags from number-properties (0 when absent)', async () => {
+      // 企点员工号：两个标志均为 1；普通账号服务器不返回这两个 key → 缺省 0
+      const qidian = makeSender({
+        body: {
+          uin: 3004251964, uid: 'u',
+          properties: {
+            bytesProperties: [],
+            numberProperties: [
+              { number1: 40410, number2: 1 },
+              { number1: 42031, number2: 1 },
+            ],
+          },
+        } as any,
+      });
+      const out = await FetchUserProfile.invoke(qidian, { uin: 3004251964 });
+      expect(out.qidianMasterFlag).toBe(1);
+      expect(out.qidianCrewFlag).toBe(1);
+      expect(out.qidianCrewFlag2).toBe(0);
+
+      // 普通账号：无企点 key → 全 0
+      const normal = makeSender({
+        body: {
+          uin: 10001, uid: 'u',
+          properties: {
+            bytesProperties: [],
+            numberProperties: [{ number1: 20009, number2: 1 }],
+          },
+        } as any,
+      });
+      const out2 = await FetchUserProfile.invoke(normal, { uin: 10001 });
+      expect(out2.qidianMasterFlag).toBe(0);
+      expect(out2.qidianCrewFlag).toBe(0);
+      expect(out2.qidianCrewFlag2).toBe(0);
     });
 
     it('decodes nickname / remark / qid / sign from bytes-properties', async () => {


### PR DESCRIPTION
<!-- 感谢贡献。请填写以下内容，方便评审。 -->

## 关联 Issue

#404

## 变更说明

给 `get_stranger_info` 补上三个企点账号标志字段：

- `qidian_master_flag`（企点主号标志，0/1）
- `qidian_crew_flag`（企点员工标志，0/1）
- `qidian_crew_flag_2`（未发现独立数据位，恒为 0）

**数据来源**：OIDB 0xFE1_2 的 numberProperty **key 40410（crew）与 42031（master）**，在现有 `REQUESTED_KEYS` 追加即可，无需新增协议命令。服务器仅在返回时才携带这两个 key（普通账号缺省），deserialize 侧缺省为 0，现有字段完全不变。

**实测验证**：
- 企点员工号：`qidian_crew_flag=1`、`qidian_master_flag=1`
- 普通账号：三个字段均为 0
- 相邻 key（40408 ~ 40412、42029 ~ 42033）被服务器 `DenyFields` 拒绝，确认 40410/42031 是公开的企点标志位

`qidian_crew_flag_2` 在已请求的全部公开 key 中无对应非零位，保持 0（NapCat 透传的该字段同样未见非零，注释中已说明）。

**变更文件**：`qq-info.ts`（UserProfileInfo 加三字段）、`fetch-user-profile.ts` / `fetch-user-profile-by-uid.ts`（key + 解析）、`contact-actions.ts`（getStrangerInfo 透传）、相关测试。

## 提交前检查

- [x] 本 PR 聚焦单一目标，未夹带无关改动
- [x] 已通过 `pnpm lint` 与 `pnpm typecheck`
- [x] 已补充/更新相关测试，且 `pnpm test` 通过
- [x] 文件行尾为 LF（未引入 CRLF）
- [x] PR 描述与实际实现一致
