### PR TITLE
feat(onebot): 新增企点标志到群成员信息接口

### DIFF
--- a/packages/mcp/src/generated/catalog.json
+++ b/packages/mcp/src/generated/catalog.json
@@ -5314,6 +5314,18 @@
           "card_changeable": {
             "type": "boolean",
             "description": "是否可改名片（占位，恒 true）"
+          },
+          "qidian_master_flag": {
+            "type": "integer",
+            "description": "企点主号标志，0 或 1；普通账号为 0"
+          },
+          "qidian_crew_flag": {
+            "type": "integer",
+            "description": "企点员工标志，0 或 1；普通账号为 0"
+          },
+          "qidian_crew_flag_2": {
+            "type": "integer",
+            "description": "企点保留标志，0 或 1；普通账号为 0"
           }
         },
         "required": [
@@ -5473,6 +5485,18 @@
             "card_changeable": {
               "type": "boolean",
               "description": "是否可改名片（占位，恒 true）"
+            },
+            "qidian_master_flag": {
+              "type": "integer",
+              "description": "企点主号标志，0 或 1；普通账号为 0"
+            },
+            "qidian_crew_flag": {
+              "type": "integer",
+              "description": "企点员工标志，0 或 1；普通账号为 0"
+            },
+            "qidian_crew_flag_2": {
+              "type": "integer",
+              "description": "企点保留标志，0 或 1；普通账号为 0"
             }
           },
           "required": [

--- a/packages/mcp/src/generated/catalog.ts
+++ b/packages/mcp/src/generated/catalog.ts
@@ -5317,6 +5317,18 @@ export const ACTIONS: CatalogAction[] = [
         "card_changeable": {
           "type": "boolean",
           "description": "是否可改名片（占位，恒 true）"
+        },
+        "qidian_master_flag": {
+          "type": "integer",
+          "description": "企点主号标志，0 或 1；普通账号为 0"
+        },
+        "qidian_crew_flag": {
+          "type": "integer",
+          "description": "企点员工标志，0 或 1；普通账号为 0"
+        },
+        "qidian_crew_flag_2": {
+          "type": "integer",
+          "description": "企点保留标志，0 或 1；普通账号为 0"
         }
       },
       "required": [
@@ -5476,6 +5488,18 @@ export const ACTIONS: CatalogAction[] = [
           "card_changeable": {
             "type": "boolean",
             "description": "是否可改名片（占位，恒 true）"
+          },
+          "qidian_master_flag": {
+            "type": "integer",
+            "description": "企点主号标志，0 或 1；普通账号为 0"
+          },
+          "qidian_crew_flag": {
+            "type": "integer",
+            "description": "企点员工标志，0 或 1；普通账号为 0"
+          },
+          "qidian_crew_flag_2": {
+            "type": "integer",
+            "description": "企点保留标志，0 或 1；普通账号为 0"
           }
         },
         "required": [

--- a/packages/onebot/src/actions/group-info.ts
+++ b/packages/onebot/src/actions/group-info.ts
@@ -115,6 +115,9 @@ export const actions = [
           unfriendly: { type: 'boolean', description: '是否不良记录（QQ NT 不提供，恒 false）' },
           title_expire_time: { type: 'integer', description: '头衔过期时间戳（QQ NT 不提供，恒 0）' },
           card_changeable: { type: 'boolean', description: '是否可改名片（占位，恒 true）' },
+          qidian_master_flag: { type: 'integer', description: '企点主号标志，0 或 1；普通账号为 0' },
+          qidian_crew_flag: { type: 'integer', description: '企点员工标志，0 或 1；普通账号为 0' },
+          qidian_crew_flag_2: { type: 'integer', description: '企点保留标志，0 或 1；普通账号为 0' },
         },
         required: ['group_id', 'user_id', 'nickname', 'role'],
       },
@@ -155,6 +158,9 @@ export const actions = [
         unfriendly: { type: 'boolean', description: '是否不良记录（QQ NT 不提供，恒 false）' },
         title_expire_time: { type: 'integer', description: '头衔过期时间戳（QQ NT 不提供，恒 0）' },
         card_changeable: { type: 'boolean', description: '是否可改名片（占位，恒 true）' },
+        qidian_master_flag: { type: 'integer', description: '企点主号标志，0 或 1；普通账号为 0' },
+        qidian_crew_flag: { type: 'integer', description: '企点员工标志，0 或 1；普通账号为 0' },
+        qidian_crew_flag_2: { type: 'integer', description: '企点保留标志，0 或 1；普通账号为 0' },
       },
       required: ['group_id', 'user_id', 'nickname', 'role'],
     },
@@ -171,6 +177,7 @@ export const actions = [
           sex: 'unknown', age: 0, join_time: 0, last_sent_time: 0,
           shut_up_timestamp: 0,
           level: '0', role: 'member', title: '',
+          qidian_master_flag: 0, qidian_crew_flag: 0, qidian_crew_flag_2: 0,
         });
       }
       return okResponse({

--- a/packages/onebot/src/modules/contact-actions.ts
+++ b/packages/onebot/src/modules/contact-actions.ts
@@ -1,7 +1,6 @@
 import { mapWithConcurrency } from '@snowluma/common/concurrency';
 import { createLogger } from '@snowluma/common/logger';
 import type { BridgeInterface } from '@snowluma/core/bridge-interface';
-import type { IdentityService } from '@snowluma/protocol/identity-service';
 import {
   formatGroupRequestFlag,
   type GroupMemberInfo,
@@ -211,12 +210,12 @@ export async function getGroupMemberList(
 ): Promise<JsonObject[]> {
   if (noCache) {
     const members = await fetchSingleGroupMembers(bridge, groupId, true);
-    return members.map(m => formatGroupMember(groupId, m));
+    return members.map(m => formatGroupMember(groupId, m, cachedQidianProfile(bridge, m.uin)));
   }
 
   try {
     const members = await bridge.apis.contacts.fetchGroupMemberList(groupId);
-    return members.map(m => formatGroupMember(groupId, m));
+    return members.map(m => formatGroupMember(groupId, m, cachedQidianProfile(bridge, m.uin)));
   } catch (err) {
     log.warn(
       'group member fetch failed, using classified cache: uin=%s group=%d err=%s',
@@ -224,7 +223,7 @@ export async function getGroupMemberList(
       groupId,
       err instanceof Error ? (err.stack ?? err.message) : String(err),
     );
-    const cached = getCachedGroupMembers(bridge.identity, groupId);
+    const cached = getCachedGroupMembers(bridge, groupId);
     if (cached.length === 0) throw err;
     return cached;
   }
@@ -242,7 +241,17 @@ export async function getGroupMemberInfo(
   }
   const m = bridge.identity.findGroupMember(groupId, userId);
   if (!m) return null;
-  return formatGroupMember(groupId, m);
+  // 企点标志（#404 后续 PR）：优先读身份缓存，无缓存时再按需拉取一次用户资料。
+  // 均为 best-effort —— 失败时回退为 0，不影响成员信息主流程。
+  let profile = cachedQidianProfile(bridge, userId);
+  if (!profile) {
+    try {
+      profile = await bridge.apis.contacts.fetchUserProfile(userId);
+    } catch {
+      // profile enrichment is best-effort; fall back to all-zero flags
+    }
+  }
+  return formatGroupMember(groupId, m, profile ?? undefined);
 }
 
 export async function getGroupFiles(
@@ -492,12 +501,12 @@ export async function getDownloadRKeys(bridge: BridgeInterface): Promise<JsonObj
   }
 }
 
-function getCachedGroupMembers(identity: IdentityService, groupId: number): JsonObject[] {
-  const g = identity.findGroup(groupId);
+function getCachedGroupMembers(bridge: BridgeInterface, groupId: number): JsonObject[] {
+  const g = bridge.identity.findGroup(groupId);
   if (!g) return [];
   const result: JsonObject[] = [];
   for (const [, member] of g.members) {
-    result.push(formatGroupMember(groupId, member));
+    result.push(formatGroupMember(groupId, member, cachedQidianProfile(bridge, member.uin)));
   }
   return result;
 }
@@ -505,6 +514,7 @@ function getCachedGroupMembers(identity: IdentityService, groupId: number): Json
 function formatGroupMember(
   groupId: number,
   member: GroupMemberInfo,
+  profile?: UserProfileInfo,
 ): JsonObject {
   if (member.isRobot === undefined) {
     throw new Error(
@@ -532,5 +542,24 @@ function formatGroupMember(
     unfriendly: false,
     title_expire_time: 0,
     card_changeable: true,
+    // 企点标志（#404 后续 PR）：群成员信息同样透传用户资料上的企点标志，
+    // 未查到资料时全部为 0（普通账号）。
+    qidian_master_flag: profile?.qidianMasterFlag ?? 0,
+    qidian_crew_flag: profile?.qidianCrewFlag ?? 0,
+    qidian_crew_flag_2: profile?.qidianCrewFlag2 ?? 0,
   };
+}
+
+/** Best-effort read of a cached user profile's qidian flags. Triggers no
+ *  network call — only the identity cache (populated by fetchUserProfile /
+ *  fetchUserProfileByUid). */
+function cachedQidianProfile(bridge: BridgeInterface, uin: number): UserProfileInfo | undefined {
+  try {
+    if ('findUserProfile' in bridge.identity) {
+      return bridge.identity.findUserProfile(uin) ?? undefined;
+    }
+  } catch {
+    // profile cache lookup is best-effort; fall back to all-zero flags
+  }
+  return undefined;
 }

--- a/packages/onebot/tests/contact-actions.test.ts
+++ b/packages/onebot/tests/contact-actions.test.ts
@@ -510,6 +510,54 @@ describe('onebot/contact-actions / getGroupMemberInfo', () => {
     expect(out).toMatchObject({ user_id: 66, is_robot: true });
   });
 
+  it('passes through the qidian (企点) flags from the member profile', async () => {
+    const member = makeMember(88, 'QidianMember', 'Q');
+    const bridge = fakeBridge({
+      fetchGroupMemberList: vi.fn(async () => []),
+      identity: fakeIdentity({
+        findGroupMember: (gid: number, uin: number) =>
+          gid === 1400 && uin === 88 ? member : null,
+      }),
+      fetchUserProfile: vi.fn(async () => ({
+        ...makeProfile(88, 'QidianMember', 'male'),
+        qidianMasterFlag: 0,
+        qidianCrewFlag: 1,
+        qidianCrewFlag2: 0,
+      })),
+    });
+
+    const out = await getGroupMemberInfo(bridge, 1400, 88);
+
+    expect(out).toMatchObject({
+      user_id: 88,
+      qidian_master_flag: 0,
+      qidian_crew_flag: 1,
+      qidian_crew_flag_2: 0,
+    });
+    expect(bridge.apis.contacts.fetchUserProfile).toHaveBeenCalledWith(88);
+  });
+
+  it('falls back to zero qidian flags when the profile fetch fails', async () => {
+    const member = makeMember(89, 'NoProfileMember', 'N');
+    const bridge = fakeBridge({
+      fetchGroupMemberList: vi.fn(async () => []),
+      identity: fakeIdentity({
+        findGroupMember: (gid: number, uin: number) =>
+          gid === 1500 && uin === 89 ? member : null,
+      }),
+      fetchUserProfile: vi.fn(async () => { throw new Error('net down'); }),
+    });
+
+    const out = await getGroupMemberInfo(bridge, 1500, 89);
+
+    expect(out).toMatchObject({
+      user_id: 89,
+      qidian_master_flag: 0,
+      qidian_crew_flag: 0,
+      qidian_crew_flag_2: 0,
+    });
+  });
+
   it('rejects when an unknown cached classification cannot be refreshed', async () => {
     const member: GroupMemberInfo = { ...makeMember(77, 'unknown'), isRobot: undefined };
     const bridge = fakeBridge({

--- a/packages/onebot/tests/group-info-actions.test.ts
+++ b/packages/onebot/tests/group-info-actions.test.ts
@@ -116,4 +116,15 @@ describe('group information actions', () => {
       data: { user_id: 654323, shut_up_timestamp: 0 },
     });
   });
+
+  it('documents qidian flags on both member-list and single-member results', () => {
+    const listSchema = getGroupMemberList.describe().returnsSchema;
+    const infoSchema = getGroupMemberInfo.describe().returnsSchema;
+
+    for (const schema of [listSchema?.items?.properties, infoSchema?.properties]) {
+      expect(schema).toHaveProperty('qidian_master_flag');
+      expect(schema).toHaveProperty('qidian_crew_flag');
+      expect(schema).toHaveProperty('qidian_crew_flag_2');
+    }
+  });
 });

--- a/packages/onebot/tests/instance-context.test.ts
+++ b/packages/onebot/tests/instance-context.test.ts
@@ -775,6 +775,9 @@ describe('buildApiContext contact reads', () => {
       unfriendly: false,
       title_expire_time: 0,
       card_changeable: true,
+      qidian_master_flag: 0,
+      qidian_crew_flag: 0,
+      qidian_crew_flag_2: 0,
     }]);
     await expect(api.getGroupMemberInfo(710503, 20002)).resolves.toMatchObject({
       group_id: 710503,


### PR DESCRIPTION
<!-- 感谢贡献。请填写以下内容，方便评审。 -->

## 关联 Issue

#404

## 变更说明

- `get_group_member_info`：在命中成员后，优先读身份缓存里的 `UserProfileInfo`；无缓存时 best-effort 调一次 `contacts.fetchUserProfile`（即已带企点标志的 OIDB 0xFE1_2），把 `qidian_master_flag / qidian_crew_flag / qidian_crew_flag_2` 透传出来。任一环节失败都回退为 0（普通账号），不影响成员信息主流程。
- `get_group_member_list`：只读身份缓存（避免对整份成员列表做 N+1 拉取，也规避 Tencent 风控），命中资料则透传企点标志，否则为 0。
- 更新 `get_group_member_info` / `get_group_member_list` 的 `returnsSchema` 与 fallback 数据。
- 重新生成 MCP 目录（`catalog.json` / `catalog.ts`）。
- 补充/更新测试：`contact-actions.test.ts`（企点标志透传 / 拉取失败回退 0）、`group-info-actions.test.ts`（schema 断言）、`instance-context.test.ts`（成员列表输出补齐企点字段）。

## 提交前检查

- [x] 本 PR 聚焦单一目标，未夹带无关改动
- [x] 已通过 `pnpm lint` 与 `pnpm typecheck`（已跑：变更文件的 `eslint`；`@snowluma/onebot` 与 `@snowluma/mcp` 的 `tsc --noEmit`。未跑全工作区 `pnpm lint` / 全仓库 `pnpm typecheck`，如 CI 需要可补跑。）
- [x] 已补充/更新相关测试，且 `pnpm test` 通过（定向 `contact-actions / group-info-actions / instance-context / friend-actions` 共 98 个用例通过；全量 onebot 仍有两个与本改动无关的既有失败：`stream-download.test.ts` 的 `ctx.getImageInfo is not a function`、`message-store-migration-worker.test.ts` 的 Windows `EBUSY` 竞态。）
- [x] 文件行尾为 LF（未引入 CRLF）
- [x] PR 描述与实际实现一致