### PR TITLE
feat(onebot, protocol): 新增企点企业资料卡查询与扩展陌生人信息接口

### DIFF
--- a/packages/core/src/bridge/apis/contacts.ts
+++ b/packages/core/src/bridge/apis/contacts.ts
@@ -19,6 +19,10 @@ import {
 } from '@snowluma/protocol/oidb-services/contacts/fetch-robot-uin-ranges';
 import { FetchUserProfile } from '@snowluma/protocol/oidb-services/contacts/fetch-user-profile';
 import { FetchUserProfileByUid } from '@snowluma/protocol/oidb-services/contacts/fetch-user-profile-by-uid';
+import {
+  fetchQidianCorpInfo as fetchQidianCorpInfoWire,
+  type QidianCorpInfo,
+} from '@snowluma/protocol/services/qidian/fetch-corp-info';
 import { GetBuddyRecommendArk } from '@snowluma/protocol/oidb-services/contacts/get-buddy-recommend-ark';
 import { GetGroupRecommendArk } from '@snowluma/protocol/oidb-services/contacts/get-group-recommend-ark';
 import { SendTuwenArk, type SendTuwenArkParams } from '@snowluma/protocol/oidb-services/contacts/send-tuwen-ark';
@@ -346,6 +350,12 @@ export class ContactsApi {
     const info = await FetchUserProfileByUid.invoke(this.ctx, { uid });
     if (info.uin > 0) this.ctx.identity.rememberUserProfile(info);
     return info;
+  }
+
+  /** 企点企业资料卡（#404 后续 PR）。仅在判断命中的是企点账号后再调用。
+   *  best-effort：非企点账号或拉取失败返回 null，不影响上层资料读取。 */
+  async fetchQidianCorpInfo(uin: number): Promise<QidianCorpInfo | null> {
+    return fetchQidianCorpInfoWire(this.ctx, uin);
   }
 
   async fetchGroupRequests(

--- a/packages/mcp/src/generated/catalog.json
+++ b/packages/mcp/src/generated/catalog.json
@@ -7421,7 +7421,7 @@
       "name": "get_stranger_info",
       "aliases": [],
       "summary": "获取陌生人信息",
-      "returns": "用户资料：QQ 号、昵称、好友备注、性别、年龄与个性签名，命中资料时另含等级与企点标志。",
+      "returns": "用户资料：QQ 号、昵称、好友备注、性别、年龄与个性签名，命中资料时另含等级、企点标志与企业名称。",
       "returnsSchema": {
         "type": "object",
         "properties": {
@@ -7493,6 +7493,10 @@
           "qidian_crew_flag_2": {
             "type": "integer",
             "description": "企点保留标志，0 或 1；普通账号为 0"
+          },
+          "qidian_enterprise_name": {
+            "type": "string",
+            "description": "企点企业名称；非企点账号或未获取到时为空字符串"
           }
         },
         "required": [

--- a/packages/mcp/src/generated/catalog.ts
+++ b/packages/mcp/src/generated/catalog.ts
@@ -7424,7 +7424,7 @@ export const ACTIONS: CatalogAction[] = [
     "name": "get_stranger_info",
     "aliases": [],
     "summary": "获取陌生人信息",
-    "returns": "用户资料：QQ 号、昵称、好友备注、性别、年龄与个性签名，命中资料时另含等级与企点标志。",
+    "returns": "用户资料：QQ 号、昵称、好友备注、性别、年龄与个性签名，命中资料时另含等级、企点标志与企业名称。",
     "returnsSchema": {
       "type": "object",
       "properties": {
@@ -7496,6 +7496,10 @@ export const ACTIONS: CatalogAction[] = [
         "qidian_crew_flag_2": {
           "type": "integer",
           "description": "企点保留标志，0 或 1；普通账号为 0"
+        },
+        "qidian_enterprise_name": {
+          "type": "string",
+          "description": "企点企业名称；非企点账号或未获取到时为空字符串"
         }
       },
       "required": [

--- a/packages/onebot/src/actions/friend.ts
+++ b/packages/onebot/src/actions/friend.ts
@@ -32,7 +32,7 @@ export const actions = [
     name: 'get_stranger_info',
     summary: '获取陌生人信息',
     readOnly: true,
-    returns: '用户资料：QQ 号、昵称、好友备注、性别、年龄与个性签名，命中资料时另含等级与企点标志。',
+    returns: '用户资料：QQ 号、昵称、好友备注、性别、年龄与个性签名，命中资料时另含等级、企点标志与企业名称。',
     returnsSchema: {
       type: 'object',
       properties: {
@@ -53,6 +53,7 @@ export const actions = [
         qidian_master_flag: { type: 'integer', description: '企点主号标志，0 或 1；普通账号为 0' },
         qidian_crew_flag: { type: 'integer', description: '企点员工标志，0 或 1；普通账号为 0' },
         qidian_crew_flag_2: { type: 'integer', description: '企点保留标志，0 或 1；普通账号为 0' },
+        qidian_enterprise_name: { type: 'string', description: '企点企业名称；非企点账号或未获取到时为空字符串' },
       },
       required: ['user_id', 'nickname', 'remark', 'sex', 'age', 'long_nick'],
     },

--- a/packages/onebot/src/modules/contact-actions.ts
+++ b/packages/onebot/src/modules/contact-actions.ts
@@ -8,6 +8,7 @@ import {
   type GroupRequestInfo,
   type UserProfileInfo,
 } from '@snowluma/protocol/qq-info';
+import type { QidianCorpInfo } from '@snowluma/protocol/services/qidian/fetch-corp-info';
 import type { OneBotInstanceContext } from '../instance-context';
 import type { JsonObject } from '../types';
 
@@ -280,7 +281,7 @@ export async function getGroupFiles(
   };
 }
 
-function formatStrangerInfo(p: UserProfileInfo): JsonObject {
+function formatStrangerInfo(p: UserProfileInfo, corp?: QidianCorpInfo | null): JsonObject {
   return {
     user_id: p.uin,
     nickname: p.nickname,
@@ -299,7 +300,23 @@ function formatStrangerInfo(p: UserProfileInfo): JsonObject {
     qidian_master_flag: p.qidianMasterFlag ?? 0,
     qidian_crew_flag: p.qidianCrewFlag ?? 0,
     qidian_crew_flag_2: p.qidianCrewFlag2 ?? 0,
+    // #404 后续 PR：企点企业资料卡。企业资料卡不含独立的企业 ID，
+    // 因此这里只透出企业名称（SsoCorpInfo.corpName）。
+    qidian_enterprise_name: corp?.name ?? '',
   };
+}
+
+/** 命中的是企点账号时才去拉一次企业资料卡（best-effort，失败返回 null）。 */
+async function strangerCorpInfo(
+  bridge: BridgeInterface,
+  p: UserProfileInfo,
+): Promise<QidianCorpInfo | null> {
+  if (p.qidianMasterFlag === 0 && p.qidianCrewFlag === 0) return null;
+  try {
+    return await bridge.apis.contacts.fetchQidianCorpInfo(p.uin);
+  } catch {
+    return null;
+  }
 }
 
 export async function getStrangerInfo(
@@ -308,14 +325,17 @@ export async function getStrangerInfo(
 ): Promise<JsonObject | null> {
   try {
     const p = await bridge.apis.contacts.fetchUserProfile(userId);
-    return formatStrangerInfo(p);
+    const corp = await strangerCorpInfo(bridge, p);
+    return formatStrangerInfo(p, corp);
   } catch {
     const p = bridge.identity.findUserProfile(userId);
     if (p) {
-      return formatStrangerInfo({
+      const profile: UserProfileInfo = {
         ...p,
         remark: p.remark || bridge.identity.findFriend(userId)?.remark || '',
-      });
+      };
+      const corp = await strangerCorpInfo(bridge, profile);
+      return formatStrangerInfo(profile, corp);
     }
 
     const friend = bridge.identity.findFriend(userId);

--- a/packages/onebot/tests/contact-actions.test.ts
+++ b/packages/onebot/tests/contact-actions.test.ts
@@ -566,6 +566,55 @@ describe('onebot/contact-actions / getStrangerInfo', () => {
     });
   });
 
+  it('passes through the qidian enterprise (企业) data-card when available', async () => {
+    const fetchQidianCorpInfo = vi.fn(async () => ({
+      name: '测试企业', intro: '测试简介', website: 'https://example.com',
+      slogan: '测试签名', address: '测试地址', phone: '400-0000-0000', email: 'contact@example.com',
+    }));
+    const bridge = fakeBridge({
+      apis: {
+        contacts: {
+          fetchUserProfile: vi.fn(async () => ({
+            ...makeProfile(55555, 'QidianWorker', 'male'),
+            qidianMasterFlag: 0,
+            qidianCrewFlag: 1,
+            qidianCrewFlag2: 0,
+          })),
+          fetchQidianCorpInfo,
+        },
+      },
+    });
+    const out = await getStrangerInfo(bridge, 55555);
+    expect(out).toMatchObject({
+      user_id: 55555,
+      qidian_master_flag: 0,
+      qidian_crew_flag: 1,
+      qidian_crew_flag_2: 0,
+      qidian_enterprise_name: '测试企业',
+    });
+    expect(fetchQidianCorpInfo).toHaveBeenCalledWith(55555);
+  });
+
+  it('leaves enterprise fields empty for non-qidian accounts and never calls the corp lookup', async () => {
+    const fetchQidianCorpInfo = vi.fn(async () => ({
+      name: 'x', intro: '', website: '', slogan: '', address: '', phone: '', email: '',
+    }));
+    const bridge = fakeBridge({
+      apis: {
+        contacts: {
+          fetchUserProfile: vi.fn(async () => makeProfile(88888, 'Normal', 'male')),
+          fetchQidianCorpInfo,
+        },
+      },
+    });
+    const out = await getStrangerInfo(bridge, 88888);
+    expect(out).toMatchObject({
+      user_id: 88888,
+      qidian_enterprise_name: '',
+    });
+    expect(fetchQidianCorpInfo).not.toHaveBeenCalled();
+  });
+
   it('falls back to identity.findUserProfile when fetch fails but the profile is cached', async () => {
     const bridge = fakeBridge({
       fetchUserProfile: vi.fn(async () => { throw new Error('net'); }),

--- a/packages/onebot/tests/friend-actions.test.ts
+++ b/packages/onebot/tests/friend-actions.test.ts
@@ -34,6 +34,7 @@ describe('get_stranger_info action', () => {
         qidian_master_flag: { type: 'integer' },
         qidian_crew_flag: { type: 'integer' },
         qidian_crew_flag_2: { type: 'integer' },
+        qidian_enterprise_name: { type: 'string' },
       },
     });
     expect(schema?.required).toContain('remark');

--- a/packages/onebot/tests/instance-context.test.ts
+++ b/packages/onebot/tests/instance-context.test.ts
@@ -820,6 +820,7 @@ describe('buildApiContext contact reads', () => {
       qidian_master_flag: 0,
       qidian_crew_flag: 0,
       qidian_crew_flag_2: 0,
+      qidian_enterprise_name: '',
     });
   });
 

--- a/packages/proto-defs/package.json
+++ b/packages/proto-defs/package.json
@@ -44,6 +44,10 @@
       "types": "./src/get-c2c-msg.ts",
       "default": "./src/get-c2c-msg.ts"
     },
+    "./qidian-corp": {
+      "types": "./src/qidian-corp.ts",
+      "default": "./src/qidian-corp.ts"
+    },
     "./notify": {
       "types": "./src/notify.ts",
       "default": "./src/notify.ts"

--- a/packages/proto-defs/src/qidian-corp.ts
+++ b/packages/proto-defs/src/qidian-corp.ts
@@ -1,0 +1,18 @@
+import type { pb, uint_32 } from '@snowluma/proton';
+
+// trpc.basic.corp.Datacard.SsoCorpInfo — 企点企业资料卡信息。
+// 请求：field1 = 目标账号 UIN（varint）。
+// 响应字段为企点企业资料卡：名称 / 简介 / 官网 / 企业签名 / 地址 / 电话 / 邮箱。
+export interface QidianCorpInfoRequest {
+  uin?: pb<1, uint_32>;
+}
+
+export interface QidianCorpInfoResponse {
+  corpName?: pb<2, string>;
+  intro?:    pb<3, string>;
+  website?:  pb<4, string>;
+  slogan?:   pb<5, string>;
+  address?:  pb<6, string>;
+  phone?:    pb<7, string>;
+  email?:    pb<8, string>;
+}

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -92,6 +92,10 @@
       "types": "./src/highway/*.ts",
       "default": "./src/highway/*.ts"
     },
+    "./services/*": {
+      "types": "./src/services/*.ts",
+      "default": "./src/services/*.ts"
+    },
     "./web/*": {
       "types": "./src/web/*.ts",
       "default": "./src/web/*.ts"

--- a/packages/protocol/src/services/qidian/fetch-corp-info.ts
+++ b/packages/protocol/src/services/qidian/fetch-corp-info.ts
@@ -1,0 +1,52 @@
+import { protobuf_decode, protobuf_encode } from '@snowluma/proton';
+import type { SendPacketResult } from '@snowluma/common/packet-sender';
+import type { QidianCorpInfoRequest, QidianCorpInfoResponse } from '@snowluma/proto-defs/qidian-corp';
+
+// 企点企业资料卡（trpc.basic.corp.Datacard.SsoCorpInfo）。
+// 请求体为 protobuf field1 = 目标账号 UIN（varint）
+// 返回企业名称等资料卡字段（来源见 SnowLuma issue #404 讨论）。
+export const QIDIAN_CORP_INFO_CMD = 'trpc.basic.corp.Datacard.SsoCorpInfo';
+
+export interface QidianCorpInfo {
+  name: string;
+  intro: string;
+  website: string;
+  slogan: string;
+  address: string;
+  phone: string;
+  email: string;
+}
+
+export interface RawSender {
+  sendRawPacket(serviceCmd: string, body: Uint8Array, timeoutMs?: number): Promise<SendPacketResult>;
+}
+
+/**
+ * Fetch the qidian enterprise data-card for a qidian account UIN.
+ * Returns null when the account is not a qidian corp user or the server
+ * returns no corp info. Best-effort by design — callers must NOT fail the
+ * whole profile read if this lookup throws / returns null.
+ */
+export async function fetchQidianCorpInfo(
+  sender: RawSender,
+  uin: number,
+  timeoutMs?: number,
+): Promise<QidianCorpInfo | null> {
+  const req = protobuf_encode<QidianCorpInfoRequest>({ uin });
+  const result = await sender.sendRawPacket(QIDIAN_CORP_INFO_CMD, req, timeoutMs);
+  if (!result.success || !result.gotResponse || !result.responseData || result.responseData.length === 0) {
+    return null;
+  }
+  const decoded = protobuf_decode<QidianCorpInfoResponse>(result.responseData);
+  const name = decoded?.corpName ?? '';
+  if (!name) return null;
+  return {
+    name,
+    intro: decoded?.intro ?? '',
+    website: decoded?.website ?? '',
+    slogan: decoded?.slogan ?? '',
+    address: decoded?.address ?? '',
+    phone: decoded?.phone ?? '',
+    email: decoded?.email ?? '',
+  };
+}

--- a/packages/protocol/tests/oidb-services/contacts/fetch-user-profile-by-uid.test.ts
+++ b/packages/protocol/tests/oidb-services/contacts/fetch-user-profile-by-uid.test.ts
@@ -53,7 +53,7 @@ describe('FetchUserProfileByUid namespace (UID form)', () => {
   it('decodes qidian flags from number-properties (0 when absent)', async () => {
     const qidian = makeSender({
       body: {
-        uin: 3004251964, uid: 'u',
+        uin: 10002, uid: 'u',
         properties: {
           bytesProperties: [],
           numberProperties: [

--- a/packages/protocol/tests/oidb-services/contacts/fetch-user-profile.test.ts
+++ b/packages/protocol/tests/oidb-services/contacts/fetch-user-profile.test.ts
@@ -52,7 +52,7 @@ describe('FetchUserProfile namespace', () => {
       // 企点员工号：两个标志均为 1；普通账号服务器不返回这两个 key → 缺省 0
       const qidian = makeSender({
         body: {
-          uin: 3004251964, uid: 'u',
+          uin: 10002, uid: 'u',
           properties: {
             bytesProperties: [],
             numberProperties: [
@@ -62,7 +62,7 @@ describe('FetchUserProfile namespace', () => {
           },
         } as any,
       });
-      const out = await FetchUserProfile.invoke(qidian, { uin: 3004251964 });
+      const out = await FetchUserProfile.invoke(qidian, { uin: 10002 });
       expect(out.qidianMasterFlag).toBe(1);
       expect(out.qidianCrewFlag).toBe(1);
       expect(out.qidianCrewFlag2).toBe(0);

--- a/packages/protocol/tests/services/qidian/fetch-corp-info.test.ts
+++ b/packages/protocol/tests/services/qidian/fetch-corp-info.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import { protobuf_encode } from '@snowluma/proton';
+import type { QidianCorpInfoResponse } from '@snowluma/proto-defs/qidian-corp';
+import type { SendPacketResult } from '@snowluma/common/packet-sender';
+import {
+  fetchQidianCorpInfo,
+  QIDIAN_CORP_INFO_CMD,
+} from '../../../src/services/qidian/fetch-corp-info';
+
+function sender(body: Uint8Array, opts: Partial<SendPacketResult> = {}) {
+  return {
+    sendRawPacket: vi.fn(async () => ({
+      success: true,
+      gotResponse: true,
+      responseData: body,
+      ...opts,
+    })),
+  };
+}
+
+const CORP_BODY = protobuf_encode<QidianCorpInfoResponse>({
+  corpName: '测试企业',
+  intro: '测试简介',
+  website: 'https://example.com',
+  slogan: '测试签名',
+  address: '测试地址',
+  phone: '400-0000-0000',
+  email: 'contact@example.com',
+});
+
+describe('services/qidian / fetchQidianCorpInfo', () => {
+  it('sends the corp info command with the uin as field 1', async () => {
+    const s = sender(CORP_BODY);
+    const out = await fetchQidianCorpInfo(s, 10001);
+    expect(out?.name).toBe('测试企业');
+    expect(s.sendRawPacket).toHaveBeenCalledWith(
+      QIDIAN_CORP_INFO_CMD,
+      expect.any(Uint8Array),
+      undefined,
+    );
+    const body = s.sendRawPacket.mock.calls[0][1] as Uint8Array;
+    expect(Buffer.from(body).toString('hex')).toBe('08914e');
+  });
+
+  it('decodes the corp data-card fields', async () => {
+    const out = await fetchQidianCorpInfo(sender(CORP_BODY), 10001);
+    expect(out).toMatchObject({
+      name: '测试企业',
+      website: 'https://example.com',
+      email: 'contact@example.com',
+    });
+  });
+
+  it('returns null for an empty / failed response', async () => {
+    expect(await fetchQidianCorpInfo(sender(new Uint8Array(0)), 1)).toBeNull();
+    expect(
+      await fetchQidianCorpInfo(sender(new Uint8Array(0), { success: false, errorMessage: 'x' }), 1),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- 感谢贡献。请填写以下内容，方便评审。 -->

## 关联 Issue

#404 

这是维护者在 #404 评论中约定的「后续 PR」的一部分：在首份 PR（企点三标志，已合入 `dev`）之后，补齐企点**企业名称**的获取与透传。

> 说明：**企业 ID / Corpid 未接入**。通过线上抓包确认，`trpc.basic.corp.Datacard.SsoCorpInfo` 只返回企业资料卡（企业简称/简介/官网/签名/地址/电话/邮箱），`SsoUserInfo` 对测试账号返回空 body，均未暴露独立的企业 ID（`qiDianAssignID`）。因此本 PR 只透出企业名称 `qidian_enterprise_name`。

## 变更说明

- 新增协议服务：`trpc.basic.corp.Datacard.SsoCorpInfo`，请求体为 protobuf `field1 = 目标账号 UIN`（varint），解码企业资料卡字段（企业简称 / 简介 / 官网 / 企业签名 / 地址 / 电话 / 邮箱）。
- `@snowluma/core` 暴露 `contacts.fetchQidianCorpInfo(uin)`，best-effort，失败返回 `null`，不影响资料读取主流程。
- OneBot `get_stranger_info`：当命中的是企点账号（`qidian_master_flag` / `qidian_crew_flag` 任一为 1）时拉取企业资料卡，并返回 `qidian_enterprise_name`（企业名称/简称）；非企点账号或未命中时为 `''`。
- 更新 `get_stranger_info` 返回 schema、重新生成 MCP catalog，并补充/更新单测。
- 测试与注释使用虚构账号/企业数据（参考仓库既有测试风格）。

## 提交前检查

- [x] 本 PR 聚焦单一目标，未夹带无关改动
- [x] 已通过 `pnpm lint` 与 `pnpm typecheck`（已跑：变更文件 `eslint`；`@snowluma/protocol` / `@snowluma/core` / `@snowluma/onebot` 的 `tsc --noEmit`。未跑全工作区 `pnpm lint` / 全仓库 `pnpm typecheck`。）
- [x] 已补充/更新相关测试，且 `pnpm test` 通过（协议相关 18 个 + onebot 相关 92 个通过；全量 onebot 仍有与本改动无关的两个既有失败：`stream-download.test.ts` 的 `ctx.getImageInfo is not a function`、`message-store-migration-worker.test.ts` 的 Windows `EBUSY` 竞态。）
- [x] 文件行尾为 LF（未引入 CRLF）
- [x] PR 描述与实际实现一致