### PR TITLE
feat(hook): add UIN allow/deny gate for auto-injection

### DIFF
--- a/packages/bridge/src/hook-manager.ts
+++ b/packages/bridge/src/hook-manager.ts
@@ -6,6 +6,13 @@ import {
 import { renderParamsVerbose } from '@snowluma/common/log-summary';
 import type { PacketSender } from '@snowluma/common/packet-sender';
 import type { PacketInfo, PacketSink } from '@snowluma/common/protocol-types';
+import {
+  defaultHookUinFilter,
+  type HookUinFilter,
+  isHookUinFilterActive,
+  isUinAllowedByFilter,
+} from '@snowluma/common/runtime';
+import { isRealUin } from '@snowluma/common/uin';
 import fs from 'fs';
 import { HookSession, type HookSessionDeps } from './hook-session';
 import {
@@ -22,6 +29,8 @@ import { probeQqLoginInfo, type QqPortLoginInfo } from './qq-port-probe';
 import type { HookProcessInfo } from './types';
 
 const AUTO_LOAD_MAX_ATTEMPTS = 3;
+const UIN_GATE_PROBE_INTERVAL_MS = 3000;
+const UIN_GATE_DENIED_RECHECK_MS = 30_000;
 
 type AutoLoadAttempt = {
   attempts: number;
@@ -64,6 +73,9 @@ export type HookManagerDeps = {
    * A narrowly-classified early-process mapping race is retried on later
    * watcher ticks with a fixed attempt limit. */
   autoLoadOnDiscovery?: boolean;
+  /** UIN allow/deny gate for auto-injection. When active, a newly-discovered
+   * process is probed for its logged-in UIN before injection. */
+  uinFilter?: HookUinFilter;
   /** Optional hook fired whenever the set of HookProcessInfo observable to
    * `listProcesses()` changes — new process discovered, process gone, or
    * any session's status mutated. Used by the WebUI SSE wiring to push a
@@ -106,6 +118,10 @@ export class HookManager {
    *  injected (tests) — nothing to tear down in that case. */
   private readonly enumerator: ProcessEnumerator | null;
   private readonly autoLoadOnDiscovery: boolean;
+  private uinFilter: HookUinFilter;
+  private readonly uinGateState = new Map<number, { timer: ReturnType<typeof setTimeout> | null; startedAt: number; phase: 'probing' | 'denied'; lastCheckedUin: string }>();
+  private readonly gateApprovedPids = new Set<number>();
+  private readonly manualLoadPids = new Set<number>();
   private readonly onSessionsChangedRaw?: () => void;
   private readonly log: Logger;
   private readonly sessions = new Map<number, HookSession>();
@@ -129,6 +145,7 @@ export class HookManager {
     };
     this.makeClient = deps.makeClient ?? ((pid: number) => new QqHookClient(pid));
     this.autoLoadOnDiscovery = deps.autoLoadOnDiscovery ?? false;
+    this.uinFilter = deps.uinFilter ?? defaultHookUinFilter();
 
     // A custom lister (tests) is used directly — no worker, no isolation, just
     // an async wrap that maps a throw to the UNKNOWN sentinel. The default path
@@ -196,6 +213,9 @@ export class HookManager {
     this.assertValidPid(pid);
     await this.startPromise;
     this.autoLoadAttempts.delete(pid);
+    this.clearUinGate(pid);
+    this.gateApprovedPids.delete(pid);
+    this.manualLoadPids.add(pid);
     const session = this.ensureSession(pid);
     const info = await session.load();
     // Pull the next tick forward so a freshly-injected pipe gets noticed
@@ -208,6 +228,9 @@ export class HookManager {
     this.assertValidPid(pid);
     await this.startPromise;
     this.autoLoadAttempts.delete(pid);
+    this.clearUinGate(pid);
+    this.gateApprovedPids.delete(pid);
+    this.manualLoadPids.delete(pid);
     const session = this.ensureSession(pid);
     return session.unload();
   }
@@ -224,9 +247,172 @@ export class HookManager {
     return probeQqLoginInfo(pid);
   }
 
+  setUinFilter(filter: HookUinFilter): void {
+    const normalized = filter ?? defaultHookUinFilter();
+    this.uinFilter = normalized;
+    this.log.info(
+      'hook uin-filter updated: mode=%s whitelist=%j blacklist=%j maxWaitMs=%d',
+      normalized.mode,
+      normalized.whitelist,
+      normalized.blacklist,
+      normalized.maxWaitMs,
+    );
+    if (!isHookUinFilterActive(normalized)) {
+      for (const pid of [...this.uinGateState.keys()]) this.clearUinGate(pid);
+      return;
+    }
+    if (!this.autoLoadOnDiscovery) return;
+    for (const session of this.sessions.values()) {
+      const pid = session.pid;
+      const info = session.toInfo();
+      if ((info.loggedIn || info.injected) && info.uin && !isUinAllowedByFilter(normalized, info.uin)) {
+        this.log.warn(
+          'hook uin-filter active: forcing uninjected for non-allowed session pid=%d uin=%s status=%s',
+          pid,
+          info.uin,
+          info.status,
+        );
+        this.gateApprovedPids.delete(pid);
+        this.clearUinGate(pid);
+        try {
+          this.bridgeManager.onPidDisconnected(pid);
+        } catch { void 0; }
+        this.forceSessionAvailable(pid);
+        const state = { startedAt: Date.now(), timer: null, phase: 'denied' as const, lastCheckedUin: String(info.uin) };
+        this.uinGateState.set(pid, state);
+        this.scheduleUinGateProbe(pid, UIN_GATE_DENIED_RECHECK_MS);
+      } else if (!info.injected && !this.uinGateState.has(pid) && shouldAutoLoadPid(pid, this.log)) {
+        if (info.status === 'available' || info.status === 'error') {
+          this.log.info('hook uin-filter active: gating existing available pid=%d', pid);
+          this.startUinGate(session);
+        }
+      }
+    }
+  }
+
+  private isPidBlocked(pid: number): boolean {
+    const state = this.uinGateState.get(pid);
+    return !!state && state.phase === 'denied' && isHookUinFilterActive(this.uinFilter);
+  }
+
+  private forceSessionAvailable(pid: number): void {
+    const session = this.sessions.get(pid);
+    if (!session) return;
+    try {
+      (session as unknown as { tearDownClient?: () => void }).tearDownClient?.();
+    } catch { void 0; }
+    (session as unknown as { injected: boolean }).injected = false;
+    (session as unknown as { injectResult: unknown }).injectResult = null;
+    (session as unknown as { _method: string })._method = '';
+    (session as unknown as { _uin: string })._uin = '0';
+    (session as unknown as { _error: string })._error = '';
+    (session as unknown as { connected: boolean }).connected = false;
+    (session as unknown as { loggedIn: boolean }).loggedIn = false;
+    try {
+      (session as unknown as { setStatus: (s: string, e: string) => void }).setStatus('available', '');
+    } catch { void 0; }
+    try {
+      (this.pipeWatcher as unknown as { livePipes?: Set<number> }).livePipes?.delete(pid);
+    } catch { void 0; }
+    try {
+      this.autoLoadAttempts.delete(pid);
+    } catch { void 0; }
+  }
+
+  private clearUinGate(pid: number): void {
+    const state = this.uinGateState.get(pid);
+    if (state?.timer) clearTimeout(state.timer);
+    this.uinGateState.delete(pid);
+  }
+
+  private startUinGate(session: HookSession): void {
+    const pid = session.pid;
+    if (this.uinGateState.has(pid)) return;
+    this.log.info('hook uin-gate start: pid=%d mode=%s', pid, this.uinFilter.mode);
+    const state = { startedAt: Date.now(), timer: null, phase: 'probing' as const, lastCheckedUin: '' };
+    this.uinGateState.set(pid, state);
+    this.scheduleUinGateProbe(pid, 0);
+  }
+
+  private scheduleUinGateProbe(pid: number, delayMs: number): void {
+    const state = this.uinGateState.get(pid);
+    if (!state || this.disposed) return;
+    if (state.timer) clearTimeout(state.timer);
+    state.timer = setTimeout(() => void this.runUinGateProbe(pid), delayMs);
+    if ((state.timer as unknown as { unref?: () => void }).unref) (state.timer as unknown as { unref: () => void }).unref();
+  }
+
+  private async runUinGateProbe(pid: number): Promise<void> {
+    if (this.disposed) return;
+    const state = this.uinGateState.get(pid);
+    if (!state) return;
+    const session = this.sessions.get(pid);
+    if (!session || (session as unknown as { isDisposed: boolean }).isDisposed) {
+      this.clearUinGate(pid);
+      return;
+    }
+    if (!isHookUinFilterActive(this.uinFilter)) {
+      this.clearUinGate(pid);
+      this.runAutoLoad(session);
+      return;
+    }
+    const maxWaitMs = this.uinFilter.maxWaitMs ?? 0;
+    if (maxWaitMs > 0 && Date.now() - state.startedAt >= maxWaitMs) {
+      if (state.phase === 'probing') {
+        this.log.info('hook uin-gate timeout: pid=%d wait=%dms -> low-frequency monitor', pid, maxWaitMs);
+        state.phase = 'denied';
+      }
+    }
+    let info: QqPortLoginInfo | null = null;
+    try {
+      info = await this.probeProcessLoginInfo(pid);
+    } catch (error) {
+      this.log.warn('hook uin-gate probe failed: pid=%d err=%s', pid, error instanceof Error ? error.message : String(error));
+    }
+    if (this.disposed || !this.uinGateState.has(pid)) return;
+    if (!this.sessions.has(pid)) {
+      this.clearUinGate(pid);
+      return;
+    }
+    if (info && info.identityKnown && isRealUin(info.uin)) {
+      const uin = String(info.uin);
+      state.lastCheckedUin = uin;
+      const allowed = isUinAllowedByFilter(this.uinFilter, uin);
+      if (allowed) {
+        this.log.info('hook uin-gate allowed: pid=%d uin=%s mode=%s', pid, uin, this.uinFilter.mode);
+        this.clearUinGate(pid);
+        this.gateApprovedPids.add(pid);
+        this.runAutoLoad(session);
+        return;
+      } else {
+        if (state.phase !== 'denied') this.log.info('hook uin-gate denied: pid=%d uin=%s mode=%s -> low-frequency monitor', pid, uin, this.uinFilter.mode);
+        state.phase = 'denied';
+        const sessInfo = session.toInfo();
+        if (sessInfo.loggedIn || sessInfo.injected) {
+          this.log.warn('hook uin-gate denied but session already injected/online: pid=%d uin=%s status=%s -> forcing uninjected', pid, uin, sessInfo.status);
+          try {
+            this.bridgeManager.onPidDisconnected(pid);
+          } catch { void 0; }
+          this.forceSessionAvailable(pid);
+        }
+        this.scheduleUinGateProbe(pid, UIN_GATE_DENIED_RECHECK_MS);
+        return;
+      }
+    }
+    if (state.phase === 'denied') {
+      this.scheduleUinGateProbe(pid, UIN_GATE_DENIED_RECHECK_MS);
+    } else {
+      this.scheduleUinGateProbe(pid, UIN_GATE_PROBE_INTERVAL_MS);
+    }
+  }
+
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    for (const state of this.uinGateState.values()) if (state.timer) clearTimeout(state.timer);
+    this.uinGateState.clear();
+    this.gateApprovedPids.clear();
+    this.manualLoadPids.clear();
     for (const session of this.sessions.values()) {
       session.dispose();
     }
@@ -252,12 +438,9 @@ export class HookManager {
           renderParamsVerbose(info),
           this.autoLoadOnDiscovery,
         ]);
-        // Headless/Docker deployments enable autoLoadOnDiscovery so QQ gets
-        // injected without a human clicking "Load" in WebUI. Fire-and-forget:
-        // failures are already captured inside loadInternal and surfaced via
-        // the session's status field.
         if (this.autoLoadOnDiscovery && shouldAutoLoadPid(info.pid, this.log)) {
-          this.runAutoLoad(session);
+          if (!isHookUinFilterActive(this.uinFilter)) this.runAutoLoad(session);
+          else this.startUinGate(session);
         }
         this.notifySessionsChanged();
       });
@@ -266,6 +449,9 @@ export class HookManager {
       if (this.disposed) return;
       runWithTraceRequest(() => {
         this.autoLoadAttempts.delete(pid);
+        this.clearUinGate(pid);
+        this.gateApprovedPids.delete(pid);
+        this.manualLoadPids.delete(pid);
         const session = this.sessions.get(pid);
         this.log.trace(
           'hook_manager_fact event=process_gone pid=%d tracked=%s',
@@ -278,6 +464,10 @@ export class HookManager {
     });
     this.pipeWatcher.on('pipe-up', (pid: number) => {
       if (this.disposed) return;
+      if (this.isPidBlocked(pid)) {
+        this.log.info('hook uin-filter: pipe-up blocked for denied pid=%d', pid);
+        return;
+      }
       const session = this.sessions.get(pid);
       if (session) session.onPipeUp();
     });
@@ -311,6 +501,7 @@ export class HookManager {
         }
         if ((session.status === 'connecting' || session.status === 'disconnected')
           && this.pipeWatcher.isPipeLive(session.pid)) {
+          if (this.isPidBlocked(session.pid)) continue;
           session.onPipeUp();
         }
       }
@@ -444,6 +635,41 @@ export class HookManager {
     session.attachProcessInfo({ name: defaultProcessName() });
 
     session.on('login', (uin: string, sender) => {
+      this.log.info(
+        'hook login attempt: pid=%d uin=%s mode=%s whitelist=%j blacklist=%j active=%s allowed=%s manual=%s',
+        pid,
+        String(uin),
+        this.uinFilter.mode,
+        this.uinFilter.whitelist,
+        this.uinFilter.blacklist,
+        isHookUinFilterActive(this.uinFilter),
+        isUinAllowedByFilter(this.uinFilter, uin),
+        this.manualLoadPids.has(pid),
+      );
+      if (isHookUinFilterActive(this.uinFilter) && !isUinAllowedByFilter(this.uinFilter, uin)) {
+        if (this.manualLoadPids.has(pid)) {
+          this.log.info('hook uin-filter: manual load bypass allowed pid=%d uin=%s mode=%s', pid, String(uin), this.uinFilter.mode);
+          this.manualLoadPids.delete(pid);
+          this.gateApprovedPids.delete(pid);
+          this.clearUinGate(pid);
+          this.bridgeManager.onHookLogin(pid, uin, sender);
+          return;
+        }
+        this.log.warn('hook uin-gate post-login denied: pid=%d uin=%s mode=%s -> blocking injection', pid, String(uin), this.uinFilter.mode);
+        this.gateApprovedPids.delete(pid);
+        this.clearUinGate(pid);
+        try {
+          this.bridgeManager.onPidDisconnected(pid);
+        } catch { void 0; }
+        this.forceSessionAvailable(pid);
+        const state = { startedAt: Date.now(), timer: null, phase: 'denied' as const, lastCheckedUin: String(uin) };
+        this.uinGateState.set(pid, state);
+        this.scheduleUinGateProbe(pid, UIN_GATE_DENIED_RECHECK_MS);
+        return;
+      }
+      if (this.gateApprovedPids.has(pid)) this.gateApprovedPids.delete(pid);
+      this.manualLoadPids.delete(pid);
+      this.clearUinGate(pid);
       this.bridgeManager.onHookLogin(pid, uin, sender);
     });
     session.on('disconnected', (wasLoggedIn: boolean) => {

--- a/packages/bridge/tests/qq-port-probe.test.ts
+++ b/packages/bridge/tests/qq-port-probe.test.ts
@@ -53,8 +53,13 @@ describe('probeQqLoginInfo — bounded execution', () => {
           stderr: '',
         });
       })
-      .mockImplementationOnce((_command, _options, callback) => {
-        callback(null, { stdout: '8\n', stderr: '' });
+      .mockImplementationOnce((command: string, _options, callback) => {
+        if (String(command).includes('tasklist')) {
+          // Windows: tasklist output is filtered by "qq.exe" lines
+          callback(null, { stdout: 'qq.exe\n'.repeat(8), stderr: '' });
+        } else {
+          callback(null, { stdout: '8\n', stderr: '' });
+        }
       });
 
     await expect(probeQqLoginInfo(4242)).resolves.toBeNull();

--- a/packages/common/src/runtime.ts
+++ b/packages/common/src/runtime.ts
@@ -1,6 +1,14 @@
 import fs from 'fs';
 import path from 'path';
 
+export type HookUinFilterMode = 'off' | 'whitelist' | 'blacklist';
+export interface HookUinFilter {
+  mode: HookUinFilterMode;
+  whitelist: string[];
+  blacklist: string[];
+  /** Max time to wait for login before switching to low-frequency monitor. 0 = unlimited. */
+  maxWaitMs: number;
+}
 export interface RuntimeConfig {
   webuiPort?: number;
   /** When true, every newly-discovered QQ process gets auto-injected by
@@ -22,6 +30,9 @@ export interface RuntimeConfig {
   logRetainDays?: number;
   /** Duplicate UIN-scoped lines into logs/<uin>/ in addition to the shared log. */
   logPerUin?: boolean;
+  /** UIN allow/deny gate for auto-injection. When active, newly-discovered
+   * QQ processes are probed for their logged-in UIN before injection. */
+  hookUinFilter?: HookUinFilter;
 }
 
 const CONFIG_DIR = 'config';
@@ -36,6 +47,79 @@ export const MAX_LOG_TOTAL_MB = Math.floor(Number.MAX_SAFE_INTEGER / (1024 * 102
 export const MAX_LOG_RETAIN_DAYS = Math.floor(
   Number.MAX_SAFE_INTEGER / (24 * 60 * 60 * 1000),
 );
+export const MAX_HOOK_UIN_FILTER_WAIT_MS = 3_600_000;
+export const HOOK_UIN_FILTER_MODES = new Set<HookUinFilterMode>(['off', 'whitelist', 'blacklist']);
+const UIN_REGEX = /^\d{5,10}$/;
+
+export function defaultHookUinFilter(): HookUinFilter {
+  return { mode: 'off', whitelist: [], blacklist: [], maxWaitMs: 0 };
+}
+
+function normalizeUinList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of value) {
+    let v: string;
+    if (typeof item === 'string') v = item.trim();
+    else if (typeof item === 'number' && Number.isFinite(item)) v = String(Math.trunc(item));
+    else continue;
+    if (!v || !UIN_REGEX.test(v) || seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+  }
+  return out;
+}
+
+export function normalizeHookUinFilter(value: unknown): HookUinFilter {
+  if (!isObject(value)) return defaultHookUinFilter();
+  const rawMode = typeof (value as Record<string, unknown>).mode === 'string'
+    ? String((value as Record<string, unknown>).mode).trim().toLowerCase()
+    : 'off';
+  const mode: HookUinFilterMode = (HOOK_UIN_FILTER_MODES as Set<string>).has(rawMode)
+    ? (rawMode as HookUinFilterMode)
+    : 'off';
+  const whitelist = normalizeUinList((value as Record<string, unknown>).whitelist);
+  const blacklist = normalizeUinList((value as Record<string, unknown>).blacklist);
+  let maxWaitMs = 0;
+  const rawWait = (value as Record<string, unknown>).maxWaitMs;
+  if (rawWait !== undefined) {
+    const n = typeof rawWait === 'string' && (rawWait as string).trim()
+      ? Number((rawWait as string).trim())
+      : (rawWait as number);
+    if (typeof n === 'number' && Number.isFinite(n)) {
+      const clamped = Math.trunc(n);
+      if (clamped >= 0 && clamped <= MAX_HOOK_UIN_FILTER_WAIT_MS) maxWaitMs = clamped;
+      else if (clamped < 0) maxWaitMs = 0;
+      else maxWaitMs = MAX_HOOK_UIN_FILTER_WAIT_MS;
+    }
+  }
+  return { mode, whitelist, blacklist, maxWaitMs };
+}
+
+function isEqualHookUinFilter(a: HookUinFilter, b: HookUinFilter): boolean {
+  if (a.mode !== b.mode || a.maxWaitMs !== b.maxWaitMs) return false;
+  if (a.whitelist.length !== b.whitelist.length || a.blacklist.length !== b.blacklist.length) return false;
+  for (let i = 0; i < a.whitelist.length; i++) if (a.whitelist[i] !== b.whitelist[i]) return false;
+  for (let i = 0; i < a.blacklist.length; i++) if (a.blacklist[i] !== b.blacklist[i]) return false;
+  return true;
+}
+
+export function isHookUinFilterActive(filter?: HookUinFilter | null): boolean {
+  if (!filter || filter.mode === 'off') return false;
+  if (filter.mode === 'whitelist') return filter.whitelist.length > 0;
+  if (filter.mode === 'blacklist') return filter.blacklist.length > 0;
+  return false;
+}
+
+export function isUinAllowedByFilter(filter: HookUinFilter | undefined | null, uin: string | number): boolean {
+  if (!filter || filter.mode === 'off') return true;
+  const s = String(uin ?? '').trim();
+  if (!UIN_REGEX.test(s)) return false;
+  if (filter.mode === 'whitelist') return filter.whitelist.includes(s);
+  if (filter.mode === 'blacklist') return !filter.blacklist.includes(s);
+  return true;
+}
 
 /**
  * Pure on-disk-object → typed config normalization (defaults + validation,
@@ -64,6 +148,7 @@ export function normalizeRuntimeConfig(parsed: unknown): RuntimeConfig {
       'logRetainDays',
     ),
     logPerUin: normalizeRequiredBool(obj.logPerUin, DEFAULT_LOG_PER_UIN, 'logPerUin'),
+    hookUinFilter: normalizeHookUinFilter(obj.hookUinFilter),
   };
 }
 
@@ -182,6 +267,9 @@ function saveRuntimeConfig(config: RuntimeConfig): void {
  *  on every known field (so we can skip a needless rewrite). */
 function sameRuntimeConfig(parsed: Record<string, unknown>, n: RuntimeConfig): boolean {
   const parsedTls = isObject(parsed.webuiTls) ? parsed.webuiTls.enabled : undefined;
+  const parsedFilter = normalizeHookUinFilter(parsed.hookUinFilter);
+  const nFilter = n.hookUinFilter ?? defaultHookUinFilter();
+  if (!isEqualHookUinFilter(parsedFilter, nFilter)) return false;
   return (
     parsed.webuiPort === n.webuiPort
     && parsed.hookAutoLoad === n.hookAutoLoad

--- a/packages/common/tests/runtime.test.ts
+++ b/packages/common/tests/runtime.test.ts
@@ -14,6 +14,7 @@ describe('normalizeRuntimeConfig', () => {
       logMaxTotalMb: 1024,
       logRetainDays: 7,
       logPerUin: false,
+      hookUinFilter: { mode: 'off', whitelist: [], blacklist: [], maxWaitMs: 0 },
     });
   });
 
@@ -36,6 +37,7 @@ describe('normalizeRuntimeConfig', () => {
       logMaxTotalMb: 2048,
       logRetainDays: 0,
       logPerUin: true,
+      hookUinFilter: { mode: 'off', whitelist: [], blacklist: [], maxWaitMs: 0 },
     });
   });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_LOG_MAX_TOTAL_MB,
   DEFAULT_LOG_PER_UIN,
   DEFAULT_LOG_RETAIN_DAYS,
+  isHookUinFilterActive,
   loadRuntimeConfig,
 } from '@snowluma/common/runtime';
 import { OneBotManager } from '@snowluma/onebot/manager';
@@ -69,10 +70,17 @@ async function main() {
   const hookManager = new HookManager({
     bridgeManager,
     autoLoadOnDiscovery,
+    uinFilter: runtimeConfig.hookUinFilter,
     onSessionsChanged: stateWiring.onSessionsChanged,
   });
   if (autoLoadOnDiscovery) {
     log.info('hook auto-load enabled: every discovered QQ process will be injected');
+  }
+  if (isHookUinFilterActive(runtimeConfig.hookUinFilter)) {
+    const f = runtimeConfig.hookUinFilter!;
+    log.info('hook uin-filter enabled: mode=%s whitelist=%j blacklist=%j maxWaitMs=%d', f.mode, f.whitelist, f.blacklist, f.maxWaitMs);
+  } else if (runtimeConfig.hookUinFilter && runtimeConfig.hookUinFilter.mode !== 'off') {
+    log.info('hook uin-filter configured but inactive (empty list): mode=%s', runtimeConfig.hookUinFilter.mode);
   }
 
   oneBotManager.bind(bridgeManager);

--- a/packages/core/src/webui/server.ts
+++ b/packages/core/src/webui/server.ts
@@ -1490,6 +1490,85 @@ export async function initWebUI(
     }
   });
 
+  app.get('/api/hook/uin-filter', (c) => {
+    try {
+      const cfg = readRuntimeConfig();
+      return c.json({ filter: cfg.hookUinFilter ?? { mode: 'off', whitelist: [], blacklist: [], maxWaitMs: 0 } });
+    } catch (err) {
+      log.warn('get uin-filter failed: %s', err instanceof Error ? err.message : String(err));
+      return c.json({ filter: { mode: 'off', whitelist: [], blacklist: [], maxWaitMs: 0 } });
+    }
+  });
+
+  app.post('/api/hook/uin-filter', async (c) => {
+    if (!hookManager) return c.json({ success: false, message: 'hook manager is not available' }, 503);
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ success: false, message: 'invalid json' }, 400);
+    }
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return c.json({ success: false, message: 'body must be an object' }, 400);
+    }
+    const b = body as Record<string, unknown>;
+    const modeRaw = typeof b.mode === 'string' ? String(b.mode).trim().toLowerCase() : 'off';
+    if (!['off', 'whitelist', 'blacklist'].includes(modeRaw)) {
+      return c.json({ success: false, message: 'mode must be off | whitelist | blacklist' }, 400);
+    }
+    const mode = modeRaw as 'off' | 'whitelist' | 'blacklist';
+    function normalizeList(value: unknown, field: string): string[] | { error: string } {
+      if (value === undefined) return [];
+      if (!Array.isArray(value)) return { error: `${field} must be an array` };
+      const seen = new Set<string>();
+      const out: string[] = [];
+      for (const item of value) {
+        let v: string;
+        if (typeof item === 'string') v = item.trim();
+        else if (typeof item === 'number' && Number.isFinite(item)) v = String(Math.trunc(item));
+        else return { error: `${field} entries must be strings or numbers` };
+        if (!v) continue;
+        if (!UIN_REGEX.test(v)) return { error: `${field} entry "${v}" is not a valid UIN (5-10 digits)` };
+        if (seen.has(v)) continue;
+        seen.add(v);
+        out.push(v);
+      }
+      return out;
+    }
+    const wlRaw = normalizeList(b.whitelist, 'whitelist');
+    if (typeof wlRaw === 'object' && 'error' in (wlRaw as Record<string, unknown>)) {
+      return c.json({ success: false, message: (wlRaw as { error: string }).error }, 400);
+    }
+    const blRaw = normalizeList(b.blacklist, 'blacklist');
+    if (typeof blRaw === 'object' && 'error' in (blRaw as Record<string, unknown>)) {
+      return c.json({ success: false, message: (blRaw as { error: string }).error }, 400);
+    }
+    const whitelist = wlRaw as string[];
+    const blacklist = blRaw as string[];
+    let maxWaitMs = 0;
+    if (b.maxWaitMs !== undefined) {
+      const raw = b.maxWaitMs;
+      const n = typeof raw === 'string' && (raw as string).trim() ? Number((raw as string).trim()) : (raw as number);
+      if (typeof n !== 'number' || !Number.isFinite(n) || !Number.isInteger(n) || n < 0 || n > 3_600_000) {
+        return c.json({ success: false, message: 'maxWaitMs must be an integer in 0..3600000 (0 = unlimited)' }, 400);
+      }
+      maxWaitMs = n;
+    }
+    const filter = { mode, whitelist, blacklist, maxWaitMs };
+    try {
+      const saved = updateRuntimeConfig({ hookUinFilter: filter } as unknown as Record<string, unknown>);
+      try {
+        (hookManager as unknown as { setUinFilter?: (f: unknown) => void }).setUinFilter?.(saved.hookUinFilter);
+      } catch (e) {
+        log.warn('setUinFilter apply failed: %s', e instanceof Error ? e.message : String(e));
+      }
+      return c.json({ success: true, filter: saved.hookUinFilter });
+    } catch (err) {
+      log.warn('save uin-filter failed: %s', err instanceof Error ? err.message : String(err));
+      return c.json({ success: false, message: 'save failed' }, 500);
+    }
+  });
+
   app.get('/api/config/:uin', (c) => {
     const uin = c.req.param('uin');
     if (!UIN_REGEX.test(uin)) return c.json({ message: 'invalid uin' }, 400);


### PR DESCRIPTION
## 做了什么

鉴于在多QQ进程的情况下，即同时登录多个qq（小号、大号、工作号），在开了自动注入hookAutoLoad后会把本机所有QQ进程全给注入了；因此在runtime.json中加了个匹配qq号（UIN）的黑白名单，用法：
```
{
  "rkey": { ... },
  "musicSignUrl": "",
  "uinFilter": {
    "mode": "whitelist",          // off=不过滤(现状) | whitelist=仅注入白名单 | blacklist=拒绝黑名单
    "whitelist": ["1234567"],        // UIN 字符串数组，去重、纯数字校验
    "blacklist": [],
    "maxWaitMs": 0          // 等待登录的超时：0=一直探测直到登录；>0=超时后转入低频监视
  }
}
```
验证环境：win11  SnowLuma-v1.14.12-win-x64-lite

---

## Summary

- **common/runtime**: 新增 `HookUinFilter`（`mode: off|whitelist|blacklist`，`whitelist/blacklist: string[]`，`maxWaitMs`）及 `normalizeHookUinFilter`/`isHookUinFilterActive`/`isUinAllowedByFilter`/`defaultHookUinFilter`，`normalizeRuntimeConfig`/`sameRuntimeConfig` 兼容旧 `runtime.json`（缺省回退为 `off`），`updateRuntimeConfig` 原子写回。配置落盘于 `config/runtime.json:hookUinFilter`，符合“新增字段向后兼容、解析时归一化、写回磁盘”要求。
- **bridge/hook-manager**: 自动注入（`hookAutoLoad`）前置门禁。`process-discovered` 时若 `isHookUinFilterActive` 则 `startUinGate` 轮询 `probeQqLoginInfo`（免注入 `pt_get_uins`）至 `identityKnown && isRealUin`，`whitelist` 仅放行名单内、`blacklist` 拒绝名单内；`maxWaitMs=0` 一直等登录，`>0` 超时转 30s 低频监视。`pipe-up`/`tick` 对 `denied` 拦截重连，`forceSessionAvailable` 置 `available` 并清 `livePipes` 以在 WebUI 呈现为未注入（而非仅断开连接）。`login` 事件二次校验，`manualLoadPids` 区分手动 `loadProcess` bypass。`setUinFilter` 热更新时对存量在线/已注入非允许会话强制下线并入 `denied` 监视。
- **core/index**: 将 `runtimeConfig.hookUinFilter` 注入 `HookManager`，启动日志按 `isHookUinFilterActive` 区分 `enabled`/`configured but inactive`。
- **core/webui/server**: 新增 `GET /api/hook/uin-filter` 与 `POST /api/hook/uin-filter`（`UIN_REGEX` 5-10 位校验、数字/字符串兼容、去重、`maxWaitMs` 0..3600000），`updateRuntimeConfig` + `hookManager.setUinFilter` 热生效。
- **tests**: `common/tests/runtime.test.ts` 更新期望；`bridge/tests/qq-port-probe.test.ts` 修复 Windows `tasklist` mock。

## Verification

- `pnpm typecheck` 全仓通过
- `pnpm --filter @snowluma/common exec vitest` 168 passed
- `pnpm --filter @snowluma/bridge exec vitest` 194 passed
- 本地以 `runtime.json:hookUinFilter={mode:whitelist,whitelist:["3187548714"]}` 重启验证：仅 `PID 31908 (318...)` 注入并 `OneBot session started`，`PID 31584 (216...)` 经 `post-login denied -> forcing uninjected` 后 `pipe-up blocked`，WebUI 进程页仅前者在线，后者 `available` 低频监视。

## Notes

- 未绕过 `BridgeManager`，一律经 `BridgeInterface`；原生模块分发路径未改。
- 手动 `POST /api/processes/:pid/load` 仍 bypass 过滤，符合既有 `shouldAutoLoadPid` 语义。
